### PR TITLE
security: validate image magic bytes before decode (partial #41)

### DIFF
--- a/src/utils/image-io.ts
+++ b/src/utils/image-io.ts
@@ -14,6 +14,32 @@ export function isSupportedFormat(type: string): type is SupportedFormat {
 }
 
 /**
+ * Inspect the first bytes of a file and return the image format identified
+ * by its magic bytes. Returns null if none of the supported formats match.
+ * Defense-in-depth against rename attacks (e.g. `.exe` → `.png`).
+ */
+async function sniffImageFormat(file: File): Promise<SupportedFormat | null> {
+  const head = new Uint8Array(await file.slice(0, 12).arrayBuffer());
+  if (head.length < 12) return null;
+
+  // PNG:  89 50 4E 47 0D 0A 1A 0A
+  if (head[0] === 0x89 && head[1] === 0x50 && head[2] === 0x4E && head[3] === 0x47 &&
+      head[4] === 0x0D && head[5] === 0x0A && head[6] === 0x1A && head[7] === 0x0A) {
+    return 'image/png';
+  }
+  // JPEG: FF D8 FF
+  if (head[0] === 0xFF && head[1] === 0xD8 && head[2] === 0xFF) {
+    return 'image/jpeg';
+  }
+  // WebP: "RIFF" <size> "WEBP"
+  if (head[0] === 0x52 && head[1] === 0x49 && head[2] === 0x46 && head[3] === 0x46 &&
+      head[8] === 0x57 && head[9] === 0x45 && head[10] === 0x42 && head[11] === 0x50) {
+    return 'image/webp';
+  }
+  return null;
+}
+
+/**
  * Load an image file to ImageData, downsampling if needed.
  */
 export async function loadImage(file: File): Promise<ImageLoadResult> {
@@ -23,6 +49,16 @@ export async function loadImage(file: File): Promise<ImageLoadResult> {
 
   if (file.size > MAX_FILE_SIZE) {
     throw new Error(`File too large: ${Math.round(file.size / 1024 / 1024)} MB. Maximum is ${Math.round(MAX_FILE_SIZE / 1024 / 1024)} MB.`);
+  }
+
+  // Magic-byte sniff: refuses renamed non-image files before the decoder
+  // gets a chance to crash cryptically on them.
+  const sniffed = await sniffImageFormat(file);
+  if (!sniffed) {
+    throw new Error('File is not a valid PNG, JPG, or WebP. It may be corrupted or renamed.');
+  }
+  if (sniffed !== file.type) {
+    throw new Error(`File content (${sniffed}) does not match its extension (${file.type}).`);
   }
 
   const bitmap = await createImageBitmap(file);

--- a/tests/utils/image-io.test.ts
+++ b/tests/utils/image-io.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect } from 'vitest';
+import { loadImage } from '../../src/utils/image-io';
+
+const PNG_MAGIC = new Uint8Array([0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A]);
+const JPEG_MAGIC = new Uint8Array([0xFF, 0xD8, 0xFF, 0xE0]);
+const WEBP_MAGIC = new Uint8Array([
+  0x52, 0x49, 0x46, 0x46, 0x00, 0x00, 0x00, 0x00, 0x57, 0x45, 0x42, 0x50,
+]);
+
+function fileFrom(bytes: Uint8Array, name: string, type: string): File {
+  return new File([bytes], name, { type });
+}
+
+describe('loadImage magic-byte sniffing', () => {
+  it('rejects a file whose MIME says PNG but whose bytes do not match', async () => {
+    const fake = fileFrom(new Uint8Array([0x4D, 0x5A, 0x90, 0x00]), 'fake.png', 'image/png');
+    await expect(loadImage(fake)).rejects.toThrow(/not a valid PNG, JPG, or WebP|does not match/i);
+  });
+
+  it('rejects a renamed JPEG masquerading as PNG', async () => {
+    const renamed = fileFrom(JPEG_MAGIC, 'photo.png', 'image/png');
+    await expect(loadImage(renamed)).rejects.toThrow(/does not match/i);
+  });
+
+  it('rejects unsupported MIME types before sniffing', async () => {
+    const gif = fileFrom(PNG_MAGIC, 'img.gif', 'image/gif');
+    await expect(loadImage(gif)).rejects.toThrow(/Unsupported format/i);
+  });
+
+  it('rejects files below the 12-byte sniff window', async () => {
+    const tiny = fileFrom(new Uint8Array([0x89, 0x50, 0x4E]), 'tiny.png', 'image/png');
+    await expect(loadImage(tiny)).rejects.toThrow(/not a valid PNG, JPG, or WebP/i);
+  });
+
+  it('passes the magic-byte gate for a valid PNG header (decode fails downstream)', async () => {
+    // A real decode is out of scope (happy-dom has no canvas). Here we just
+    // confirm the error surface is not the sniff error.
+    const pngStub = fileFrom(PNG_MAGIC, 'img.png', 'image/png');
+    await expect(loadImage(pngStub)).rejects.not.toThrow(/does not match|not a valid/i);
+  });
+
+  it('passes the magic-byte gate for a valid WebP header', async () => {
+    const webpStub = fileFrom(WEBP_MAGIC, 'img.webp', 'image/webp');
+    await expect(loadImage(webpStub)).rejects.not.toThrow(/does not match|not a valid/i);
+  });
+});


### PR DESCRIPTION
## Summary
- Add `sniffImageFormat()` in `src/utils/image-io.ts` to verify the first 12 bytes match PNG / JPEG / WebP magic bytes.
- Reject files whose sniffed format does not match the declared MIME type (renamed-extension attack).
- New test file `tests/utils/image-io.test.ts` covering: renamed JPEG-as-PNG, MZ (PE) header as PNG, unsupported MIME, truncated file, and happy-path PNG/WebP.

## Why
`createImageBitmap` would eventually fail on bogus content, but with an opaque message. Now the user sees "File content (image/jpeg) does not match its extension (image/png)." or "File is not a valid PNG, JPG, or WebP." — both actionable. It also closes the small window where a decoder quirk could misbehave on crafted content.

## Not in this PR
The 80 MB size cap + 268 MP pixel cap were already enforced in `loadImage()`. The processing timeout piece of #41 + COEP header piece will ship separately.

## Test plan
- [ ] `npm test -- image-io` passes locally.
- [ ] Dropping an `.exe` renamed to `.png` shows the new mismatch error instead of a generic failure.
- [ ] Dropping a genuine PNG still loads normally.

Partial resolution of #41.