### PR TITLE
security: remove script-src 'unsafe-inline' (closes #39)

### DIFF
--- a/index.html
+++ b/index.html
@@ -374,16 +374,9 @@
   <div class="kbd-toast" id="kbd-toast" role="status" aria-live="polite"></div>
   <div class="smoke-overlay" id="smoke-overlay"></div>
 
-  <!-- Auto-recovery: if main JS fails to load (stale SW cache), clear and reload -->
-  <script>
-    setTimeout(function() {
-      if (document.getElementById('seo-content') && 'serviceWorker' in navigator) {
-        caches.keys().then(function(keys) {
-          return Promise.all(keys.map(function(k) { return caches.delete(k); }));
-        }).then(function() { location.reload(); });
-      }
-    }, 5000);
-  </script>
+  <!-- Auto-recovery: if main JS fails to load (stale SW cache), clear and reload.
+       Externalized so CSP can drop script-src 'unsafe-inline'. -->
+  <script src="/sw-recovery.js"></script>
   <script type="module" src="/src/main.ts"></script>
 </body>
 </html>

--- a/nginx.conf
+++ b/nginx.conf
@@ -16,8 +16,12 @@ server {
     add_header Cross-Origin-Opener-Policy "same-origin" always;
     add_header X-DNS-Prefetch-Control "off" always;
 
-    # CSP: 'unsafe-eval' required because onnxruntime-web uses new Function() for WASM bootstrap
-    add_header Content-Security-Policy "default-src 'self'; script-src 'self' blob: 'wasm-unsafe-eval' 'unsafe-eval' 'unsafe-inline' https://cdn.jsdelivr.net; worker-src 'self' blob:; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; connect-src 'self' https://huggingface.co https://cdn-lfs.huggingface.co https://cdn-lfs-us-1.huggingface.co https://cdn.jsdelivr.net https://cas-bridge.xethub.hf.co; font-src 'self'; object-src 'none'; base-uri 'self'; form-action 'none'" always;
+    # CSP:
+    # - 'unsafe-eval' + 'wasm-unsafe-eval' required by onnxruntime-web's
+    #   new Function() WASM bootstrap.
+    # - sha256 hashes cover the 3 inline JSON-LD blocks in index.html.
+    #   Regenerate with `node scripts/compute-csp-hashes.mjs` after edits.
+    add_header Content-Security-Policy "default-src 'self'; script-src 'self' blob: 'wasm-unsafe-eval' 'unsafe-eval' 'sha256-JSdElvxpt5GcONn3DDDXII0S4CoV8+KeXxnYZ8zN4D0=' 'sha256-fsUqdEzMWK7PJDf2qw03sfBDAurm5pLGgdK1mxXy34A=' 'sha256-RhzsrPZXTEaJGnKq6h14mKgFoh+UQ+AlxxnS/+EzMRM=' https://cdn.jsdelivr.net; worker-src 'self' blob:; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; connect-src 'self' https://huggingface.co https://cdn-lfs.huggingface.co https://cdn-lfs-us-1.huggingface.co https://cdn.jsdelivr.net https://cas-bridge.xethub.hf.co; font-src 'self'; object-src 'none'; base-uri 'self'; form-action 'none'" always;
 
     # Cache static assets
     # Note: add_header in location blocks replaces parent headers in nginx,
@@ -32,7 +36,7 @@ server {
         add_header Strict-Transport-Security "max-age=63072000; includeSubDomains; preload" always;
         add_header Cross-Origin-Opener-Policy "same-origin" always;
         add_header X-DNS-Prefetch-Control "off" always;
-        add_header Content-Security-Policy "default-src 'self'; script-src 'self' blob: 'wasm-unsafe-eval' 'unsafe-eval' 'unsafe-inline' https://cdn.jsdelivr.net; worker-src 'self' blob:; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; connect-src 'self' https://huggingface.co https://cdn-lfs.huggingface.co https://cdn-lfs-us-1.huggingface.co https://cdn.jsdelivr.net https://cas-bridge.xethub.hf.co; font-src 'self'; object-src 'none'; base-uri 'self'; form-action 'none'" always;
+        add_header Content-Security-Policy "default-src 'self'; script-src 'self' blob: 'wasm-unsafe-eval' 'unsafe-eval' 'sha256-JSdElvxpt5GcONn3DDDXII0S4CoV8+KeXxnYZ8zN4D0=' 'sha256-fsUqdEzMWK7PJDf2qw03sfBDAurm5pLGgdK1mxXy34A=' 'sha256-RhzsrPZXTEaJGnKq6h14mKgFoh+UQ+AlxxnS/+EzMRM=' https://cdn.jsdelivr.net; worker-src 'self' blob:; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; connect-src 'self' https://huggingface.co https://cdn-lfs.huggingface.co https://cdn-lfs-us-1.huggingface.co https://cdn.jsdelivr.net https://cas-bridge.xethub.hf.co; font-src 'self'; object-src 'none'; base-uri 'self'; form-action 'none'" always;
     }
 
     # ONNX model files — cache aggressively, same-origin so CORP is fine
@@ -46,7 +50,7 @@ server {
         add_header Strict-Transport-Security "max-age=63072000; includeSubDomains; preload" always;
         add_header Cross-Origin-Opener-Policy "same-origin" always;
         add_header X-DNS-Prefetch-Control "off" always;
-        add_header Content-Security-Policy "default-src 'self'; script-src 'self' blob: 'wasm-unsafe-eval' 'unsafe-eval' 'unsafe-inline' https://cdn.jsdelivr.net; worker-src 'self' blob:; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; connect-src 'self' https://huggingface.co https://cdn-lfs.huggingface.co https://cdn-lfs-us-1.huggingface.co https://cdn.jsdelivr.net https://cas-bridge.xethub.hf.co; font-src 'self'; object-src 'none'; base-uri 'self'; form-action 'none'" always;
+        add_header Content-Security-Policy "default-src 'self'; script-src 'self' blob: 'wasm-unsafe-eval' 'unsafe-eval' 'sha256-JSdElvxpt5GcONn3DDDXII0S4CoV8+KeXxnYZ8zN4D0=' 'sha256-fsUqdEzMWK7PJDf2qw03sfBDAurm5pLGgdK1mxXy34A=' 'sha256-RhzsrPZXTEaJGnKq6h14mKgFoh+UQ+AlxxnS/+EzMRM=' https://cdn.jsdelivr.net; worker-src 'self' blob:; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; connect-src 'self' https://huggingface.co https://cdn-lfs.huggingface.co https://cdn-lfs-us-1.huggingface.co https://cdn.jsdelivr.net https://cas-bridge.xethub.hf.co; font-src 'self'; object-src 'none'; base-uri 'self'; form-action 'none'" always;
     }
 
     # SPA fallback

--- a/public/_headers
+++ b/public/_headers
@@ -7,7 +7,7 @@
   Cross-Origin-Resource-Policy: same-origin
   X-DNS-Prefetch-Control: off
   Strict-Transport-Security: max-age=63072000; includeSubDomains; preload
-  Content-Security-Policy: default-src 'self'; script-src 'self' blob: 'wasm-unsafe-eval' 'unsafe-eval' 'unsafe-inline' https://cdn.jsdelivr.net; worker-src 'self' blob:; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; connect-src 'self' https://huggingface.co https://cdn-lfs.huggingface.co https://cdn-lfs-us-1.huggingface.co https://cdn.jsdelivr.net https://cas-bridge.xethub.hf.co; font-src 'self'; object-src 'none'; base-uri 'self'; form-action 'none'
+  Content-Security-Policy: default-src 'self'; script-src 'self' blob: 'wasm-unsafe-eval' 'unsafe-eval' 'sha256-JSdElvxpt5GcONn3DDDXII0S4CoV8+KeXxnYZ8zN4D0=' 'sha256-fsUqdEzMWK7PJDf2qw03sfBDAurm5pLGgdK1mxXy34A=' 'sha256-RhzsrPZXTEaJGnKq6h14mKgFoh+UQ+AlxxnS/+EzMRM=' https://cdn.jsdelivr.net; worker-src 'self' blob:; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; connect-src 'self' https://huggingface.co https://cdn-lfs.huggingface.co https://cdn-lfs-us-1.huggingface.co https://cdn.jsdelivr.net https://cas-bridge.xethub.hf.co; font-src 'self'; object-src 'none'; base-uri 'self'; form-action 'none'
 
 /assets/*
   Cache-Control: public, max-age=31536000, immutable

--- a/public/sw-recovery.js
+++ b/public/sw-recovery.js
@@ -1,0 +1,12 @@
+// Auto-recovery: if main JS fails to load within 5 seconds (e.g. a stale
+// Service Worker is serving a broken cache bundle), clear all caches and
+// reload so the fresh network copy can run. Externalized from index.html
+// so CSP can drop script-src 'unsafe-inline' without losing this escape
+// hatch. The file is tiny and served once per navigation.
+setTimeout(function () {
+  if (document.getElementById('seo-content') && 'serviceWorker' in navigator) {
+    caches.keys().then(function (keys) {
+      return Promise.all(keys.map(function (k) { return caches.delete(k); }));
+    }).then(function () { location.reload(); });
+  }
+}, 5000);

--- a/scripts/compute-csp-hashes.mjs
+++ b/scripts/compute-csp-hashes.mjs
@@ -1,0 +1,37 @@
+#!/usr/bin/env node
+// Compute sha256 CSP hashes for every inline <script> block in index.html.
+// Used when updating JSON-LD (or any other inline script) to refresh the
+// Content-Security-Policy header. Run: `node scripts/compute-csp-hashes.mjs`
+//
+// CSP hashes the EXACT bytes between <script ...> and </script>, whitespace
+// and all. If the hash drifts, the browser silently blocks the script.
+//
+// Usage: invoke after editing index.html, copy the printed directives into
+// nginx.conf + public/_headers. A future CI check (see issue #50) will
+// fail when the computed set drifts from what's declared.
+import { readFileSync } from 'node:fs';
+import { createHash } from 'node:crypto';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const htmlPath = resolve(__dirname, '..', 'index.html');
+const html = readFileSync(htmlPath, 'utf8');
+
+// Match <script ...>...</script> blocks. We intentionally exclude scripts
+// that use `src=` — those are fetched separately and covered by 'self'.
+const re = /<script\b([^>]*)>([\s\S]*?)<\/script>/g;
+const hashes = [];
+let m;
+while ((m = re.exec(html)) !== null) {
+  const attrs = m[1];
+  const body = m[2];
+  if (/\bsrc\s*=/.test(attrs)) continue; // external, covered by 'self'
+  if (body.trim() === '') continue;
+  const digest = createHash('sha256').update(body, 'utf8').digest('base64');
+  hashes.push(`'sha256-${digest}'`);
+}
+
+console.log('# CSP hashes for inline <script> blocks in index.html');
+console.log('# Paste into the script-src directive after \'self\'.');
+console.log(hashes.join(' '));

--- a/tests/csp-hashes.test.ts
+++ b/tests/csp-hashes.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { createHash } from 'node:crypto';
+import { resolve } from 'node:path';
+
+/**
+ * CSP sha256 hash drift guard.
+ *
+ * Every inline <script> block in index.html (JSON-LD blocks, currently 3
+ * of them) must have a matching `'sha256-...'` entry in the CSP header
+ * declared in both nginx.conf and public/_headers. If JSON-LD content
+ * is edited without regenerating hashes, the browser silently blocks
+ * the script — this test catches that at CI time.
+ *
+ * Regenerate with `node scripts/compute-csp-hashes.mjs`.
+ */
+
+const ROOT = resolve(__dirname, '..');
+const INLINE_SCRIPT_RE = /<script\b([^>]*)>([\s\S]*?)<\/script>/g;
+
+function extractInlineHashes(): string[] {
+  const html = readFileSync(resolve(ROOT, 'index.html'), 'utf8');
+  const hashes: string[] = [];
+  let m: RegExpExecArray | null;
+  while ((m = INLINE_SCRIPT_RE.exec(html)) !== null) {
+    const attrs = m[1];
+    const body = m[2];
+    if (/\bsrc\s*=/.test(attrs)) continue;
+    if (body.trim() === '') continue;
+    const digest = createHash('sha256').update(body, 'utf8').digest('base64');
+    hashes.push(`'sha256-${digest}'`);
+  }
+  return hashes;
+}
+
+function cspFrom(path: string): string {
+  const text = readFileSync(resolve(ROOT, path), 'utf8');
+  const match = text.match(/Content-Security-Policy[^\n]*/);
+  if (!match) throw new Error(`No CSP header in ${path}`);
+  return match[0];
+}
+
+describe('CSP inline-script hashes', () => {
+  const expected = extractInlineHashes();
+
+  it('has at least one inline <script> block to hash', () => {
+    expect(expected.length).toBeGreaterThan(0);
+  });
+
+  it('nginx.conf CSP declares every inline-script hash', () => {
+    const csp = cspFrom('nginx.conf');
+    for (const h of expected) {
+      expect(csp, `missing ${h} in nginx.conf CSP`).toContain(h);
+    }
+  });
+
+  it('public/_headers CSP declares every inline-script hash', () => {
+    const csp = cspFrom('public/_headers');
+    for (const h of expected) {
+      expect(csp, `missing ${h} in public/_headers CSP`).toContain(h);
+    }
+  });
+
+  it('no CSP still carries script-src unsafe-inline', () => {
+    for (const p of ['nginx.conf', 'public/_headers']) {
+      const csp = cspFrom(p);
+      const scriptSrc = csp.match(/script-src [^;]+/)?.[0] ?? '';
+      expect(scriptSrc, `${p} script-src still has 'unsafe-inline'`).not.toMatch(/'unsafe-inline'/);
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- `public/sw-recovery.js`: the 5-second stale-cache recovery that used to be inline in `index.html`.
- `index.html`: replaces the inline recovery with `<script src="/sw-recovery.js">`. Three JSON-LD blocks stay inline (Google/Bing expect inline LD) and are now hashed.
- `nginx.conf` + `public/_headers`: drop `'unsafe-inline'` from `script-src`, add three `sha256-...` hashes covering the JSON-LD blocks. `'unsafe-eval'` + `'wasm-unsafe-eval'` remain — still required by `onnxruntime-web`.
- `scripts/compute-csp-hashes.mjs`: prints the hashes derived from `index.html`. Paste the output into both CSP sites after editing JSON-LD.
- `tests/csp-hashes.test.ts`: CI guard that fails when hashes drift or `'unsafe-inline'` reappears.

## Why
Closes the second half of #39. After this PR, `script-src` is hash-pinned, which means any attacker-injected inline `<script>` is blocked even if the rest of the CSP fails. `'unsafe-eval'` stays because ONNX Runtime boots WASM via `new Function()`; removing it would need an upstream change.

## Test plan
- [ ] `npm test -- csp-hashes` passes locally and in CI.
- [ ] Load the site: JSON-LD still appears in page source; no CSP violations in DevTools console.
- [ ] Simulate a broken main bundle: `sw-recovery.js` kicks in after 5s, clears caches, reloads.
- [ ] Editing any JSON-LD block without updating CSP fails the drift test in CI.

Closes #39.