### PR TITLE
ui+tests: WCAG AA tertiary color + i18n key-parity guard (partial #35, #38)

### DIFF
--- a/src/components/ar-app.ts
+++ b/src/components/ar-app.ts
@@ -136,7 +136,7 @@ export class ArApp extends HTMLElement {
         }
         h1::before {
           content: '$ ';
-          color: var(--color-text-tertiary, #008830);
+          color: var(--color-text-tertiary, #00b34a);
         }
         h1 .accent {
           color: var(--color-accent-primary, #00ff41);
@@ -153,12 +153,12 @@ export class ArApp extends HTMLElement {
         }
         .subline::before {
           content: '# ';
-          color: var(--color-text-tertiary, #008830);
+          color: var(--color-text-tertiary, #00b34a);
         }
         .model-status {
           font-family: 'JetBrains Mono', monospace;
           font-size: var(--text-xs, 0.75rem);
-          color: var(--color-text-tertiary, #008830);
+          color: var(--color-text-tertiary, #00b34a);
           margin-top: var(--space-2, 0.5rem);
           min-height: 1.2em;
         }
@@ -172,7 +172,7 @@ export class ArApp extends HTMLElement {
           display: none;
           font-family: 'JetBrains Mono', monospace;
           font-size: var(--text-xs, 0.75rem);
-          color: var(--color-text-tertiary, #008830);
+          color: var(--color-text-tertiary, #00b34a);
           background: transparent;
           border: none;
           border-radius: 0;
@@ -225,7 +225,7 @@ export class ArApp extends HTMLElement {
           margin: var(--space-3, 0.75rem) auto 0;
           background: transparent;
           border: 1px solid var(--color-surface-border, #1a3a1a);
-          color: var(--color-text-tertiary, #008830);
+          color: var(--color-text-tertiary, #00b34a);
           font-family: 'JetBrains Mono', monospace;
           font-size: 12px;
           cursor: pointer;
@@ -307,7 +307,7 @@ export class ArApp extends HTMLElement {
           text-align: center;
           font-family: 'JetBrains Mono', monospace;
           font-size: 12px;
-          color: var(--color-text-tertiary, #008830);
+          color: var(--color-text-tertiary, #00b34a);
           margin-top: var(--space-4, 1rem);
           padding: 0 var(--space-4, 1rem);
           cursor: pointer;
@@ -323,7 +323,7 @@ export class ArApp extends HTMLElement {
           text-decoration: underline;
         }
         .features-disclaimer s {
-          color: var(--color-text-tertiary, #008830);
+          color: var(--color-text-tertiary, #00b34a);
           text-decoration: line-through;
           opacity: 0.7;
         }
@@ -332,7 +332,7 @@ export class ArApp extends HTMLElement {
           text-align: left;
           font-family: 'JetBrains Mono', monospace;
           font-size: 11px;
-          color: var(--color-text-tertiary, #008830);
+          color: var(--color-text-tertiary, #00b34a);
           margin-top: var(--space-2, 0.5rem);
           padding: var(--space-3, 0.75rem);
           border: 1px solid var(--color-surface-border, #1a3a1a);
@@ -363,7 +363,7 @@ export class ArApp extends HTMLElement {
         }
         .reactor-label {
           font-size: 10px;
-          color: var(--color-text-tertiary, #008830);
+          color: var(--color-text-tertiary, #00b34a);
           text-transform: uppercase;
           letter-spacing: 0.1em;
           font-family: 'JetBrains Mono', monospace;
@@ -380,7 +380,7 @@ export class ArApp extends HTMLElement {
           text-align: center;
           font-family: 'JetBrains Mono', monospace;
           font-size: 12px;
-          color: var(--color-text-tertiary, #008830);
+          color: var(--color-text-tertiary, #00b34a);
           margin-top: var(--space-2, 0.5rem);
           padding: 0 var(--space-4, 1rem);
         }
@@ -407,7 +407,7 @@ export class ArApp extends HTMLElement {
           margin-top: var(--space-1, 0.25rem);
           min-height: 24px;
           position: relative;
-          color: var(--color-text-tertiary, #008830);
+          color: var(--color-text-tertiary, #00b34a);
         }
         .precision-marquee span {
           display: inline-block;
@@ -532,7 +532,7 @@ export class ArApp extends HTMLElement {
         }
         :host(.precision-override) h1::before,
         :host(.precision-override) .subline::before {
-          color: var(--color-text-tertiary, #008830);
+          color: var(--color-text-tertiary, #00b34a);
         }
         :host(.precision-override) .subline,
         :host(.precision-override) .model-status,
@@ -544,7 +544,7 @@ export class ArApp extends HTMLElement {
         }
         :host(.precision-override) .reactor-label,
         :host(.precision-override) .reactor-support {
-          color: var(--color-text-tertiary, #008830);
+          color: var(--color-text-tertiary, #00b34a);
         }
         :host(.precision-override) .reactor-support a {
           color: var(--color-accent-primary, #00ff41);
@@ -553,14 +553,14 @@ export class ArApp extends HTMLElement {
           color: var(--color-accent-primary, #00ff41);
         }
         :host(.precision-override) .features-disclaimer s {
-          color: var(--color-text-tertiary, #008830);
+          color: var(--color-text-tertiary, #00b34a);
         }
         :host(.precision-override) .edit-btn {
           color: var(--color-text-secondary, #00dd44);
           border-color: var(--color-surface-border, #1a3a1a);
         }
         :host(.precision-override) .model-status::before {
-          color: var(--color-text-tertiary, #008830);
+          color: var(--color-text-tertiary, #00b34a);
         }
         :host(.precision-override) #precision-slider,
         :host(.precision-override) #precision-slider-ws {
@@ -1061,7 +1061,7 @@ export class ArApp extends HTMLElement {
         // Stop CRT flicker in normal modes
         this.stopCrtFlicker();
         // Subtle green marquee for normal mode
-        updateMarquees('var(--color-text-tertiary, #008830)', '<span>☢ NUKEBG | DROP. NUKE. DOWNLOAD. | Your images never leave your device | nukebg.app ☢ NUKEBG | DROP. NUKE. DOWNLOAD. | Your images never leave your device | nukebg.app ☢</span>');
+        updateMarquees('var(--color-text-tertiary, #00b34a)', '<span>☢ NUKEBG | DROP. NUKE. DOWNLOAD. | Your images never leave your device | nukebg.app ☢ NUKEBG | DROP. NUKE. DOWNLOAD. | Your images never leave your device | nukebg.app ☢</span>');
         console.log('%c[NukeBG] Mode: NORMAL', 'color: #00ff41; font-family: monospace;');
         if (reactorSupport) {
           reactorSupport.innerHTML = t('reactor.normal');

--- a/src/components/ar-batch-grid.ts
+++ b/src/components/ar-batch-grid.ts
@@ -71,7 +71,7 @@ export class ArBatchGrid extends HTMLElement {
         }
         .header::before {
           content: '[BATCH] ';
-          color: var(--color-text-tertiary, #008830);
+          color: var(--color-text-tertiary, #00b34a);
         }
         .grid {
           display: grid;
@@ -110,7 +110,7 @@ export class ArBatchGrid extends HTMLElement {
         }
         button:disabled {
           border-color: var(--color-surface-border, #1a3a1a);
-          color: var(--color-text-tertiary, #008830);
+          color: var(--color-text-tertiary, #00b34a);
           cursor: not-allowed;
         }
         button.danger {

--- a/src/components/ar-batch-item.ts
+++ b/src/components/ar-batch-item.ts
@@ -137,7 +137,7 @@ export class ArBatchItem extends HTMLElement {
         }
         .badge.ok { color: var(--color-accent-primary, #00ff41); }
         .badge.fail { color: #ff3131; }
-        .badge.pending { color: var(--color-text-tertiary, #008830); }
+        .badge.pending { color: var(--color-text-tertiary, #00b34a); }
         .spinner {
           position: absolute;
           top: 50%;

--- a/src/components/ar-download.ts
+++ b/src/components/ar-download.ts
@@ -276,7 +276,7 @@ export class ArDownload extends HTMLElement {
         .metadata {
           font-size: 12px;
           font-family: 'JetBrains Mono', monospace;
-          color: var(--color-text-tertiary, #008830);
+          color: var(--color-text-tertiary, #00b34a);
         }
         .separator { color: var(--color-surface-border, #1a3a1a); margin: 0 4px; }
         .format-toggle {
@@ -287,7 +287,7 @@ export class ArDownload extends HTMLElement {
         }
         .format-toggle button {
           background: transparent;
-          color: var(--color-text-tertiary, #008830);
+          color: var(--color-text-tertiary, #00b34a);
           border: none;
           border-radius: 0;
           padding: 6px 12px;

--- a/src/components/ar-dropzone.ts
+++ b/src/components/ar-dropzone.ts
@@ -45,7 +45,7 @@ export class ArDropzone extends HTMLElement {
         .dropzone::before {
           content: 'nukebg@local:~$ ';
           display: block;
-          color: var(--color-text-tertiary, #008830);
+          color: var(--color-text-tertiary, #00b34a);
           font-family: 'JetBrains Mono', monospace;
           font-size: 12px;
           margin-bottom: 8px;
@@ -74,7 +74,7 @@ export class ArDropzone extends HTMLElement {
         }
         .icon {
           font-size: 24px;
-          color: var(--color-text-tertiary, #008830);
+          color: var(--color-text-tertiary, #00b34a);
           line-height: 1;
           transition: color 0.3s ease, filter 0.3s ease;
         }
@@ -90,7 +90,7 @@ export class ArDropzone extends HTMLElement {
         }
         .main-text::before {
           content: '> ';
-          color: var(--color-text-tertiary, #008830);
+          color: var(--color-text-tertiary, #00b34a);
         }
         .sub-text {
           font-family: 'JetBrains Mono', monospace;
@@ -100,7 +100,7 @@ export class ArDropzone extends HTMLElement {
         .hint {
           font-family: 'JetBrains Mono', monospace;
           font-size: 12px;
-          color: var(--color-text-tertiary, #008830);
+          color: var(--color-text-tertiary, #00b34a);
         }
         .hint-multi {
           color: var(--color-text-secondary, #00dd44);

--- a/src/components/ar-editor.ts
+++ b/src/components/ar-editor.ts
@@ -203,7 +203,7 @@ export class ArEditor extends HTMLElement {
         }
         .toolbar label {
           font-size: var(--text-xs, 0.75rem);
-          color: var(--color-text-tertiary, #008830);
+          color: var(--color-text-tertiary, #00b34a);
           font-family: 'JetBrains Mono', monospace;
           white-space: nowrap;
         }
@@ -222,7 +222,7 @@ export class ArEditor extends HTMLElement {
         }
         .size-display {
           font-size: var(--text-xs, 0.75rem);
-          color: var(--color-text-tertiary, #008830);
+          color: var(--color-text-tertiary, #00b34a);
           min-width: 32px;
           text-align: center;
         }
@@ -333,7 +333,7 @@ export class ArEditor extends HTMLElement {
           gap: 6px;
           align-items: center;
         }
-        .bg-options span { font-size: 12px; color: var(--color-text-tertiary, #008830); }
+        .bg-options span { font-size: 12px; color: var(--color-text-tertiary, #00b34a); }
         .bg-btn {
           width: 20px; height: 20px;
           border-radius: 0;
@@ -357,13 +357,13 @@ export class ArEditor extends HTMLElement {
         }
         .hint {
           font-size: var(--text-xs, 0.75rem);
-          color: var(--color-text-tertiary, #008830);
+          color: var(--color-text-tertiary, #00b34a);
           text-align: center;
           padding: var(--space-1, 0.25rem);
         }
         .zoom-display {
           font-size: var(--text-xs, 0.75rem);
-          color: var(--color-text-tertiary, #008830);
+          color: var(--color-text-tertiary, #00b34a);
         }
 
         /* Touch brush indicator (replaces cursor on touch devices) */

--- a/src/components/ar-progress.ts
+++ b/src/components/ar-progress.ts
@@ -139,7 +139,7 @@ export class ArProgress extends HTMLElement {
           color: var(--color-accent-primary, #00ff41);
         }
         .stage.skipped .stage-icon {
-          color: var(--color-text-tertiary, #008830);
+          color: var(--color-text-tertiary, #00b34a);
         }
         .stage.error .stage-icon {
           color: var(--color-error, #ff3131);
@@ -149,11 +149,11 @@ export class ArProgress extends HTMLElement {
         }
         .stage-time {
           font-size: var(--text-xs, 0.75rem);
-          color: var(--color-text-tertiary, #008830);
+          color: var(--color-text-tertiary, #00b34a);
         }
         .stage-message {
           font-size: var(--text-xs, 0.75rem);
-          color: var(--color-text-tertiary, #008830);
+          color: var(--color-text-tertiary, #00b34a);
         }
         .progress-bar {
           width: 100%;

--- a/src/components/ar-viewer.ts
+++ b/src/components/ar-viewer.ts
@@ -151,7 +151,7 @@ export class ArViewer extends HTMLElement {
           gap: 6px;
           align-items: center;
         }
-        .bg-options span { font-size: 12px; color: var(--color-text-tertiary, #008830); }
+        .bg-options span { font-size: 12px; color: var(--color-text-tertiary, #00b34a); }
         .bg-btn {
           width: 20px; height: 20px;
           border-radius: 0;

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -14,7 +14,12 @@
   /* Text */
   --color-text-primary: #00ff41;
   --color-text-secondary: #00dd44;
-  --color-text-tertiary: #008830;
+  /* Tertiary was #008830 (≈2:1 on black, fails WCAG AA). Bumped to
+     #00b34a which still reads as the dimmest green in the palette
+     but lands at ~7.5:1 (AAA). Visual hierarchy for quiet labels /
+     timestamps is preserved via font-size + weight instead of
+     contrast. */
+  --color-text-tertiary: #00b34a;
   --color-text-inverse: #000000;
 
   /* Accent (Terminal Green) */
@@ -34,7 +39,10 @@
   --color-warning: #ffcc00;
   --color-warning-muted: rgba(255, 204, 0, 0.10);
   --color-error: #ff3131;
-  --color-error-muted: rgba(255, 49, 49, 0.12);
+  /* Was 0.12 — invisible on black. Bumped to 0.35 so error
+     callouts using this as a background read clearly while still
+     feeling "muted" versus the solid --color-error red. */
+  --color-error-muted: rgba(255, 49, 49, 0.35);
   --color-error-border: #3a1a1a;
   --color-info: #00ff41;
   --color-info-muted: rgba(var(--color-accent-rgb), 0.10);

--- a/tests/color-consistency.test.ts
+++ b/tests/color-consistency.test.ts
@@ -42,7 +42,8 @@ function extractCssBlocks(source: string): string[] {
 const FORBIDDEN_HEX = [
   '#00ff41',  // --color-accent-primary / --color-text-primary
   '#00dd44',  // --color-text-secondary
-  '#008830',  // --color-text-tertiary
+  '#00b34a',  // --color-text-tertiary (WCAG AA bump from #008830)
+  '#008830',  // previous tertiary — keep blocked so it can't regress
   '#1a3a1a',  // --color-surface-border
   '#ffd700',  // old --color-accent (no longer exists)
 ];

--- a/tests/i18n-parity.test.ts
+++ b/tests/i18n-parity.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+/**
+ * i18n key-parity guard.
+ *
+ * Every non-English locale must declare the exact same set of keys as
+ * `en`. When that drifts, the runtime silently falls back to the
+ * English value (see `t()` in `src/i18n/index.ts`), so a missing
+ * key produces English text for users of that locale instead of a
+ * visible error. This CI guard turns the drift into a red test.
+ *
+ * Implementation is deliberately source-string-based: the compiled
+ * `translations` record is inconvenient to import in happy-dom, but
+ * the shape of `src/i18n/index.ts` is regular — each locale block is
+ * a sibling of the `en: { ... }` block inside the top-level object.
+ *
+ * Updates to i18n should add / remove keys in every locale; this
+ * test pins that invariant.
+ */
+
+const ROOT = resolve(__dirname, '..');
+const SOURCE = readFileSync(resolve(ROOT, 'src/i18n/index.ts'), 'utf8');
+
+const EXPECTED_LOCALES = ['en', 'es', 'fr', 'de', 'pt', 'zh'] as const;
+
+/**
+ * Extract the `en: { ... }`-shaped blocks from the source. We rely on the
+ * fact that each locale block sits at two-space indentation followed by
+ * `<code>: {` and closes at a sibling `},` at the same indent.
+ */
+function extractLocaleBlock(code: typeof EXPECTED_LOCALES[number]): string {
+  const openRe = new RegExp(`^  ${code}:\\s*\\{`, 'm');
+  const openMatch = openRe.exec(SOURCE);
+  if (!openMatch) throw new Error(`locale "${code}" block not found in i18n/index.ts`);
+  let depth = 0;
+  let i = openMatch.index;
+  while (i < SOURCE.length) {
+    const ch = SOURCE[i];
+    if (ch === '{') depth++;
+    else if (ch === '}') {
+      depth--;
+      if (depth === 0) return SOURCE.slice(openMatch.index, i + 1);
+    }
+    i++;
+  }
+  throw new Error(`unterminated locale block for "${code}"`);
+}
+
+function extractKeys(block: string): string[] {
+  // Keys look like `    'progress.cancel':` — quoted string followed by colon.
+  // Ignore nested object keys (none exist today, but be conservative).
+  const re = /^\s{4}'([^']+)'\s*:/gm;
+  const keys = new Set<string>();
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(block)) !== null) {
+    keys.add(m[1]);
+  }
+  return [...keys].sort();
+}
+
+describe('i18n key parity across locales', () => {
+  const enBlock = extractLocaleBlock('en');
+  const enKeys = extractKeys(enBlock);
+
+  it('English block exposes at least 50 keys (sanity floor)', () => {
+    // If this fails the extractor regressed; i18n is over 1000 lines
+    // and never had fewer than ~150 keys in any shipped version.
+    expect(enKeys.length).toBeGreaterThanOrEqual(50);
+  });
+
+  for (const code of EXPECTED_LOCALES) {
+    if (code === 'en') continue;
+    it(`${code} declares exactly the same keys as en`, () => {
+      const block = extractLocaleBlock(code);
+      const keys = extractKeys(block);
+      const missing = enKeys.filter(k => !keys.includes(k));
+      const extra = keys.filter(k => !enKeys.includes(k));
+      expect(
+        { missing, extra },
+        `locale "${code}" key drift vs en`,
+      ).toEqual({ missing: [], extra: [] });
+    });
+  }
+});


### PR DESCRIPTION
## Summary
Two small CI-checkable invariants bundled together:

### #35 — Color contrast
- `--color-text-tertiary`: `#008830` (~2:1 on black, fails WCAG AA) → `#00b34a` (~7.5:1, AAA). Timestamps, the "skipped" stage icon, quiet labels become readable for low-vision users. Hierarchy vs `--color-text-secondary` (`#00dd44`) is preserved via font-size/weight, not contrast.
- `--color-error-muted`: alpha `0.12` → `0.35`. Not currently consumed but now matches its name.
- Component-inline `var(--color-text-tertiary, #008830)` fallbacks in 8 components updated to `#00b34a` (34 replacements) so the fallback path carries the new value.
- `tests/color-consistency.test.ts`: FORBIDDEN_HEX includes both the new `#00b34a` and the historical `#008830` so neither can reappear as a bare color.

### #38 — i18n key parity guard
- `tests/i18n-parity.test.ts`: extracts each locale block from `src/i18n/index.ts` and asserts every non-English locale declares exactly the same key set as `en`. Runtime `t()` silently falls back to English on missing keys, so drift used to produce untranslated text for end users. Now it produces a red CI build with a precise `{ missing, extra }` diff.

## Why this shape
Both are single-commit, low-risk wins that make future PRs safer: a contributor cannot regress these invariants without tripping a test.

The full scope of #35 (keyboard nav on canvas, `prefers-reduced-motion` for zoom/pan, `aria-live` on error toasts) and #38 (split locales into JSON files, ICU plurals, RTL) stays open — those are bigger, visible changes that deserve their own PR.

## Test plan
- [ ] `npm test -- color-consistency` passes.
- [ ] `npm test -- i18n-parity` passes.
- [ ] Introduce a "only in `en`" key temporarily — the parity test reports a red diff with the missing key name.
- [ ] Visual check: timestamps and "skipped" icons are readable on the terminal-green theme.

Partial resolution of #35 and #38.