### PR TITLE
build: disable sourcemap in production (#49)

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -5,6 +5,7 @@ export default defineConfig({
   build: {
     target: 'es2022',
     outDir: 'dist',
+    sourcemap: false,
   },
   worker: {
     format: 'es',


### PR DESCRIPTION
## Summary
- `vite.config.ts`: set `build.sourcemap: false` so TS source is not leaked via `dist/**.js.map` in production.

## Why
`tsconfig.json` enables `sourceMap: true` (dev ergonomics) and Vite had no prod override, so maps and original TS were shipped — discoverable via browser DevTools. Privacy-posture fix aligned with the rest of the app's client-side/no-telemetry stance.

## Test plan
- [ ] `npm run build` produces `dist/` with no `.map` files.
- [ ] Dev (`npm run dev`) still has working source maps.

Part of #49.