### PR TITLE
chore: npm run typecheck script (partial #50)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
         run: npm ci
 
       - name: TypeScript typecheck
-        run: npx tsc --noEmit
+        run: npm run typecheck
 
       - name: Vitest
         run: npm test

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "dev": "vite",
     "build": "tsc && vite build",
     "preview": "vite preview",
+    "typecheck": "tsc --noEmit",
     "test": "vitest run",
     "test:watch": "vitest",
     "test:e2e": "playwright test",


### PR DESCRIPTION
## Summary
- `package.json`: add `"typecheck": "tsc --noEmit"` script.
- `.github/workflows/ci.yml`: call `npm run typecheck` instead of `npx tsc --noEmit`.

## Why
Minor DX + consistency win. Contributors can run the exact check CI runs via `npm run typecheck`. Also a prep hook for later work in #50 (ESLint job, branch protection, etc.) — the workflow can now reference script names directly.

## Test plan
- [ ] `npm run typecheck` completes without errors locally.
- [ ] CI green on this PR.

Partial resolution of #50.