### PR TITLE
docs: OFL attribution + License Compliance section (#42)

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,22 @@ OPEN SOURCE.             Don't trust us -- verify.
 | Open source | Yes (GPL-3.0) | No | No | No |
 | Works offline | Yes | No | No | Yes |
 
+## > license_compliance
+
+NukeBG itself is GPL-3.0 (see [LICENSE](LICENSE)), but it ships with third-party
+artifacts whose licenses carry independent obligations:
+
+| Component | License | Notes |
+|-----------|---------|-------|
+| RMBG-1.4 ML model (BRIA AI) | [bria-rmbg-1.4 license](https://huggingface.co/briaai/RMBG-1.4) | **Non-commercial use only**. Commercial deployments — paid products, paid APIs, paid SaaS — require a commercial agreement with BRIA AI, or swapping to a different model. The GPL-3.0 license of NukeBG's code does not override this. |
+| JetBrains Mono font | [SIL Open Font License 1.1](public/fonts/OFL.txt) | Bundled self-hosted. Attribution preserved in `public/fonts/OFL.txt`. |
+| Transformers.js, ONNX Runtime Web | Apache-2.0 / MIT | Compatible. |
+
+If you fork NukeBG and host it commercially, you are responsible for complying
+with the RMBG-1.4 model license. The project does not bundle the model weights —
+they are fetched at runtime from Hugging Face — but that does not change the
+downstream obligation.
+
 ## > contributing
 
 ```

--- a/public/fonts/OFL.txt
+++ b/public/fonts/OFL.txt
@@ -1,0 +1,92 @@
+Copyright 2020 The JetBrains Mono Project Authors (https://github.com/JetBrains/JetBrainsMono)
+
+This Font Software is licensed under the SIL Open Font License, Version 1.1.
+This license is copied below, and is also available with a FAQ at:
+https://openfontlicense.org
+
+-----------------------------------------------------------
+SIL OPEN FONT LICENSE Version 1.1 - 26 February 2007
+-----------------------------------------------------------
+
+PREAMBLE
+The goals of the Open Font License (OFL) are to stimulate worldwide
+development of collaborative font projects, to support the font creation
+efforts of academic and linguistic communities, and to provide a free and
+open framework in which fonts may be shared and improved in partnership
+with others.
+
+The OFL allows the licensed fonts to be used, studied, modified and
+redistributed freely as long as they are not sold by themselves. The
+fonts, including any derivative works, can be bundled, embedded,
+redistributed and/or sold with any software provided that any reserved
+names are not used by derivative works. The fonts and derivatives,
+however, cannot be released under any other type of license. The
+requirement for fonts to remain under this license does not apply
+to any document created using the fonts or their derivatives.
+
+DEFINITIONS
+"Font Software" refers to the set of files released by the Copyright
+Holder(s) under this license and clearly marked as such. This may
+include source files, build scripts and documentation.
+
+"Reserved Font Name" refers to any names specified as such after the
+copyright statement(s).
+
+"Original Version" refers to the collection of Font Software components
+as distributed by the Copyright Holder(s).
+
+"Modified Version" refers to any derivative made by adding to, deleting,
+or substituting -- in part or in whole -- any of the components of the
+Original Version, by changing formats or by porting the Font Software to
+a new environment.
+
+"Author" refers to any designer, engineer, programmer, technical writer
+or other person who contributed to the Font Software.
+
+PERMISSION & CONDITIONS
+Permission is hereby granted, free of charge, to any person obtaining a
+copy of the Font Software, to use, study, copy, merge, embed, modify,
+redistribute, and sell modified and unmodified copies of the Font
+Software, subject to the following conditions:
+
+1) Neither the Font Software nor any of its individual components, in
+Original or Modified Versions, may be sold by itself.
+
+2) Original or Modified Versions of the Font Software may be bundled,
+redistributed and/or sold with any software, provided that each copy
+contains the above copyright notice and this license. These can be
+included either as stand-alone text files, human-readable headers or in
+the appropriate machine-readable metadata fields within text or binary
+files as long as those fields can be easily viewed by the user.
+
+3) No Modified Version of the Font Software may use the Reserved Font
+Name(s) unless explicit written permission is granted by the
+corresponding Copyright Holder. This restriction only applies to the
+primary font name as presented to the users.
+
+4) The name(s) of the Copyright Holder(s) or the Author(s) of the Font
+Software shall not be used to promote, endorse or advertise any
+Modified Version, except to acknowledge the contribution(s) of the
+Copyright Holder(s) and the Author(s) or with their explicit written
+permission.
+
+5) The Font Software, modified or unmodified, in part or in whole,
+must be distributed entirely under this license, and must not be
+distributed under any other license. The requirement for fonts to
+remain under this license does not apply to any document created
+using the Font Software.
+
+TERMINATION
+This license becomes null and void if any of the above conditions are
+not met.
+
+DISCLAIMER
+THE FONT SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT
+OF COPYRIGHT, PATENT, TRADEMARK, OR OTHER RIGHT. IN NO EVENT SHALL THE
+COPYRIGHT HOLDER BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+INCLUDING ANY GENERAL, SPECIAL, INDIRECT, INCIDENTAL, OR CONSEQUENTIAL
+DAMAGES, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF THE USE OR INABILITY TO USE THE FONT SOFTWARE OR FROM
+OTHER DEALINGS IN THE FONT SOFTWARE.


### PR DESCRIPTION
## Summary
- `public/fonts/OFL.txt`: canonical SIL Open Font License 1.1 with JetBrains Mono copyright notice (OFL requires the license to travel with the font files).
- `README.md`: new **License Compliance** section listing BRIA's non-commercial restriction on RMBG-1.4, the OFL on JetBrains Mono, and the compatible Apache-2.0/MIT licenses on the JS runtimes.

## Why
Two gaps flagged in the audit:
1. JetBrains Mono was self-hosted without the required OFL attribution file.
2. RMBG-1.4 is CC-BY-NC-ish (non-commercial) while NukeBG's code is GPL-3.0 (commercial-friendly copyleft). A downstream fork hosting NukeBG for pay would infringe BRIA's model license without realizing it. Surfacing that explicitly.

## Not in this PR (split from #42)
README still says "zero network requests during processing" — reconciling that with the jsDelivr WASM fetch on first LaMa use is a separate, language-sensitive edit across README and docs. Will ship as a follow-up.

## Test plan
- [ ] `public/fonts/OFL.txt` is included in `dist/` after build (Vite copies `public/`).
- [ ] Rendered README section reads correctly on GitHub.

Partial resolution of #42.