### PR TITLE
pipeline: freeze PipelineResult + validate LaMa download (partial #44)

### DIFF
--- a/src/pipeline/orchestrator.ts
+++ b/src/pipeline/orchestrator.ts
@@ -639,7 +639,11 @@ export class PipelineOrchestrator {
     const resultImageData = new ImageData(resultPixels, width, height);
     const totalTimeMs = performance.now() - startTime;
 
-    return {
+    // Freeze to prevent accidental reassignment by callers. Typed-array
+    // contents remain writable (the runtime does not freeze ArrayBuffer
+    // views), but the `readonly` marks on PipelineResult catch those at
+    // compile time. If a caller truly needs to mutate, it clones first.
+    return Object.freeze({
       imageData: resultImageData,
       workingPixels: originalPixels,
       workingAlpha: finalAlpha,
@@ -651,7 +655,7 @@ export class PipelineOrchestrator {
       nukedPct,
       stageTiming,
       contentType,
-    };
+    });
   }
 
   destroy(): void {

--- a/src/types/pipeline.ts
+++ b/src/types/pipeline.ts
@@ -16,37 +16,45 @@ export interface StageEvent {
   message?: string;
 }
 
+/**
+ * Pipeline output. Buffers (`workingPixels`, `workingAlpha`, `watermarkMask`)
+ * are caller-owned but **treated as read-only snapshots** — mutating them
+ * would corrupt subsequent exports and editor operations that reference the
+ * same result. The object itself is `Object.freeze`'d before return; types
+ * are marked `readonly` so the compiler catches accidental reassignment.
+ * If you need to mutate, clone first (e.g. `new Uint8ClampedArray(buffer)`).
+ */
 export interface PipelineResult {
   /** Processed image with alpha channel (at the working resolution fed to the pipeline) */
-  imageData: ImageData;
+  readonly imageData: ImageData;
   /**
    * RGB pixels at working resolution, possibly modified by inpainting.
    * Exposed so callers can upscale and composite into a full-resolution
    * output when the pipeline ran on a downscaled working copy.
    */
-  workingPixels: Uint8ClampedArray;
+  readonly workingPixels: Uint8ClampedArray;
   /** Alpha mask at working resolution (0..255) */
-  workingAlpha: Uint8Array;
+  readonly workingAlpha: Uint8Array;
   /** Working width — matches imageData.width */
-  workingWidth: number;
+  readonly workingWidth: number;
   /** Working height — matches imageData.height */
-  workingHeight: number;
+  readonly workingHeight: number;
   /**
    * Watermark mask at working resolution (0 or 1), if inpainting happened.
    * Used by the final composite to blend upscaled inpainted RGB only in
    * the watermark region, preserving pristine original RGB elsewhere.
    */
-  watermarkMask: Uint8Array | null;
+  readonly watermarkMask: Uint8Array | null;
   /** Total processing time in ms */
-  totalTimeMs: number;
+  readonly totalTimeMs: number;
   /** Whether watermark was found and removed */
-  watermarkRemoved: boolean;
+  readonly watermarkRemoved: boolean;
   /** Percentage of pixels made transparent */
-  nukedPct: number;
+  readonly nukedPct: number;
   /** Per-stage timing breakdown */
-  stageTiming: Partial<Record<PipelineStage, number>>;
+  readonly stageTiming: Partial<Record<PipelineStage, number>>;
   /** Detected content type for auto-algorithm selection */
-  contentType: ImageContentType;
+  readonly contentType: ImageContentType;
 }
 
 /** Result from background color detection */

--- a/src/workers/lama.worker.ts
+++ b/src/workers/lama.worker.ts
@@ -77,6 +77,16 @@ async function loadModel(id: string): Promise<ort.InferenceSession> {
       }
     }
 
+    // Validate stream completeness. A truncated body (connection drop,
+    // proxy cap) would otherwise flow through and blow up inside ORT
+    // with an opaque "failed to load model" — we want a specific,
+    // retryable error instead.
+    if (total > 0 && received !== total) {
+      throw new Error(
+        `Truncated LaMa model download: got ${received} / ${total} bytes`,
+      );
+    }
+
     const buffer = new Uint8Array(received);
     let offset = 0;
     for (const c of chunks) {


### PR DESCRIPTION
## Summary
- `src/types/pipeline.ts`: all `PipelineResult` fields are now `readonly`, with a doc block covering the caller-owned / no-mutate contract.
- `src/pipeline/orchestrator.ts`: `composeResult()` wraps the return value in `Object.freeze(...)` so reassignment also fails at runtime.
- `src/workers/lama.worker.ts`: after streaming the model, assert `received === total` (Content-Length). A truncated fetch now throws `"Truncated LaMa model download"` instead of letting ORT blow up deep in `InferenceSession.create()` on a partial buffer.

## Why
Two findings from the audit:
- Editor components hold a `PipelineResult` reference and could accidentally mutate `workingPixels`/`workingAlpha` between preview and export. `readonly` + `Object.freeze` shuts the door on the common footgun. Typed-array contents still mutate (the runtime doesn't freeze ArrayBuffer views), but the `readonly` marks catch the typical field reassignment.
- `loadModel()` in the LaMa worker streamed chunks without verifying stream completeness. A proxy cap or connection drop would surface as a cryptic ORT error; now it's a specific, retryable message.

## Dropped from original #44 scope
- `rejectAllPending()` / `pendingTimers` cleanup — the audit flagged this, but the current code already clears timers in both `rejectAllPending()` (lines 167-174) and `destroy()` (lines 657-664). No-op.
- Exhaustive discriminated-union checks in worker message handlers — meaningful but touches every handler in `orchestrator.ts`. Belongs with #48 (orchestrator refactor + WorkerPool abstraction) where the handler shape changes anyway.

## Test plan
- [ ] `npm run typecheck` passes.
- [ ] Any would-be reassignment like `result.workingPixels = x` in consumer code surfaces as a TS error.
- [ ] Unit tests still pass.

Partial resolution of #44.