### PR TITLE
security: disable DNS prefetch + drop HF hints (partial #39)

### DIFF
--- a/index.html
+++ b/index.html
@@ -49,8 +49,6 @@
   <link rel="manifest" href="/manifest.webmanifest" />
   <link rel="preload" href="/fonts/JetBrainsMono-Regular.woff2" as="font" type="font/woff2" crossorigin />
   <link rel="preload" href="/fonts/JetBrainsMono-Bold.woff2" as="font" type="font/woff2" crossorigin />
-  <link rel="dns-prefetch" href="https://huggingface.co" />
-  <link rel="preconnect" href="https://cdn-lfs.huggingface.co" crossorigin />
 
   <!-- Fonts: self-hosted, zero external requests -->
   <style>

--- a/nginx.conf
+++ b/nginx.conf
@@ -14,6 +14,7 @@ server {
     # COOP/COEP: credentialless enables SharedArrayBuffer for multi-threaded WASM
     # Model is self-hosted (same-origin) so no cross-origin issues
     add_header Cross-Origin-Opener-Policy "same-origin" always;
+    add_header X-DNS-Prefetch-Control "off" always;
 
     # CSP: 'unsafe-eval' required because onnxruntime-web uses new Function() for WASM bootstrap
     add_header Content-Security-Policy "default-src 'self'; script-src 'self' blob: 'wasm-unsafe-eval' 'unsafe-eval' 'unsafe-inline' https://cdn.jsdelivr.net; worker-src 'self' blob:; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; connect-src 'self' https://huggingface.co https://cdn-lfs.huggingface.co https://cdn-lfs-us-1.huggingface.co https://cdn.jsdelivr.net https://cas-bridge.xethub.hf.co; font-src 'self'; object-src 'none'; base-uri 'self'; form-action 'none'" always;
@@ -30,6 +31,7 @@ server {
         add_header Permissions-Policy "camera=(), microphone=(), geolocation=()" always;
         add_header Strict-Transport-Security "max-age=63072000; includeSubDomains; preload" always;
         add_header Cross-Origin-Opener-Policy "same-origin" always;
+        add_header X-DNS-Prefetch-Control "off" always;
         add_header Content-Security-Policy "default-src 'self'; script-src 'self' blob: 'wasm-unsafe-eval' 'unsafe-eval' 'unsafe-inline' https://cdn.jsdelivr.net; worker-src 'self' blob:; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; connect-src 'self' https://huggingface.co https://cdn-lfs.huggingface.co https://cdn-lfs-us-1.huggingface.co https://cdn.jsdelivr.net https://cas-bridge.xethub.hf.co; font-src 'self'; object-src 'none'; base-uri 'self'; form-action 'none'" always;
     }
 
@@ -43,6 +45,7 @@ server {
         add_header Permissions-Policy "camera=(), microphone=(), geolocation=()" always;
         add_header Strict-Transport-Security "max-age=63072000; includeSubDomains; preload" always;
         add_header Cross-Origin-Opener-Policy "same-origin" always;
+        add_header X-DNS-Prefetch-Control "off" always;
         add_header Content-Security-Policy "default-src 'self'; script-src 'self' blob: 'wasm-unsafe-eval' 'unsafe-eval' 'unsafe-inline' https://cdn.jsdelivr.net; worker-src 'self' blob:; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; connect-src 'self' https://huggingface.co https://cdn-lfs.huggingface.co https://cdn-lfs-us-1.huggingface.co https://cdn.jsdelivr.net https://cas-bridge.xethub.hf.co; font-src 'self'; object-src 'none'; base-uri 'self'; form-action 'none'" always;
     }
 

--- a/public/_headers
+++ b/public/_headers
@@ -5,6 +5,7 @@
   Permissions-Policy: camera=(), microphone=(), geolocation=()
   Cross-Origin-Opener-Policy: same-origin
   Cross-Origin-Resource-Policy: same-origin
+  X-DNS-Prefetch-Control: off
   Strict-Transport-Security: max-age=63072000; includeSubDomains; preload
   Content-Security-Policy: default-src 'self'; script-src 'self' blob: 'wasm-unsafe-eval' 'unsafe-eval' 'unsafe-inline' https://cdn.jsdelivr.net; worker-src 'self' blob:; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; connect-src 'self' https://huggingface.co https://cdn-lfs.huggingface.co https://cdn-lfs-us-1.huggingface.co https://cdn.jsdelivr.net https://cas-bridge.xethub.hf.co; font-src 'self'; object-src 'none'; base-uri 'self'; form-action 'none'
 


### PR DESCRIPTION
## Summary
- Add `X-DNS-Prefetch-Control: off` to `nginx.conf` (top-level + both `location` blocks) and `public/_headers`.
- Remove `<link rel="dns-prefetch" href="https://huggingface.co">` and `<link rel="preconnect" href="https://cdn-lfs.huggingface.co">` from `index.html`.

## Why
Both hints fired at page load, leaking DNS timing to observers even for users who never triggered an HF fetch (e.g. image never uploaded). The actual fetch triggers DNS resolution at the right moment, so the hints don't buy meaningful latency here.

## Not in this PR (split from #39)
Removing `'unsafe-inline'` from `script-src` was out of scope because `index.html` contains:
- 3 × inline `<script type="application/ld+json">` (SEO) — browsers enforce script-src even on JSON-LD blocks.
- 1 × inline `<script>` at lines 380–388 (SW auto-recovery after 5s).

The clean fix requires externalizing the recovery script and adding sha256 hashes for JSON-LD blocks to CSP. That's a more delicate change with its own review surface — follow-up PR will land it.

## Test plan
- [ ] `curl -I` shows `X-DNS-Prefetch-Control: off` on both static and container deployments.
- [ ] No regression on first-load performance (HF model is still fetched when needed).

Partial resolution of #39.