### PR TITLE
ui: Cancel button in ar-progress (partial #36)

### DIFF
--- a/src/components/ar-app.ts
+++ b/src/components/ar-app.ts
@@ -781,6 +781,18 @@ export class ArApp extends HTMLElement {
     };
     document.addEventListener('nukebg:locale-changed', this.boundLocaleHandler);
 
+    // Cancel button in ar-progress fires ar:cancel-processing. We abort
+    // the active pipeline run; the processImage/batch catch blocks already
+    // swallow PipelineAbortError, and the new image flow keeps working.
+    this.progress.addEventListener('ar:cancel-processing', () => {
+      if (this.processingAbortController && !this.processingAbortController.signal.aborted) {
+        this.processingAbortController.abort('user cancelled');
+      }
+      if (this.batchMode !== 'off') {
+        this.batchAborted = true;
+      }
+    });
+
     // PWA install button - mobile only
     const installBtn = this.shadowRoot!.querySelector('#install-btn') as HTMLButtonElement;
     const installGuide = this.shadowRoot!.querySelector('#install-guide') as HTMLDivElement;
@@ -1350,6 +1362,7 @@ export class ArApp extends HTMLElement {
     // whether the pipeline worked on a downscaled copy.
     this.viewer.setOriginal(originalImageData, fileSize);
     this.progress.reset();
+    this.progress.setRunning(true);
     this.download.reset();
 
     // Reuse existing pipeline (keeps model loaded)
@@ -1444,6 +1457,7 @@ export class ArApp extends HTMLElement {
       const msg = err instanceof Error ? err.message : String(err);
       this.progress.setStage('ml-segmentation', 'error', t('pipeline.error', { msg }));
     } finally {
+      this.progress.setRunning(false);
       if (!this.processingAborted) {
         this.isProcessing = false;
         this.enableWorkspaceButtons();
@@ -1560,6 +1574,7 @@ export class ArApp extends HTMLElement {
       // Fresh slate for this item: empty history, empty live console.
       item.stageHistory = [];
       this.progress.reset();
+      this.progress.setRunning(true);
       this.batchCurrentProcessingItem = item;
       if (this.batchGrid) this.batchGrid.updateItem(item.id, 'processing');
       // One signal per batch item so cancelling the batch aborts the
@@ -1601,6 +1616,7 @@ export class ArApp extends HTMLElement {
         // Abort during batch = user cancelled. Don't mark the item as
         // failed; the outer batchAborted check will return on next tick.
         if (err instanceof PipelineAbortError || this.batchAborted) {
+          this.progress.setRunning(false);
           return;
         }
         item.errorMessage = err instanceof Error ? err.message : String(err);
@@ -1611,6 +1627,7 @@ export class ArApp extends HTMLElement {
         }
       }
     }
+    this.progress.setRunning(false);
     this.batchCurrentProcessingItem = null;
   }
 

--- a/src/components/ar-progress.ts
+++ b/src/components/ar-progress.ts
@@ -14,6 +14,7 @@ export class ArProgress extends HTMLElement {
   private startTimes = new Map<PipelineStage, number>();
   private detectedContentType: string | null = null;
   private boundLocaleHandler: (() => void) | null = null;
+  private running = false;
 
   constructor() {
     super();
@@ -30,6 +31,14 @@ export class ArProgress extends HTMLElement {
         else if (s.stage === 'inpaint') s.label = t('progress.inpaint');
         else if (s.stage === 'ml-segmentation') s.label = t('progress.bgRemovalML');
       });
+      // Update Cancel button label in place — re-rendering would drop
+      // the click listener we attached in render().
+      const btn = this.shadowRoot?.querySelector('#cancel-btn') as HTMLButtonElement | null;
+      if (btn) {
+        const label = t('progress.cancel') || 'Cancel';
+        btn.textContent = label;
+        btn.setAttribute('aria-label', label);
+      }
       this.update();
     };
     document.addEventListener('nukebg:locale-changed', this.boundLocaleHandler);
@@ -49,6 +58,25 @@ export class ArProgress extends HTMLElement {
     this.detectedContentType = null;
     this.startTimes.clear();
     this.update();
+  }
+
+  /**
+   * Toggle the Cancel control visibility. The hosting component
+   * (`ar-app`) calls `setRunning(true)` when pipeline.process() starts
+   * and `setRunning(false)` when it settles (success, failure, or abort).
+   * Clicking the button dispatches `ar:cancel-processing` which the
+   * host listens for and wires to its AbortController.
+   */
+  setRunning(running: boolean): void {
+    this.running = running;
+    this.syncCancelButton();
+  }
+
+  private syncCancelButton(): void {
+    const btn = this.shadowRoot?.querySelector('#cancel-btn') as HTMLButtonElement | null;
+    if (!btn) return;
+    btn.hidden = !this.running;
+    btn.disabled = !this.running;
   }
 
   setStage(stage: PipelineStage, status: StageStatus, message?: string): void {
@@ -216,9 +244,53 @@ export class ArProgress extends HTMLElement {
           .progress-fill.parsing { animation: none !important; }
         }
 
+        .cancel-row {
+          display: flex;
+          justify-content: flex-end;
+          margin-top: 6px;
+        }
+        .cancel-btn {
+          font-family: 'JetBrains Mono', monospace;
+          font-size: 12px;
+          padding: 4px 10px;
+          background: transparent;
+          color: var(--color-text-secondary, #00dd44);
+          border: 1px solid var(--color-surface-border, #1a3a1a);
+          border-radius: 0;
+          cursor: pointer;
+          min-height: 32px;
+        }
+        .cancel-btn:hover:not(:disabled),
+        .cancel-btn:focus-visible {
+          color: var(--color-error, #ff3131);
+          border-color: var(--color-error, #ff3131);
+          outline: none;
+        }
+        .cancel-btn:disabled { opacity: 0.4; cursor: not-allowed; }
+        @media (pointer: coarse) {
+          .cancel-btn { min-height: 44px; min-width: 88px; }
+        }
       </style>
       <div class="stages" role="log" aria-live="polite"></div>
+      <div class="cancel-row">
+        <button
+          id="cancel-btn"
+          class="cancel-btn"
+          type="button"
+          hidden
+          disabled
+          aria-label="${this.escapeHtml(t('progress.cancel') || 'Cancel')}"
+        >${this.escapeHtml(t('progress.cancel') || 'Cancel')}</button>
+      </div>
     `;
+    const cancelBtn = this.shadowRoot!.querySelector('#cancel-btn');
+    cancelBtn?.addEventListener('click', () => {
+      if (!this.running) return;
+      this.dispatchEvent(new CustomEvent('ar:cancel-processing', {
+        bubbles: true,
+        composed: true,
+      }));
+    });
   }
 
   /** Escape HTML entities to prevent XSS from worker error messages */

--- a/src/i18n/index.ts
+++ b/src/i18n/index.ts
@@ -31,6 +31,7 @@ const translations: Translations = {
     'progress.bgRemovalCV': 'Removing background [CV]',
     'progress.bgRemovalML': 'Removing background [ML]',
     'progress.initAI': 'Initializing AI engine...',
+    'progress.cancel': 'Cancel',
     'progress.total': 'Total:',
     'progress.downscaled': 'Large image: processing at {w}\u00D7{h} to fit memory (output at original {ow}\u00D7{oh}).',
 
@@ -227,6 +228,7 @@ const translations: Translations = {
     'progress.bgRemovalCV': 'Eliminando fondo [CV]',
     'progress.bgRemovalML': 'Eliminando fondo [ML]',
     'progress.initAI': 'Inicializando motor IA...',
+    'progress.cancel': 'Cancelar',
     'progress.total': 'Total:',
     'progress.downscaled': 'Imagen grande: procesando en {w}\u00D7{h} para ahorrar memoria (salida a {ow}\u00D7{oh} original).',
 
@@ -423,6 +425,7 @@ const translations: Translations = {
     'progress.bgRemovalCV': "Suppression de l'arri\u00E8re-plan [CV]",
     'progress.bgRemovalML': "Suppression de l'arri\u00E8re-plan [ML]",
     'progress.initAI': "Initialisation du moteur IA...",
+    'progress.cancel': 'Annuler',
     'progress.total': 'Total :',
     'progress.downscaled': 'Grande image : traitement en {w}\u00D7{h} pour la m\u00E9moire (sortie en {ow}\u00D7{oh} d\u2019origine).',
 
@@ -619,6 +622,7 @@ const translations: Translations = {
     'progress.bgRemovalCV': 'Hintergrund entfernen [CV]',
     'progress.bgRemovalML': 'Hintergrund entfernen [ML]',
     'progress.initAI': 'KI-Engine wird initialisiert...',
+    'progress.cancel': 'Abbrechen',
     'progress.total': 'Gesamt:',
     'progress.downscaled': 'Gro\u00DFes Bild: Verarbeitung bei {w}\u00D7{h} zur Speicherschonung (Ausgabe in Original {ow}\u00D7{oh}).',
 
@@ -815,6 +819,7 @@ const translations: Translations = {
     'progress.bgRemovalCV': 'Removendo fundo [CV]',
     'progress.bgRemovalML': 'Removendo fundo [ML]',
     'progress.initAI': 'Inicializando motor de IA...',
+    'progress.cancel': 'Cancelar',
     'progress.total': 'Total:',
     'progress.downscaled': 'Imagem grande: processando em {w}\u00D7{h} para economizar mem\u00F3ria (sa\u00EDda em {ow}\u00D7{oh} original).',
 
@@ -1011,6 +1016,7 @@ const translations: Translations = {
     'progress.bgRemovalCV': '\u53BB\u9664\u80CC\u666F [CV]',
     'progress.bgRemovalML': '\u53BB\u9664\u80CC\u666F [ML]',
     'progress.initAI': 'AI \u5F15\u64CE\u521D\u59CB\u5316\u4E2D...',
+    'progress.cancel': '\u53D6\u6D88',
     'progress.total': '\u603B\u8BA1:',
     'progress.downscaled': '\u5927\u56FE\u50CF\uFF1A\u4EE5 {w}\u00D7{h} \u5904\u7406\u4EE5\u8282\u7701\u5185\u5B58\uFF08\u8F93\u51FA\u4F4D\u539F\u59CB {ow}\u00D7{oh}\uFF09\u3002',
 


### PR DESCRIPTION
## Summary
Adds a visible Cancel control to `ar-progress`. Builds directly on the AbortController plumbing that landed in #43.

- `ar-progress.ts`: new `setRunning(true|false)` method toggles a button hidden in the rendered shadow DOM. Click dispatches `ar:cancel-processing` (bubbles, composed). Styles: 44×88 min target on coarse pointers, error-red hover/focus, respects `prefers-reduced-motion` via the existing media query on the component.
- `ar-app.ts`: listens for `ar:cancel-processing`, fires `processingAbortController.abort('user cancelled')`, and in batch mode also flips `batchAborted`. Calls `setRunning(true)` on both single-image and batch paths, `setRunning(false)` in each finally / catch.
- `i18n/index.ts`: new `progress.cancel` key added to all six locales (en/es/fr/de/pt/zh). Label is patched in place on locale change so the click handler survives.

## Why
Closes the "stuck spinner, no way out" experience: before this, users with large images or slow devices would sit through the 60 s–5 min per-stage timeouts, or reload the page. Now one tap stops the workers.

## Test plan
- [ ] `npm run typecheck` passes.
- [ ] Drop a large image, click Cancel mid-process — workers terminate immediately, button hides, no error toast.
- [ ] Start a batch of 3+ images, click Cancel during item 2 — queue stops cleanly, no "failed" items.
- [ ] Switch locale mid-process — button label updates, click still fires cancel.
- [ ] Keyboard-only: Tab to Cancel, Enter fires cancel.

Partial resolution of #36 (the remaining pieces — error modal with Retry/Reload, per-item batch retry, viewer render fallback — ship separately).