### PR TITLE
pipeline: 20-min wall-clock timeout in process() (closes #41)

### DIFF
--- a/src/pipeline/orchestrator.ts
+++ b/src/pipeline/orchestrator.ts
@@ -37,6 +37,13 @@ const INPAINT_TIMEOUT_MS = 30_000;
  *  then runs Fourier-convolution inference on WASM. 5 min covers the
  *  worst-case cold start on a slow connection. */
 const LAMA_TIMEOUT_MS = 300_000;
+/** Total wall-clock cap for process(). Generous because a first-time
+ *  run on a slow connection can pay for the RMBG download (~45MB),
+ *  the LaMa download (~95MB) and the ONNX Runtime WASM fetch from
+ *  jsDelivr (~6MB) in sequence before any CPU work starts. If this
+ *  fires, we've almost certainly hit a pathological hang the per-stage
+ *  timeouts didn't catch — abort instead of letting the UI sit forever. */
+const PROCESS_TIMEOUT_MS = 20 * 60_000;
 
 /**
  * Error thrown when a pipeline run is aborted via AbortSignal or
@@ -478,9 +485,16 @@ export class PipelineOrchestrator {
     signal?: AbortSignal,
   ): Promise<PipelineResult> {
     this.bindAbortSignal(signal);
+    // Wall-clock safety net. Rarely meaningful in practice — the
+    // per-stage timeouts should kick first — but guarantees the UI
+    // never sits on a spinner indefinitely if something truly hangs.
+    const timeoutId = setTimeout(() => {
+      this.abort(`processing timeout after ${PROCESS_TIMEOUT_MS / 60_000}min`);
+    }, PROCESS_TIMEOUT_MS);
     try {
       return await this._process(imageData, modelId, precision);
     } finally {
+      clearTimeout(timeoutId);
       // Detach signal listener so a late abort on a previous run can't
       // tear down a subsequent process() that reuses the same signal.
       this.activeSignalCleanup?.();


### PR DESCRIPTION
## Summary
- Adds a `setTimeout` around `process()` that fires `abort('processing timeout after 20min')` if the whole run exceeds 20 minutes.
- Timer is cleared in the existing `finally` block, alongside the signal-listener cleanup.

## Why
The per-stage timeouts (60s CV, 300s ML, 300s LaMa, 30s Inpaint) cover stage-local hangs — but a pathological chain could still sit indefinitely without any single stage tripping. This closes that gap with a wall-clock ceiling.

**Why 20 min and not 5 min**: a first-load worst case can legitimately chain:
- RMBG download ~45 MB
- LaMa download ~95 MB
- ONNX Runtime WASM from jsDelivr ~6 MB
- …plus the actual CPU work.

On a 1 Mbit/s connection that lands near 25 min. Picking 5 min (the audit's original suggestion) would false-positive cancel real users on slow links. 20 min leaves comfortable headroom while still bounding "something is truly stuck" cases.

The timeout rides the `PipelineAbortError` path from #43, so the UI handles it identically to a user cancel — no generic "error" toast.

## Test plan
- [ ] `npm run typecheck` passes.
- [ ] Temporarily lower `PROCESS_TIMEOUT_MS` to 2000, drop an image, verify the pipeline cleanly aborts with `PipelineAbortError("processing timeout after 0.03min")`.
- [ ] Restore, confirm a normal run completes without tripping the timer.

Closes #41.