### PR TITLE
ui: Escape closes help + unconditional touch-action (partial #35, #37)

### DIFF
--- a/src/components/ar-editor-advanced.ts
+++ b/src/components/ar-editor-advanced.ts
@@ -972,6 +972,14 @@ export class ArEditorAdvanced extends HTMLElement {
 
       if (e.key === 'Escape') {
         e.preventDefault();
+        // Help panel closes first: keyboard users expect Escape to dismiss
+        // whatever transient overlay is visible before nuking their
+        // in-progress selection.
+        const helpPanel = this.shadowRoot?.getElementById('help-panel');
+        if (helpPanel && !helpPanel.classList.contains('hidden')) {
+          this.toggleHelp();
+          return;
+        }
         if (this.busy) {
           this.cancelAction();
           return;

--- a/src/components/ar-editor.ts
+++ b/src/components/ar-editor.ts
@@ -310,6 +310,11 @@ export class ArEditor extends HTMLElement {
           min-height: 400px;
           display: flex;
           align-items: center;
+          /* touch-action:none unconditionally — iOS Safari treats
+             long-press on canvas as context menu and pinch as page
+             zoom, both of which break the brush / erase flow even
+             when a mouse is also attached (iPad with trackpad). */
+          touch-action: none;
           justify-content: center;
         }
         canvas {
@@ -457,9 +462,6 @@ export class ArEditor extends HTMLElement {
           .bg-btn {
             width: 32px;
             height: 32px;
-          }
-          .canvas-wrap {
-            touch-action: none;
           }
         }
 
@@ -612,6 +614,14 @@ export class ArEditor extends HTMLElement {
     // Close on click outside
     this.shadowRoot!.addEventListener('click', (e) => {
       if (e.target !== helpBtn && !helpTooltip.contains(e.target as Node)) {
+        helpTooltip.classList.remove('visible');
+      }
+    }, { signal });
+    // Close on Escape — keyboard users otherwise have no way out of
+    // the help overlay short of clicking the button again.
+    window.addEventListener('keydown', (e) => {
+      if (e.key === 'Escape' && helpTooltip.classList.contains('visible')) {
+        e.preventDefault();
         helpTooltip.classList.remove('visible');
       }
     }, { signal });


### PR DESCRIPTION
## Summary
Small, safe a11y + mobile slice:
- `ar-editor-advanced.ts`: Escape now closes the open help panel before falling through to the existing cancel/clear-lasso/clear-selection flow. Keyboard users could not dismiss the overlay before.
- `ar-editor.ts`: equivalent Escape handler for the help tooltip.
- `ar-editor.ts`: `.canvas-wrap { touch-action: none }` moved out of `@media (pointer: coarse)`. On iPads with trackpads, `pointer: coarse` is false but touch still works, and long-press was opening the iOS context menu mid-brush. Unconditional is the safer default.

## Not in this PR
The big-ticket a11y items from #35 (keyboard nav on canvases, `prefers-reduced-motion` for zoom/pan, color-contrast audit, `aria-live` for error/toast regions) and the rest of #37 (toolbar overflow at 375 px, touch indicator in advanced editor, batch-grid per-item progress, download-button size labels) stay open — they're meaningful changes that want individual review.

## Test plan
- [ ] Keyboard: open editor help (`?`), press Escape, overlay closes.
- [ ] Keyboard: same in advanced editor.
- [ ] iPad trackpad / mouse: long-press on canvas no longer opens the iOS context menu.
- [ ] Pointer users: normal behavior unchanged.

Partial resolution of #35 and #37.