### PR TITLE
infra: runtime hardening — tokens, limits, caps, engines, HEALTHCHECK (partial #49)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,3 +16,9 @@ RUN addgroup -S nukebg && adduser -S nukebg -G nukebg \
 
 USER nukebg
 EXPOSE 8080
+
+# Healthcheck for `docker run` users — docker-compose defines its own
+# healthcheck that takes precedence when composed. Kept here so
+# `docker run --rm nukebg` is observable too.
+HEALTHCHECK --interval=30s --timeout=5s --retries=3 \
+    CMD wget --quiet --tries=1 --spider http://localhost:8080/ || exit 1

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,6 +4,27 @@ services:
     ports:
       - "8080:8080"
     restart: unless-stopped
+    # Resource ceiling — a static-asset container should not be able to
+    # eat a host. Tune up if self-hosting for heavy traffic.
+    mem_limit: 512m
+    memswap_limit: 512m
+    cpus: 1.0
+    # Read-only root filesystem. nginx writes go to tmpfs mounts below.
+    read_only: true
+    tmpfs:
+      - /var/cache/nginx
+      - /var/log/nginx
+      - /var/run
+    # Drop all Linux capabilities, add back only NET_BIND_SERVICE (not
+    # strictly needed at port 8080, but kept for completeness if the
+    # user maps to 80).
+    cap_drop:
+      - ALL
+    cap_add:
+      - NET_BIND_SERVICE
+    # Block privilege escalation post-exec.
+    security_opt:
+      - no-new-privileges:true
     healthcheck:
       test: ["CMD", "wget", "--spider", "-q", "http://localhost:8080"]
       interval: 30s

--- a/nginx.conf
+++ b/nginx.conf
@@ -4,6 +4,9 @@ server {
     root /usr/share/nginx/html;
     index index.html;
 
+    # Hide nginx version from the Server: header.
+    server_tokens off;
+
     # Security headers
     add_header X-Content-Type-Options "nosniff" always;
     add_header X-Frame-Options "DENY" always;

--- a/package.json
+++ b/package.json
@@ -32,5 +32,8 @@
   },
   "overrides": {
     "protobufjs": "^7.5.5"
+  },
+  "engines": {
+    "node": ">=20.0.0"
   }
 }


### PR DESCRIPTION
## Summary
Four discrete hardening items from #49:

- `package.json`: `engines.node: ">=20.0.0"`.
- `Dockerfile`: `HEALTHCHECK` so `docker run` users match the compose-time observability.
- `nginx.conf`: `server_tokens off`.
- `docker-compose.yml`:
  - `mem_limit: 512m`, `memswap_limit: 512m`, `cpus: 1.0`.
  - `read_only: true` + `tmpfs` for `/var/cache/nginx`, `/var/log/nginx`, `/var/run` (nginx's only writable paths).
  - `cap_drop: ALL`, `cap_add: NET_BIND_SERVICE` only.
  - `security_opt: no-new-privileges:true`.

## Why
Defense-in-depth wins that don't need application code changes. The container still runs as a non-root user (pre-existing), plus now it cannot: consume unbounded memory, write outside tmpfs-backed paths, gain new privileges at runtime, or carry Linux capabilities beyond port binding.

## Not in this PR (deferred from #49)
- Vite `manualChunks` + `vite-plugin-visualizer` — affects build output, wants dedicated review.
- Brotli compression — nginx-alpine base lacks the brotli module; swapping to `nginx-extras` or compiling a dynamic module is its own change.
- TS strict extras (`noUncheckedIndexedAccess`, `exactOptionalPropertyTypes`) — will surface code changes across the codebase, better as a focused PR.
- `capability-detector.ts` comment fix — trivial, will land with one of the editor refactors.

## Test plan
- [ ] `docker compose up -d --build` succeeds with the new limits.
- [ ] `docker compose exec nukebg wget --spider -q http://localhost:8080` returns 0 (healthcheck still green).
- [ ] `curl -I http://localhost:8080` shows `Server: nginx` (no version).
- [ ] `docker compose exec nukebg touch /tmp/test` fails (root FS is read-only, only tmpfs writable).

Partial resolution of #49.