### PR TITLE
ui: pipeline error modal with Retry (partial #36)

### DIFF
--- a/src/components/ar-app.ts
+++ b/src/components/ar-app.ts
@@ -664,6 +664,83 @@ export class ArApp extends HTMLElement {
             transition: none !important;
           }
         }
+
+        /* === Error modal === */
+        .error-modal[hidden] { display: none !important; }
+        .error-modal {
+          position: fixed;
+          inset: 0;
+          z-index: 9999;
+          display: flex;
+          align-items: center;
+          justify-content: center;
+          padding: var(--space-4, 1rem);
+        }
+        .error-modal-backdrop {
+          position: absolute;
+          inset: 0;
+          background: rgba(0, 0, 0, 0.75);
+        }
+        .error-modal-dialog {
+          position: relative;
+          max-width: 520px;
+          width: 100%;
+          background: var(--color-bg-primary, #000);
+          border: 1px solid var(--color-error, #ff3131);
+          padding: var(--space-5, 1.25rem);
+          font-family: 'JetBrains Mono', monospace;
+          color: var(--color-text-primary, #00ff41);
+          box-shadow: 0 0 24px rgba(255, 49, 49, 0.25);
+        }
+        .error-modal-title {
+          margin: 0 0 var(--space-3, 0.75rem);
+          font-size: 16px;
+          font-weight: 600;
+          color: var(--color-error, #ff3131);
+          text-transform: uppercase;
+          letter-spacing: 0.04em;
+        }
+        .error-modal-message {
+          margin: 0 0 var(--space-4, 1rem);
+          font-size: 13px;
+          line-height: 1.5;
+          color: var(--color-text-secondary, #00dd44);
+          word-break: break-word;
+        }
+        .error-modal-actions {
+          display: flex;
+          gap: var(--space-2, 0.5rem);
+          justify-content: flex-end;
+          flex-wrap: wrap;
+        }
+        .error-modal-btn {
+          font-family: 'JetBrains Mono', monospace;
+          font-size: 13px;
+          padding: 8px 16px;
+          background: transparent;
+          color: var(--color-text-secondary, #00dd44);
+          border: 1px solid var(--color-surface-border, #1a3a1a);
+          border-radius: 0;
+          cursor: pointer;
+          min-height: 40px;
+        }
+        .error-modal-btn:hover,
+        .error-modal-btn:focus-visible {
+          color: var(--color-accent-primary, #00ff41);
+          border-color: var(--color-accent-primary, #00ff41);
+          outline: none;
+        }
+        .error-modal-btn.primary {
+          color: var(--color-accent-primary, #00ff41);
+          border-color: var(--color-accent-primary, #00ff41);
+        }
+        .error-modal-btn.primary:hover,
+        .error-modal-btn.primary:focus-visible {
+          background: var(--color-accent-muted, rgba(0, 255, 65, 0.08));
+        }
+        @media (pointer: coarse) {
+          .error-modal-btn { min-height: 44px; min-width: 88px; }
+        }
       </style>
 
       <section class="hero" id="hero">
@@ -721,6 +798,26 @@ export class ArApp extends HTMLElement {
         <div class="limitations-detail" id="limitations-detail">${t('features.limitations')}</div>
         <p class="reactor-support visible" id="reactor-support">${t('reactor.normal')}</p>
       </section>
+
+      <div
+        class="error-modal"
+        id="error-modal"
+        role="alertdialog"
+        aria-modal="true"
+        aria-labelledby="error-modal-title"
+        aria-describedby="error-modal-message"
+        hidden
+      >
+        <div class="error-modal-backdrop" id="error-modal-backdrop"></div>
+        <div class="error-modal-dialog">
+          <h2 class="error-modal-title" id="error-modal-title">${t('error.title')}</h2>
+          <p class="error-modal-message" id="error-modal-message"></p>
+          <div class="error-modal-actions">
+            <button type="button" class="error-modal-btn primary" id="error-modal-retry">${t('error.retry')}</button>
+            <button type="button" class="error-modal-btn" id="error-modal-dismiss">${t('error.dismiss')}</button>
+          </div>
+        </div>
+      </div>
     `;
   }
 
@@ -759,6 +856,12 @@ export class ArApp extends HTMLElement {
     if (retryBtnEl) retryBtnEl.textContent = t('batch.retry');
     const discardBtnEl = root.querySelector('#batch-discard-btn');
     if (discardBtnEl) discardBtnEl.textContent = t('batch.discard');
+    const errTitle = root.querySelector('#error-modal-title');
+    if (errTitle) errTitle.textContent = t('error.title');
+    const errRetry = root.querySelector('#error-modal-retry');
+    if (errRetry) errRetry.textContent = t('error.retry');
+    const errDismiss = root.querySelector('#error-modal-dismiss');
+    if (errDismiss) errDismiss.textContent = t('error.dismiss');
   }
 
   private getInstallGuide(): string {
@@ -790,6 +893,22 @@ export class ArApp extends HTMLElement {
       }
       if (this.batchMode !== 'off') {
         this.batchAborted = true;
+      }
+    });
+
+    // Error modal wiring (#36).
+    const retryBtn = this.shadowRoot!.querySelector('#error-modal-retry') as HTMLButtonElement | null;
+    const dismissBtn = this.shadowRoot!.querySelector('#error-modal-dismiss') as HTMLButtonElement | null;
+    const backdrop = this.shadowRoot!.querySelector('#error-modal-backdrop') as HTMLElement | null;
+    retryBtn?.addEventListener('click', () => this.retryFromError());
+    dismissBtn?.addEventListener('click', () => this.hideErrorModal());
+    backdrop?.addEventListener('click', () => this.hideErrorModal());
+    window.addEventListener('keydown', (e) => {
+      if (e.key !== 'Escape') return;
+      const modal = this.shadowRoot?.querySelector('#error-modal') as HTMLElement | null;
+      if (modal && !modal.hasAttribute('hidden')) {
+        e.preventDefault();
+        this.hideErrorModal();
       }
     });
 
@@ -1456,6 +1575,7 @@ export class ArApp extends HTMLElement {
       console.error('Pipeline error:', err);
       const msg = err instanceof Error ? err.message : String(err);
       this.progress.setStage('ml-segmentation', 'error', t('pipeline.error', { msg }));
+      this.showErrorModal(msg);
     } finally {
       this.progress.setRunning(false);
       if (!this.processingAborted) {
@@ -1463,6 +1583,47 @@ export class ArApp extends HTMLElement {
         this.enableWorkspaceButtons();
       }
     }
+  }
+
+  /**
+   * Show the error modal with the given message. Retry is only
+   * meaningful if we still have the source image buffers — otherwise
+   * the button hides itself and the user can only dismiss.
+   */
+  private showErrorModal(msg: string): void {
+    const modal = this.shadowRoot?.querySelector('#error-modal') as HTMLElement | null;
+    const messageEl = this.shadowRoot?.querySelector('#error-modal-message');
+    const retryBtn = this.shadowRoot?.querySelector('#error-modal-retry') as HTMLButtonElement | null;
+    if (!modal || !messageEl) return;
+    messageEl.textContent = msg;
+    const canRetry = !!(this.currentImageData && this.currentOriginalImageData);
+    if (retryBtn) retryBtn.hidden = !canRetry;
+    modal.hidden = false;
+    // Shift focus to the primary action so keyboard users can act
+    // without hunting for the dialog.
+    queueMicrotask(() => {
+      (canRetry ? retryBtn : (this.shadowRoot?.querySelector('#error-modal-dismiss') as HTMLElement | null))?.focus();
+    });
+  }
+
+  private hideErrorModal(): void {
+    const modal = this.shadowRoot?.querySelector('#error-modal') as HTMLElement | null;
+    if (modal) modal.hidden = true;
+  }
+
+  private retryFromError(): void {
+    if (!this.currentImageData || !this.currentOriginalImageData) {
+      this.hideErrorModal();
+      return;
+    }
+    this.hideErrorModal();
+    // Re-run processing with the same inputs. processImage() already
+    // handles the state reset (progress, viewer, abort controller, etc).
+    this.processImage(
+      this.currentImageData,
+      this.currentOriginalImageData,
+      this.currentFileSize,
+    );
   }
 
   private makeThumbnail(imageData: ImageData, maxSide = 200): string {

--- a/src/i18n/index.ts
+++ b/src/i18n/index.ts
@@ -174,6 +174,9 @@ const translations: Translations = {
 
     // Pipeline error
     'pipeline.error': 'Processing failed: {msg}',
+    'error.title': 'Something went wrong',
+    'error.retry': 'Retry',
+    'error.dismiss': 'Dismiss',
 
     // PWA
     'pwa.install': '[INSTALL] Run locally',
@@ -371,6 +374,9 @@ const translations: Translations = {
 
     // Pipeline error
     'pipeline.error': 'Procesamiento fallido: {msg}',
+    'error.title': 'Algo salió mal',
+    'error.retry': 'Reintentar',
+    'error.dismiss': 'Cerrar',
 
     // PWA
     'pwa.install': '[INSTALAR] Ejecutar local',
@@ -568,6 +574,9 @@ const translations: Translations = {
 
     // Pipeline error
     'pipeline.error': 'Traitement \u00E9chou\u00E9 : {msg}',
+    'error.title': 'Une erreur est survenue',
+    'error.retry': 'R\u00E9essayer',
+    'error.dismiss': 'Fermer',
 
     // PWA
     'pwa.install': '[INSTALLER] Ex\u00E9cuter en local',
@@ -765,6 +774,9 @@ const translations: Translations = {
 
     // Pipeline error
     'pipeline.error': 'Verarbeitung fehlgeschlagen: {msg}',
+    'error.title': 'Etwas ist schiefgelaufen',
+    'error.retry': 'Erneut versuchen',
+    'error.dismiss': 'Schließen',
 
     // PWA
     'pwa.install': '[INSTALLIEREN] Lokal ausf\u00FChren',
@@ -962,6 +974,9 @@ const translations: Translations = {
 
     // Pipeline error
     'pipeline.error': 'Processamento falhou: {msg}',
+    'error.title': 'Algo deu errado',
+    'error.retry': 'Tentar novamente',
+    'error.dismiss': 'Fechar',
 
     // PWA
     'pwa.install': '[INSTALAR] Rodar local',
@@ -1159,6 +1174,9 @@ const translations: Translations = {
 
     // Pipeline error
     'pipeline.error': '\u5904\u7406\u5931\u8D25: {msg}',
+    'error.title': '\u51FA\u9519\u4E86',
+    'error.retry': '\u91CD\u8BD5',
+    'error.dismiss': '\u5173\u95ED',
 
     // PWA
     'pwa.install': '[\u5B89\u88C5] \u672C\u5730\u8FD0\u884C',


### PR DESCRIPTION
## Summary
Renders an `aria-modal="true"` alertdialog when `process()` rejects with a non-abort error. Displays the message, offers Retry (re-runs with the same inputs) and Dismiss. Escape / backdrop click also close.

## What changed
- `src/components/ar-app.ts`:
  - New `<div id="error-modal">` in the rendered shadow DOM with title / message / Retry / Dismiss / backdrop.
  - Styles matching the existing terminal palette, reduced-motion-safe, 44×88 min tap targets on coarse pointers.
  - `showErrorModal(msg)` / `hideErrorModal()` / `retryFromError()` private methods.
  - Wired in `setupEvents`: Retry → re-invokes `processImage(...)` with `currentImageData` / `currentOriginalImageData` / `currentFileSize`. Escape key also closes.
  - `updateTexts()` refreshes modal labels on locale change.
  - `processImage()` catch block calls `showErrorModal(msg)` alongside the existing `progress.setStage('ml-segmentation', 'error', ...)`. Aborts (`PipelineAbortError`) short-circuit and never show the modal.
- `src/i18n/index.ts`: new keys `error.title`, `error.retry`, `error.dismiss` in all six locales. The key-parity guard from #38 covers them.

## Test plan
- [ ] `npm run typecheck` passes.
- [ ] Throw a contrived error inside `orchestrator.process()` — modal appears with the message, focus lands on Retry.
- [ ] Click Retry — pipeline runs again.
- [ ] Click Dismiss / press Escape / click backdrop — modal closes without retrying.
- [ ] Switch locale mid-modal — title / buttons re-translate.
- [ ] Cancel (abort) path still silent: no modal, just clears progress.

Partial resolution of #36 (remaining: per-batch-item retry UI, viewer canvas fallback).