### PR TITLE
security: pin LaMa revision + verify size + SHA-256 (closes #40)

### DIFF
--- a/src/pipeline/constants.ts
+++ b/src/pipeline/constants.ts
@@ -152,9 +152,24 @@ export const INPAINT_PARAMS = {
  *  Unlike PatchMatch (patch-based), LaMa uses Fourier convolutions that
  *  understand structure and semantics, so it reconstructs watermarks
  *  sitting on faces, text, or complex objects without the flat-patch
- *  look. Only loaded when the router says structure is present. */
+ *  look. Only loaded when the router says structure is present.
+ *
+ *  Integrity:
+ *  - URL is pinned to a specific repo commit (not `main`) so an upstream
+ *    replacement is caught by size + hash checks below.
+ *  - EXPECTED_SIZE is the Content-Length served by HF for this revision.
+ *  - EXPECTED_SHA256 is the LFS content hash (HF's X-Linked-ETag).
+ *    The worker computes SHA-256 of the downloaded bytes and refuses
+ *    to hand them to ORT if it diverges.
+ *  Audit date: 2026-04-24. Refresh with:
+ *    curl -sSLI "https://huggingface.co/opencv/inpainting_lama/resolve/<sha>/inpainting_lama_2025jan.onnx"
+ */
 export const LAMA_PARAMS = {
-  MODEL_URL: 'https://huggingface.co/opencv/inpainting_lama/resolve/main/inpainting_lama_2025jan.onnx',
+  MODEL_URL:
+    'https://huggingface.co/opencv/inpainting_lama/resolve/aee6d22f0a13e5e35af1c9a1c3afd62841fc6f3f/inpainting_lama_2025jan.onnx',
+  EXPECTED_SIZE: 92_591_623,
+  EXPECTED_SHA256:
+    '7df918ac3921d3daf0aae1d219776cf0dc4e4935f035af81841b40adcf74fdf2',
   /** Fixed 1:1 input expected by the ONNX graph. Changing this breaks
    *  inference — it's baked into the Fourier convolution tensor sizes. */
   INPUT_SIZE: 512,

--- a/src/workers/lama.worker.ts
+++ b/src/workers/lama.worker.ts
@@ -86,12 +86,32 @@ async function loadModel(id: string): Promise<ort.InferenceSession> {
         `Truncated LaMa model download: got ${received} / ${total} bytes`,
       );
     }
+    if (received !== LAMA_PARAMS.EXPECTED_SIZE) {
+      throw new Error(
+        `LaMa model size mismatch: got ${received} bytes, expected ` +
+        `${LAMA_PARAMS.EXPECTED_SIZE}. Upstream may have been replaced.`,
+      );
+    }
 
     const buffer = new Uint8Array(received);
     let offset = 0;
     for (const c of chunks) {
       buffer.set(c, offset);
       offset += c.byteLength;
+    }
+
+    // Integrity check: fail closed if the downloaded bytes don't match
+    // the audited SHA-256. Protects against an upstream swap, a MITM,
+    // or a poisoned Service Worker cache serving unverified content.
+    const digestBuf = await crypto.subtle.digest('SHA-256', buffer);
+    const digestHex = Array.from(new Uint8Array(digestBuf))
+      .map((b) => b.toString(16).padStart(2, '0'))
+      .join('');
+    if (digestHex !== LAMA_PARAMS.EXPECTED_SHA256) {
+      throw new Error(
+        `LaMa model hash mismatch: got ${digestHex}, ` +
+        `expected ${LAMA_PARAMS.EXPECTED_SHA256}. Refusing to load.`,
+      );
     }
 
     const created = await ort.InferenceSession.create(buffer, {


### PR DESCRIPTION
## Summary
- `src/pipeline/constants.ts`: LaMa URL pinned to commit `aee6d22f0a13e5e35af1c9a1c3afd62841fc6f3f` (no more `/resolve/main/`). Added `EXPECTED_SIZE` and `EXPECTED_SHA256` constants with a comment documenting the refresh command and audit date.
- `src/workers/lama.worker.ts`: after the fetch, assert `received === EXPECTED_SIZE`, then compute SHA-256 with `crypto.subtle.digest` and reject on hash mismatch. Both fail with a specific message (`"Upstream may have been replaced"` / `"Refusing to load"`) so a poisoned cache or MITM is actionable instead of surfacing as a cryptic ORT error.

## Why
Closes the supply-chain gap flagged in #40. RMBG was already pinned by revision; LaMa loaded from `main`, which meant an upstream replacement would flow through the Service Worker cache and into ORT undetected.

The hash check also backfills defense against a poisoned Service Worker cache — if the cached bytes diverge for any reason, the worker now fails closed instead of running adversarial weights.

## How to refresh the pin
When LaMa is updated upstream, bump the three constants using:
```bash
curl -sSLI "https://huggingface.co/opencv/inpainting_lama/resolve/<new-sha>/inpainting_lama_2025jan.onnx"
```
`X-Repo-Commit` → `MODEL_URL` revision segment. `X-Linked-Size` → `EXPECTED_SIZE`. `X-Linked-ETag` → `EXPECTED_SHA256`.

## Test plan
- [ ] `npm run typecheck` passes.
- [ ] Cold load: LaMa session initializes normally (size + hash match).
- [ ] If you flip one hex character in `EXPECTED_SHA256`, LaMa refuses to load with the expected error.
- [ ] If you flip one digit in `EXPECTED_SIZE`, LaMa refuses to load before the hash is even computed.

Closes #40.