### PR TITLE
docs: reconcile zero-network claim with reality (closes #42)

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,8 +38,10 @@ Drop. Nuke. Download. That's it.
 [+] WATERMARK REMOVAL            Auto-detects Gemini sparkle + DALL-E color bar watermarks.
                                   Telea FMM reconstruction -- no blurry patches.
 
-[+] 100% CLIENT-SIDE             Zero server uploads. Zero network requests during processing.
-                                  Verify it yourself in DevTools.
+[+] 100% CLIENT-SIDE             Zero server uploads. Your images NEVER leave your device.
+                                  First load fetches the ML model (HuggingFace) and the
+                                  ONNX runtime (jsDelivr) once, then cached — no pixels
+                                  go anywhere. Verify it yourself in DevTools.
 
 [+] OFFLINE MODE                 After first visit, app + model weights are cached.
                                   Process images without internet.
@@ -154,6 +156,13 @@ NO tracking.             No analytics. No telemetry.
 NO accounts.             No sign-up required.
 OFFLINE capable.         Works without internet after first visit.
 OPEN SOURCE.             Don't trust us -- verify.
+
+What actually goes over the network (first load only, then cached):
+  - briaai/RMBG-1.4 weights from huggingface.co
+  - onnxruntime-web WASM runtime from cdn.jsdelivr.net (needed for LaMa inpainting)
+  - opencv/inpainting_lama weights from huggingface.co (first watermark inpaint only)
+Open DevTools > Network while you process an image: the only requests
+you should see after the first warmup are the initial page load.
 ```
 
 ## > comparison


### PR DESCRIPTION
## Summary
Rephrases the README claim from the absolute "Zero network requests during processing" to a more truthful version that itemizes what goes over the wire on first load (RMBG weights from HF, ONNX Runtime WASM from jsDelivr, LaMa weights from HF on first inpaint), and clarifies that everything is cached after that.

The "images never leave your device" guarantee — which is the actually-important privacy claim — stays unchanged and load-bearing.

## Why
The old wording didn't survive the DevTools Network panel test. A curious user inspecting their first load would see HF + jsDelivr requests and correctly conclude the README was misleading. We now document exactly what the network does and leave the real privacy invariant (image data stays local) as the headline.

## Test plan
- [ ] README renders correctly on GitHub.
- [ ] DevTools Network check matches what the privacy block now says.

Closes #42.