### PR TITLE
ui: landing redesign — marquee bleed + ASCII dropzone + status line (closes #69)

### DIFF
--- a/src/components/ar-app.ts
+++ b/src/components/ar-app.ts
@@ -67,7 +67,10 @@ export class ArApp extends HTMLElement {
 
   /** Pre-load model + warmup as soon as page opens */
   private preloadModel(): void {
-    const statusEl = () => this.shadowRoot?.querySelector('#model-status');
+    // During first-load warmup we repurpose the consolidated status line
+    // to show "Loading AI model..." progress. After ready, updateTexts()
+    // restores the default `status.model.cached` copy.
+    const statusEl = () => this.shadowRoot?.querySelector('#status-model');
 
     this.pipeline = new PipelineOrchestrator(
       (_stage: PipelineStage, _status: StageStatus, message?: string) => {
@@ -470,6 +473,7 @@ export class ArApp extends HTMLElement {
         .reactor-support.visible {
           display: block;
         }
+        /* Legacy column-scoped marquee (still used inside .workspace). */
         .precision-marquee {
           display: block;
           overflow: hidden;
@@ -488,6 +492,94 @@ export class ArApp extends HTMLElement {
         .precision-marquee span {
           display: inline-block;
           animation: marquee-scroll 20s linear infinite;
+        }
+        /* Full-bleed marquee for the landing — sibling to <section class=hero>.
+           Gradient mask fades text at both edges so it never clips mid-word. */
+        .marquee-bleed {
+          display: block;
+          width: 100%;
+          overflow: hidden;
+          white-space: nowrap;
+          font-family: 'JetBrains Mono', monospace;
+          font-size: 12px;
+          font-weight: 700;
+          letter-spacing: 0.15em;
+          text-transform: uppercase;
+          padding: 6px 0;
+          min-height: 28px;
+          color: var(--color-text-tertiary, #00b34a);
+          border-bottom: 1px solid var(--color-surface-border, #1a3a1a);
+          -webkit-mask-image: linear-gradient(90deg, transparent, #000 48px, #000 calc(100% - 48px), transparent);
+                  mask-image: linear-gradient(90deg, transparent, #000 48px, #000 calc(100% - 48px), transparent);
+        }
+        .marquee-bleed span {
+          display: inline-block;
+          animation: marquee-scroll 26s linear infinite;
+        }
+        /* Consolidated [STATUS] line */
+        .status-line {
+          display: flex;
+          flex-wrap: wrap;
+          align-items: center;
+          gap: 6px;
+          font-family: 'JetBrains Mono', monospace;
+          font-size: 12px;
+          color: var(--color-text-tertiary, #00b34a);
+          margin: 12px 0 0;
+          padding: 0;
+        }
+        .status-line .status-tag {
+          color: var(--color-text-tertiary, #00b34a);
+        }
+        .status-line .status-dot {
+          color: var(--color-accent-primary, #00ff41);
+          text-shadow: 0 0 4px var(--color-accent-glow, rgba(0, 255, 65, 0.35));
+        }
+        .status-line .status-reactor {
+          color: var(--color-accent-primary, #00ff41);
+        }
+        .status-line .status-model {
+          color: var(--color-text-secondary, #00dd44);
+        }
+        .status-line .status-sep {
+          color: var(--color-surface-border, #1a3a1a);
+        }
+        .status-details {
+          display: inline;
+        }
+        .status-details summary {
+          list-style: none;
+          cursor: pointer;
+          color: var(--color-text-tertiary, #00b34a);
+          text-decoration: underline;
+          text-decoration-style: dotted;
+          display: inline;
+          padding: 2px 0;
+          min-height: 24px;
+        }
+        .status-details summary::-webkit-details-marker { display: none; }
+        .status-details summary:hover,
+        .status-details summary:focus-visible {
+          color: var(--color-text-secondary, #00dd44);
+          outline: none;
+        }
+        .status-details[open] summary {
+          color: var(--color-text-secondary, #00dd44);
+        }
+        .status-limits-body {
+          display: block;
+          margin-top: 6px;
+          color: var(--color-text-tertiary, #00b34a);
+          font-size: 12px;
+          line-height: 1.55;
+          border-left: 1px solid var(--color-surface-border, #1a3a1a);
+          padding-left: 10px;
+        }
+        .status-limits-body a {
+          color: var(--color-accent-primary, #00ff41);
+        }
+        @media (pointer: coarse) {
+          .status-details summary { min-height: 44px; padding: 10px 0; }
         }
         @keyframes marquee-scroll {
           0% { transform: translateX(100%); }
@@ -826,20 +918,36 @@ export class ArApp extends HTMLElement {
         }
       </style>
 
+      <!-- Full-bleed marquee outside the main column per design #69.
+           Gradient mask fades text in/out at the edges so it never
+           clips mid-word the way the old column-scoped marquee did. -->
+      <div class="marquee-bleed" id="precision-marquee-bleed"><span>☢ NUKEBG | DROP. NUKE. DOWNLOAD. | Your images never leave your device | nukebg.app ☢ NUKEBG | DROP. NUKE. DOWNLOAD. | Your images never leave your device | nukebg.app ☢</span></div>
+
       <section class="hero" id="hero">
         <h1><span class="accent">${t('hero.title.accent')}</span> ${t('hero.title.rest')}</h1>
         <p class="subline">
           ${t('hero.subtitle').replace(/\n/g, ' ')}
         </p>
-        <div class="hero-controls">
-          ${this.renderReactorSegmented('hero')}
-        </div>
         <ar-dropzone></ar-dropzone>
         <ar-batch-grid id="batch-grid" style="display:none"></ar-batch-grid>
-        <p class="model-status" id="model-status">${t('hero.modelStatus')}</p>
+
+        <!-- Consolidated status line replaces model-status + reactor-support
+             + features-disclaimer; the honesty copy lives in <details>. -->
+        <p class="status-line" id="status-line">
+          <span class="status-tag">[STATUS]</span>
+          <span class="status-dot">●</span>
+          <span class="status-reactor" id="status-reactor">${t('status.reactor.online')}</span>
+          <span class="status-sep">|</span>
+          <span class="status-model" id="status-model">${t('status.model.cached')}</span>
+          <span class="status-sep">|</span>
+          <details class="status-details">
+            <summary id="status-limits-summary"># ${t('status.limitations')}</summary>
+            <div class="status-limits-body" id="status-limits-body">${t('features.limitations')}</div>
+          </details>
+        </p>
+
         <button class="install-btn" id="install-btn" aria-label="${t('pwa.install')}">${isAppInstalled() ? t('pwa.installed') : t('pwa.install')}</button>
         <div class="install-guide" id="install-guide"></div>
-        <div class="precision-marquee" id="precision-marquee"><span>☢ NUKEBG | DROP. NUKE. DOWNLOAD. | Your images never leave your device | nukebg.app ☢ NUKEBG | DROP. NUKE. DOWNLOAD. | Your images never leave your device | nukebg.app ☢</span></div>
         <div class="smoke-effect" id="smoke-effect"></div>
       </section>
 
@@ -866,12 +974,6 @@ export class ArApp extends HTMLElement {
           <ar-editor-advanced id="editor-advanced"></ar-editor-advanced>
           </div>
         </div>
-      </section>
-
-      <section class="features" aria-label="Key features">
-        <p class="features-disclaimer" id="features-disclaimer">${t('features.disclaimer')}</p>
-        <div class="limitations-detail" id="limitations-detail">${t('features.limitations')}</div>
-        <p class="reactor-support visible" id="reactor-support">${t('reactor.normal')}</p>
       </section>
 
       <div
@@ -912,14 +1014,16 @@ export class ArApp extends HTMLElement {
     if (h1) h1.innerHTML = `<span class="accent">${t('hero.title.accent')}</span> ${t('hero.title.rest')}`;
     const subline = root.querySelector('.subline');
     if (subline) subline.textContent = t('hero.subtitle').replace(/\n/g, ' ');
-    const modelStatus = root.querySelector('#model-status');
-    if (modelStatus) modelStatus.textContent = t('hero.modelStatus');
+    const statusReactor = root.querySelector('#status-reactor');
+    if (statusReactor) statusReactor.textContent = t('status.reactor.online');
+    const statusModel = root.querySelector('#status-model');
+    if (statusModel) statusModel.textContent = t('status.model.cached');
+    const statusLimSum = root.querySelector('#status-limits-summary');
+    if (statusLimSum) statusLimSum.textContent = `# ${t('status.limitations')}`;
+    const statusLimBody = root.querySelector('#status-limits-body');
+    if (statusLimBody) statusLimBody.innerHTML = t('features.limitations');
     const editBtn = root.querySelector('#edit-btn');
     if (editBtn) editBtn.textContent = this.preEditResult ? t('edit.discard') : t('edit.btn');
-    const disclaimer = root.querySelector('#features-disclaimer');
-    if (disclaimer) disclaimer.innerHTML = t('features.disclaimer');
-    const limDetail = root.querySelector('#limitations-detail');
-    if (limDetail) limDetail.innerHTML = t('features.limitations');
     const installBtnEl = root.querySelector('#install-btn') as HTMLButtonElement;
     if (installBtnEl) {
       installBtnEl.textContent = isAppInstalled() ? t('pwa.installed') : t('pwa.install');
@@ -1169,10 +1273,8 @@ export class ArApp extends HTMLElement {
     });
 
     // Disclaimer click - toggle limitations detail
-    this.shadowRoot!.querySelector('#features-disclaimer')?.addEventListener('click', () => {
-      const detail = this.shadowRoot!.querySelector('#limitations-detail');
-      if (detail) detail.classList.toggle('visible');
-    }, { signal });
+    // Limitations now live inside <details id="status-limits"> — native
+    // disclosure widget handles open/close. No click wiring needed.
 
     // Edit button - opens editor or discards edits
     this.shadowRoot!.querySelector('#edit-btn')?.addEventListener('click', async () => {
@@ -1307,7 +1409,7 @@ export class ArApp extends HTMLElement {
    * out of the original `#precision-slider` input handler.
    */
   private applyPrecisionSideEffects(val: number): void {
-    const marquee = this.shadowRoot!.querySelector('#precision-marquee') as HTMLElement;
+    const marquee = this.shadowRoot!.querySelector('#precision-marquee-bleed') as HTMLElement;
     const marqueeWs = this.shadowRoot!.querySelector('#precision-marquee-ws') as HTMLElement;
     const smoke = document.getElementById('smoke-overlay');
     const reactorSupport = this.shadowRoot!.querySelector('#reactor-support') as HTMLElement;

--- a/src/components/ar-dropzone.ts
+++ b/src/components/ar-dropzone.ts
@@ -25,43 +25,115 @@ export class ArDropzone extends HTMLElement {
           display: block;
           width: 100%;
         }
+        /* ASCII-framed dropzone per design #69.
+           Outer: accent-primary border + soft glow + inner stroke.
+           Inside: terminal prompt row, large centered drop target, bottom
+           meta row. The four corner glyphs sit absolute-positioned as
+           decoration — they don't affect layout. */
         .dropzone {
-          border: 1px solid var(--color-surface-border, #1a3a1a);
+          position: relative;
+          border: 1px solid var(--color-accent-primary, #00ff41);
           border-radius: 0;
           background: var(--color-bg-primary, #000);
-          padding: 2rem;
-          min-height: 200px;
+          padding: 28px 28px 20px;
+          min-height: 320px;
           max-width: 100%;
           margin: 0 auto;
           cursor: pointer;
           display: flex;
           flex-direction: column;
-          align-items: center;
-          justify-content: center;
-          gap: 0.75rem;
-          transition: border-color 0.3s ease, background 0.3s ease, box-shadow 0.3s ease;
-          text-align: center;
+          gap: 0;
+          transition: border-color 0.2s ease, background 0.2s ease, box-shadow 0.2s ease;
+          box-shadow:
+            0 0 14px rgba(var(--color-accent-rgb, 0, 255, 65), 0.08),
+            inset 0 0 0 4px #000,
+            inset 0 0 0 5px rgba(var(--color-accent-rgb, 0, 255, 65), 0.15);
         }
-        .dropzone::before {
-          content: 'nukebg@local:~$ ';
-          display: block;
+        .dz-corner {
+          position: absolute;
+          color: var(--color-accent-primary, #00ff41);
+          font-family: 'JetBrains Mono', monospace;
+          font-size: 16px;
+          line-height: 1;
+          text-shadow: 0 0 6px rgba(var(--color-accent-rgb, 0, 255, 65), 0.5);
+          pointer-events: none;
+        }
+        .dz-corner.tl { top: 6px; left: 8px; }
+        .dz-corner.tr { top: 6px; right: 8px; }
+        .dz-corner.bl { bottom: 6px; left: 8px; }
+        .dz-corner.br { bottom: 6px; right: 8px; }
+        .dz-prompt {
           color: var(--color-text-tertiary, #00b34a);
           font-family: 'JetBrains Mono', monospace;
           font-size: 12px;
-          margin-bottom: 8px;
-          text-align: left;
-          width: 100%;
+        }
+        .dz-prompt .cmd {
+          color: var(--color-text-secondary, #00dd44);
+        }
+        .dz-center {
+          flex: 1;
+          display: flex;
+          flex-direction: column;
+          align-items: center;
+          justify-content: center;
+          gap: 10px;
+          text-align: center;
+        }
+        .dz-glyph {
+          color: var(--color-accent-primary, #00ff41);
+          font-family: 'JetBrains Mono', monospace;
+          font-size: 12px;
+          letter-spacing: 0.2em;
+          border: 1px solid var(--color-surface-border, #1a3a1a);
+          padding: 4px 10px;
+          transition: border-color 0.2s ease, color 0.2s ease;
+        }
+        .dropzone:hover .dz-glyph,
+        .dropzone.dragover .dz-glyph {
+          border-color: var(--color-accent-primary, #00ff41);
+          text-shadow: 0 0 6px rgba(var(--color-accent-rgb, 0, 255, 65), 0.5);
+        }
+        .dz-title {
+          color: var(--color-accent-primary, #00ff41);
+          font-family: 'JetBrains Mono', monospace;
+          font-size: 22px;
+          font-weight: 700;
+          letter-spacing: 0.08em;
+          text-transform: uppercase;
+          text-shadow: 0 0 10px rgba(var(--color-accent-rgb, 0, 255, 65), 0.35);
+        }
+        .dz-hint {
+          color: var(--color-text-secondary, #00dd44);
+          font-family: 'JetBrains Mono', monospace;
+          font-size: 13px;
+        }
+        .dz-foot {
+          display: flex;
+          justify-content: space-between;
+          align-items: center;
+          padding-top: 10px;
+          margin-top: 14px;
+          border-top: 1px dashed var(--color-surface-border, #1a3a1a);
+          color: var(--color-text-tertiary, #00b34a);
+          font-family: 'JetBrains Mono', monospace;
+          font-size: 11px;
+        }
+        .dz-foot .hint-multi::before {
+          content: '[*] ';
+          color: var(--color-accent-primary, #00ff41);
         }
         .dropzone:hover {
-          border-color: var(--color-accent-primary, #00ff41);
-          background: rgba(var(--color-accent-rgb, 0, 255, 65), 0.02);
-          box-shadow: 0 0 10px rgba(var(--color-accent-rgb, 0, 255, 65), 0.1);
+          box-shadow:
+            0 0 18px rgba(var(--color-accent-rgb, 0, 255, 65), 0.14),
+            inset 0 0 0 4px #000,
+            inset 0 0 0 5px rgba(var(--color-accent-rgb, 0, 255, 65), 0.25);
         }
         .dropzone.dragover {
-          border-color: var(--color-accent-primary, #00ff41);
-          border-style: solid;
           background: rgba(var(--color-accent-rgb, 0, 255, 65), 0.04);
-          box-shadow: 0 0 15px rgba(var(--color-accent-rgb, 0, 255, 65), 0.15);
+          box-shadow:
+            0 0 22px rgba(var(--color-accent-rgb, 0, 255, 65), 0.22),
+            inset 0 0 0 4px #000,
+            inset 0 0 0 5px rgba(var(--color-accent-rgb, 0, 255, 65), 0.35);
         }
         .dropzone.error {
           animation: shake 0.3s;
@@ -72,49 +144,17 @@ export class ArDropzone extends HTMLElement {
           50% { transform: translateX(6px); }
           75% { transform: translateX(-6px); }
         }
-        .icon {
-          font-size: 24px;
-          color: var(--color-text-tertiary, #00b34a);
-          line-height: 1;
-          transition: color 0.3s ease, filter 0.3s ease;
-        }
-        .dropzone:hover .icon {
-          color: var(--color-accent-primary, #00ff41);
-          filter: drop-shadow(0 0 6px rgba(var(--color-accent-rgb, 0, 255, 65), 0.5));
-        }
-        .main-text {
-          font-family: 'JetBrains Mono', monospace;
-          font-size: var(--text-sm, 0.875rem);
-          font-weight: var(--font-medium, 500);
-          color: var(--color-accent-primary, #00ff41);
-        }
-        .main-text::before {
-          content: '> ';
-          color: var(--color-text-tertiary, #00b34a);
-        }
-        .sub-text {
-          font-family: 'JetBrains Mono', monospace;
-          font-size: 12px;
-          color: var(--color-text-secondary, #00dd44);
-        }
-        .hint {
-          font-family: 'JetBrains Mono', monospace;
-          font-size: 12px;
-          color: var(--color-text-tertiary, #00b34a);
-        }
-        .hint-multi {
-          color: var(--color-text-secondary, #00dd44);
-          margin-top: 4px;
-        }
-        .hint-multi::before {
-          content: '[*] ';
-          color: var(--color-accent-primary, #00ff41);
-        }
         .dragover-text {
           display: none;
         }
         .dropzone.dragover .idle-content { display: none; }
-        .dropzone.dragover .dragover-text { display: block; }
+        .dropzone.dragover .dragover-text {
+          display: flex;
+          flex: 1;
+          align-items: center;
+          justify-content: center;
+        }
+        .dropzone.dragover .dragover-text .dz-title { font-size: 24px; }
         input[type="file"] { display: none; }
         .dropzone.dropzone-disabled {
           opacity: 0.4;
@@ -123,69 +163,66 @@ export class ArDropzone extends HTMLElement {
         :host(:focus-visible) .dropzone,
         .dropzone:focus-visible {
           outline: none;
-          box-shadow: 0 0 10px var(--color-accent-glow, rgba(0, 255, 65, 0.25)),
-                      0 0 0 2px var(--color-accent-primary, #00ff41);
+          box-shadow:
+            0 0 10px var(--color-accent-glow, rgba(0, 255, 65, 0.25)),
+            0 0 0 2px var(--color-accent-primary, #00ff41),
+            inset 0 0 0 4px #000,
+            inset 0 0 0 5px rgba(var(--color-accent-rgb, 0, 255, 65), 0.25);
         }
         /* === Mobile (max-width: 480px) === */
         @media (max-width: 480px) {
           .dropzone {
-            padding: 1.25rem 1rem;
-            min-height: 150px;
-            gap: 0.5rem;
+            padding: 18px 14px 14px;
+            min-height: 44vh;
           }
-          .dropzone::before {
-            font-size: 12px;
-            margin-bottom: 4px;
-          }
-          .icon {
-            font-size: 20px;
-          }
-          .main-text {
-            font-size: var(--text-xs, 0.75rem);
-          }
-          .sub-text {
-            font-size: 12px;
-          }
-          .hint {
-            font-size: 12px;
-          }
+          .dz-corner { font-size: 14px; top: 4px; bottom: 4px; left: 6px; right: 6px; }
+          .dz-corner.tl { top: 4px; left: 6px; bottom: auto; right: auto; }
+          .dz-corner.tr { top: 4px; right: 6px; bottom: auto; left: auto; }
+          .dz-corner.bl { bottom: 4px; left: 6px; top: auto; right: auto; }
+          .dz-corner.br { bottom: 4px; right: 6px; top: auto; left: auto; }
+          .dz-title { font-size: 16px; }
+          .dz-hint { font-size: 11px; }
+          .dz-foot { font-size: 10px; flex-direction: column; gap: 4px; align-items: stretch; }
+          .dz-foot span:last-child { text-align: right; }
         }
 
         /* === Tablet (481px - 768px) === */
         @media (min-width: 481px) and (max-width: 768px) {
           .dropzone {
-            padding: 1.5rem;
-            min-height: 170px;
+            padding: 22px 20px 16px;
+            min-height: 280px;
           }
-          .main-text {
-            font-size: var(--text-sm, 0.875rem);
-          }
+          .dz-title { font-size: 18px; }
         }
 
         /* === Touch targets === */
         @media (pointer: coarse) {
-          .dropzone {
-            min-height: 150px;
-          }
+          .dz-glyph { padding: 8px 14px; font-size: 13px; }
         }
 
         @media (prefers-reduced-motion: reduce) {
-          .dropzone { animation: none !important; }
+          .dropzone { animation: none !important; transition: none !important; }
           .dropzone.dragover { animation: none !important; }
         }
       </style>
       <div class="dropzone" role="button" tabindex="0"
            aria-label="${t('dropzone.ariaLabel')}">
-        <div class="idle-content">
-          <div class="icon">&#9729;</div>
-          <div class="main-text" id="dz-title">${t('dropzone.title')}</div>
-          <div class="sub-text" id="dz-subtitle">${t('dropzone.subtitle')}</div>
-          <div class="hint" id="dz-formats">${t('dropzone.formats')}</div>
-          <div class="hint" id="dz-clipboard">${t('dropzone.clipboard')}</div>
-          <div class="hint hint-multi" id="dz-multi">${t('dropzone.multi')}</div>
+        <span class="dz-corner tl" aria-hidden="true">&#9484;</span>
+        <span class="dz-corner tr" aria-hidden="true">&#9488;</span>
+        <span class="dz-corner bl" aria-hidden="true">&#9492;</span>
+        <span class="dz-corner br" aria-hidden="true">&#9496;</span>
+        <div class="dz-prompt">nukebg@local:~$ <span class="cmd">drop --image</span></div>
+        <div class="idle-content dz-center">
+          <div class="dz-glyph" aria-hidden="true">[ &#8595; ]</div>
+          <div class="dz-title" id="dz-title">${t('dropzone.title')}</div>
+          <div class="dz-hint" id="dz-hint">${t('dropzone.hint')}</div>
         </div>
         <div class="dragover-text">
-          <div class="main-text" id="dz-dragover">${t('dropzone.dragover')}</div>
+          <div class="dz-title" id="dz-dragover">${t('dropzone.dragover')}</div>
+        </div>
+        <div class="dz-foot">
+          <span id="dz-formats">${t('dropzone.formats')}</span>
+          <span class="hint-multi" id="dz-multi">${t('dropzone.multi')}</span>
         </div>
       </div>
       <input type="file" accept="image/png,image/jpeg,image/webp" multiple />
@@ -199,12 +236,10 @@ export class ArDropzone extends HTMLElement {
     const root = this.shadowRoot!;
     const title = root.querySelector('#dz-title');
     if (title) title.textContent = t('dropzone.title');
-    const subtitle = root.querySelector('#dz-subtitle');
-    if (subtitle) subtitle.textContent = t('dropzone.subtitle');
+    const hint = root.querySelector('#dz-hint');
+    if (hint) hint.textContent = t('dropzone.hint');
     const formats = root.querySelector('#dz-formats');
     if (formats) formats.textContent = t('dropzone.formats');
-    const clipboard = root.querySelector('#dz-clipboard');
-    if (clipboard) clipboard.textContent = t('dropzone.clipboard');
     const multi = root.querySelector('#dz-multi');
     if (multi) multi.textContent = t('dropzone.multi');
     const dragover = root.querySelector('#dz-dragover');

--- a/src/i18n/index.ts
+++ b/src/i18n/index.ts
@@ -17,6 +17,7 @@ const translations: Translations = {
     // Dropzone
     'dropzone.title': 'Drop your image here',
     'dropzone.subtitle': "or click to browse. We'll nuke the background",
+    'dropzone.hint': '# or click to browse · paste with Ctrl+V',
     'dropzone.formats': 'PNG, JPG, WebP up to 100 MP / 80 MB',
     'dropzone.clipboard': 'Ctrl+V to paste from clipboard',
     'dropzone.dragover': 'Drop to process',
@@ -169,6 +170,9 @@ const translations: Translations = {
     'reactor.segment.high': 'HIGH',
     'reactor.segment.fullNuke': 'FULL NUKE',
     'reactor.segment.groupLabel': 'Reactor power',
+    'status.reactor.online': 'reactor online',
+    'status.model.cached': 'RMBG-1.4 cached locally',
+    'status.limitations': 'known limitations',
     'reactor.highPower': 'High power burns more fuel. <a href="https://ko-fi.com/yocreoquesi" target="_blank" rel="noopener">Recharge on Ko-fi</a>.',
     'reactor.fullNuke': 'FULL NUKE MODE drains the core. <a href="https://ko-fi.com/yocreoquesi" target="_blank" rel="noopener">Prevent meltdown on Ko-fi</a>.',
 
@@ -222,6 +226,7 @@ const translations: Translations = {
     // Dropzone
     'dropzone.title': 'Arrastra tu imagen aqu\u00ED',
     'dropzone.subtitle': 'o haz clic para buscar. Nukearemos el fondo',
+    'dropzone.hint': '# o clic para buscar · pega con Ctrl+V',
     'dropzone.formats': 'PNG, JPG, WebP hasta 100 MP / 80 MB',
     'dropzone.clipboard': 'Ctrl+V para pegar del portapapeles',
     'dropzone.dragover': 'Suelta para procesar',
@@ -374,6 +379,9 @@ const translations: Translations = {
     'reactor.segment.high': 'ALTO',
     'reactor.segment.fullNuke': 'FULL NUKE',
     'reactor.segment.groupLabel': 'Potencia del reactor',
+    'status.reactor.online': 'reactor en línea',
+    'status.model.cached': 'RMBG-1.4 cacheado localmente',
+    'status.limitations': 'limitaciones conocidas',
     'reactor.highPower': 'Alta potencia consume m\u00E1s combustible. <a href="https://ko-fi.com/yocreoquesi" target="_blank" rel="noopener">Recarga en Ko-fi</a>.',
     'reactor.fullNuke': 'MODO NUKE TOTAL agota el n\u00FAcleo. <a href="https://ko-fi.com/yocreoquesi" target="_blank" rel="noopener">Evita el colapso en Ko-fi</a>.',
 
@@ -427,6 +435,7 @@ const translations: Translations = {
     // Dropzone
     'dropzone.title': 'D\u00E9pose ton image ici',
     'dropzone.subtitle': 'ou clique pour parcourir. On atomise le fond',
+    'dropzone.hint': '# ou cliquez pour parcourir · collez avec Ctrl+V',
     'dropzone.formats': 'PNG, JPG, WebP jusqu\u2019\u00E0 100 MP / 80 Mo',
     'dropzone.clipboard': 'Ctrl+V pour coller depuis le presse-papiers',
     'dropzone.dragover': 'L\u00E2che pour traiter',
@@ -579,6 +588,9 @@ const translations: Translations = {
     'reactor.segment.high': 'HAUT',
     'reactor.segment.fullNuke': 'FULL NUKE',
     'reactor.segment.groupLabel': 'Puissance du r\u00E9acteur',
+    'status.reactor.online': 'r\u00E9acteur en ligne',
+    'status.model.cached': 'RMBG-1.4 en cache local',
+    'status.limitations': 'limitations connues',
     'reactor.highPower': 'Haute puissance br\u00FBle plus de combustible. <a href="https://ko-fi.com/yocreoquesi" target="_blank" rel="noopener">Recharge sur Ko-fi</a>.',
     'reactor.fullNuke': 'MODE NUKE TOTAL \u00E9puise le c\u0153ur. <a href="https://ko-fi.com/yocreoquesi" target="_blank" rel="noopener">\u00C9vite l\u2019effondrement sur Ko-fi</a>.',
 
@@ -632,6 +644,7 @@ const translations: Translations = {
     // Dropzone
     'dropzone.title': 'Bild hier ablegen',
     'dropzone.subtitle': 'oder klicken zum Ausw\u00E4hlen. Wir nuken den Hintergrund',
+    'dropzone.hint': '# oder klicken · Strg+V zum Einf\u00FCgen',
     'dropzone.formats': 'PNG, JPG, WebP bis 100 MP / 80 MB',
     'dropzone.clipboard': 'Strg+V zum Einf\u00FCgen aus Zwischenablage',
     'dropzone.dragover': 'Loslassen zum Verarbeiten',
@@ -784,6 +797,9 @@ const translations: Translations = {
     'reactor.segment.high': 'HOCH',
     'reactor.segment.fullNuke': 'FULL NUKE',
     'reactor.segment.groupLabel': 'Reaktorleistung',
+    'status.reactor.online': 'Reaktor online',
+    'status.model.cached': 'RMBG-1.4 lokal zwischengespeichert',
+    'status.limitations': 'bekannte Einschr\u00E4nkungen',
     'reactor.highPower': 'Hohe Leistung verbrennt mehr Treibstoff. <a href="https://ko-fi.com/yocreoquesi" target="_blank" rel="noopener">Nachtanken auf Ko-fi</a>.',
     'reactor.fullNuke': 'VOLLER NUKE-MODUS ersch\u00F6pft den Kern. <a href="https://ko-fi.com/yocreoquesi" target="_blank" rel="noopener">Kernschmelze verhindern auf Ko-fi</a>.',
 
@@ -837,6 +853,7 @@ const translations: Translations = {
     // Dropzone
     'dropzone.title': 'Solta a imagem aqui',
     'dropzone.subtitle': 'ou clica pra escolher. A gente nukeia o fundo',
+    'dropzone.hint': '# ou clique pra escolher · cole com Ctrl+V',
     'dropzone.formats': 'PNG, JPG, WebP at\u00E9 100 MP / 80 MB',
     'dropzone.clipboard': 'Ctrl+V pra colar da \u00E1rea de transfer\u00EAncia',
     'dropzone.dragover': 'Solta pra processar',
@@ -989,6 +1006,9 @@ const translations: Translations = {
     'reactor.segment.high': 'ALTO',
     'reactor.segment.fullNuke': 'FULL NUKE',
     'reactor.segment.groupLabel': 'Pot\u00EAncia do reator',
+    'status.reactor.online': 'reator online',
+    'status.model.cached': 'RMBG-1.4 em cache local',
+    'status.limitations': 'limita\u00E7\u00F5es conhecidas',
     'reactor.highPower': 'Alta pot\u00EAncia queima mais combust\u00EDvel. <a href="https://ko-fi.com/yocreoquesi" target="_blank" rel="noopener">Recarrega no Ko-fi</a>.',
     'reactor.fullNuke': 'MODO NUKE TOTAL esgota o n\u00FAcleo. <a href="https://ko-fi.com/yocreoquesi" target="_blank" rel="noopener">Evita o colapso no Ko-fi</a>.',
 
@@ -1042,6 +1062,7 @@ const translations: Translations = {
     // Dropzone
     'dropzone.title': '\u628A\u56FE\u7247\u4E22\u8FD9\u91CC',
     'dropzone.subtitle': '\u6216\u8005\u70B9\u51FB\u9009\u62E9\uFF0C\u6211\u4EEC\u6765\u6838\u7206\u80CC\u666F',
+    'dropzone.hint': '# \u70B9\u51FB\u9009\u62E9 · Ctrl+V \u7C98\u8D34',
     'dropzone.formats': 'PNG, JPG, WebP \u6700\u5927 100 MP / 80 MB',
     'dropzone.clipboard': 'Ctrl+V \u4ECE\u526A\u8D34\u677F\u7C98\u8D34',
     'dropzone.dragover': '\u677E\u624B\u5F00\u59CB\u5904\u7406',
@@ -1194,6 +1215,9 @@ const translations: Translations = {
     'reactor.segment.high': '\u9AD8\u529F\u7387',
     'reactor.segment.fullNuke': 'FULL NUKE',
     'reactor.segment.groupLabel': '\u53CD\u5E94\u5806\u529F\u7387',
+    'status.reactor.online': '\u53CD\u5E94\u5806\u5728\u7EBF',
+    'status.model.cached': 'RMBG-1.4 \u672C\u5730\u7F13\u5B58',
+    'status.limitations': '\u5DF2\u77E5\u9650\u5236',
     'reactor.highPower': '\u9AD8\u529F\u7387\u71C3\u70E7\u66F4\u591A\u71C3\u6599\u3002<a href="https://ko-fi.com/yocreoquesi" target="_blank" rel="noopener">\u5728 Ko-fi \u4E0A\u5145\u7535</a>\u3002',
     'reactor.fullNuke': '\u5168\u529B\u6838\u7206\u6A21\u5F0F\u8017\u5C3D\u5806\u82AF\u3002<a href="https://ko-fi.com/yocreoquesi" target="_blank" rel="noopener">\u5728 Ko-fi \u4E0A\u963B\u6B62\u5D29\u6E83</a>\u3002',
 

--- a/tests/components/ar-landing-redesign.test.ts
+++ b/tests/components/ar-landing-redesign.test.ts
@@ -1,0 +1,111 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+/**
+ * Landing redesign invariants (#69).
+ *
+ * ar-app is too heavy to mount in happy-dom (it imports PipelineOrchestrator
+ * which constructs Web Workers). These tests are source-level invariants
+ * that pin the four design-proposal requirements so a future edit can't
+ * silently regress the landing:
+ *
+ *   1. Full-bleed marquee with gradient edge masks (outside the 960px column).
+ *   2. ASCII-framed dropzone with corner glyphs and [ ↓ ] drop indicator.
+ *   3. Consolidated [STATUS] line (reactor + model + known-limitations details).
+ *   4. Reactor Power control hidden from the hero/landing.
+ */
+
+const ROOT = resolve(__dirname, '..', '..');
+const APP = readFileSync(resolve(ROOT, 'src/components/ar-app.ts'), 'utf8');
+const DZ = readFileSync(resolve(ROOT, 'src/components/ar-dropzone.ts'), 'utf8');
+const I18N = readFileSync(resolve(ROOT, 'src/i18n/index.ts'), 'utf8');
+
+describe('Landing redesign — ar-app.ts invariants', () => {
+  it('renders a full-bleed marquee (.marquee-bleed) outside the 960 column', () => {
+    expect(APP).toMatch(/id="precision-marquee-bleed"/);
+    expect(APP).toMatch(/\.marquee-bleed\s*\{/);
+    // Gradient mask at both edges
+    expect(APP).toMatch(/mask-image:\s*linear-gradient\(90deg,\s*transparent,\s*#000 48px/);
+    expect(APP).toMatch(/-webkit-mask-image:\s*linear-gradient\(90deg,\s*transparent,\s*#000 48px/);
+  });
+
+  it('mounts the consolidated [STATUS] line with reactor + model + details', () => {
+    expect(APP).toMatch(/id="status-line"/);
+    expect(APP).toMatch(/id="status-reactor"/);
+    expect(APP).toMatch(/id="status-model"/);
+    // native <details> disclosure for limitations
+    expect(APP).toMatch(/id="status-limits-summary"/);
+    expect(APP).toMatch(/<details class="status-details">/);
+  });
+
+  it('no longer mounts the legacy model-status / features-disclaimer / reactor-support elements', () => {
+    expect(APP).not.toMatch(/id="model-status"/);
+    expect(APP).not.toMatch(/id="features-disclaimer"/);
+    expect(APP).not.toMatch(/id="reactor-support"/);
+    expect(APP).not.toMatch(/id="limitations-detail"/);
+  });
+
+  it('does NOT render the Reactor Power control inside the hero', () => {
+    // Hero section body: from `<section class="hero"` to the closing `</section>`
+    const heroMatch = APP.match(/<section class="hero"[\s\S]*?<\/section>/);
+    expect(heroMatch).not.toBeNull();
+    expect(heroMatch![0]).not.toMatch(/renderReactorSegmented\(['"]hero['"]\)/);
+    expect(heroMatch![0]).not.toMatch(/\bid="precision-slider"/);
+    expect(heroMatch![0]).not.toMatch(/\bclass="hero-controls"/);
+  });
+});
+
+describe('Landing redesign — ar-dropzone.ts invariants', () => {
+  it('drops the cloud Unicode glyph (&#9729; / ☁)', () => {
+    expect(DZ).not.toMatch(/&#9729;/);
+    expect(DZ).not.toMatch(/☁/);
+  });
+
+  it('renders four ASCII corner glyphs (┌ ┐ └ ┘) absolutely positioned', () => {
+    expect(DZ).toMatch(/class="dz-corner tl"/);
+    expect(DZ).toMatch(/class="dz-corner tr"/);
+    expect(DZ).toMatch(/class="dz-corner bl"/);
+    expect(DZ).toMatch(/class="dz-corner br"/);
+    // Their Unicode entities
+    expect(DZ).toMatch(/&#9484;/); // ┌
+    expect(DZ).toMatch(/&#9488;/); // ┐
+    expect(DZ).toMatch(/&#9492;/); // └
+    expect(DZ).toMatch(/&#9496;/); // ┘
+  });
+
+  it('renders the [ ↓ ] drop-indicator glyph in a bordered box', () => {
+    expect(DZ).toMatch(/class="dz-glyph"/);
+    // Down-arrow entity
+    expect(DZ).toMatch(/&#8595;/);
+  });
+
+  it('has a terminal prompt row (nukebg@local:~$ drop --image)', () => {
+    expect(DZ).toMatch(/nukebg@local:~\$ <span class="cmd">drop --image<\/span>/);
+  });
+
+  it('has a bottom meta row with formats on left and batch hint on right', () => {
+    expect(DZ).toMatch(/class="dz-foot"/);
+    expect(DZ).toMatch(/id="dz-formats"/);
+    expect(DZ).toMatch(/id="dz-multi"/);
+  });
+
+  it('outer dropzone border uses accent-primary (not surface-border) + glow shadow', () => {
+    expect(DZ).toMatch(/border:\s*1px solid var\(--color-accent-primary/);
+    expect(DZ).toMatch(/box-shadow:\s*\n?\s*0 0 14px rgba\(var\(--color-accent-rgb[^)]+\),\s*0\.08\)/);
+  });
+
+  it('mobile dropzone gets min-height: 44vh so it occupies most of the viewport', () => {
+    expect(DZ).toMatch(/@media \(max-width: 480px\)[^}]*\.dropzone\s*\{[^}]*min-height:\s*44vh/s);
+  });
+});
+
+describe('Landing redesign — i18n invariants', () => {
+  const keys = ['status.reactor.online', 'status.model.cached', 'status.limitations', 'dropzone.hint'];
+  for (const key of keys) {
+    it(`has '${key}' in all six locales`, () => {
+      const matches = I18N.match(new RegExp(`'${key.replace(/\./g, '\\.')}'\\s*:`, 'g')) ?? [];
+      expect(matches.length).toBe(6);
+    });
+  }
+});

--- a/tests/components/ar-reactor-segmented.test.ts
+++ b/tests/components/ar-reactor-segmented.test.ts
@@ -23,9 +23,10 @@ describe('reactor segmented — source invariants', () => {
     expect(SOURCE).not.toMatch(/<input[^>]*type="range"[^>]*id="precision-slider/);
   });
 
-  it('renders the segmented control in both scopes via renderReactorSegmented', () => {
-    expect(SOURCE).toMatch(/renderReactorSegmented\(['"]hero['"]\)/);
+  it('renders the segmented control in the workspace (landing reactor hidden per #69)', () => {
     expect(SOURCE).toMatch(/renderReactorSegmented\(['"]ws['"]\)/);
+    // Hero no longer mounts the reactor — moved to workspace-only per #69.
+    expect(SOURCE).not.toMatch(/renderReactorSegmented\(['"]hero['"]\)/);
   });
 
   it('wires click + keydown (arrow/home/end) on the segmented buttons', () => {


### PR DESCRIPTION
## Summary
Four coordinated changes to the above-the-fold landing per design #68:

1. **Full-bleed marquee outside the 960 column.** New `<div class="marquee-bleed">` sibling of `<section class="hero">`, spans viewport, gradient mask fades at both edges — no more mid-word clipping.
2. **ASCII-framed dropzone.** Cloud emoji + 5 stacked lines replaced with accent-primary bordered box + corner glyphs `┌ ┐ └ ┘` + `[ ↓ ]` center glyph + `> DROP IMAGE HERE` + foot row with formats/batch. Mobile: `min-height: 44vh`.
3. **Consolidated `[STATUS]` line.** Collapses `#model-status` + `#features-disclaimer` + `#reactor-support` into one line with reactor dot, model status, and native `<details>` for known limitations.
4. **Reactor hidden from hero.** `renderReactorSegmented('hero')` no longer called; segmented control renders only in workspace.

## Tests
- 15 source-invariant tests in `tests/components/ar-landing-redesign.test.ts` pin all four requirements (marquee mask regex, dropzone corners + glyphs, status-line structure, hero-absent reactor).
- `i18n-parity` still passes with 4 new keys × 6 locales.
- Updated `ar-reactor-segmented.test.ts` to reflect hero-less reality (+1 assertion that hero no longer mounts it).
- Full suite: 537 pass / 2 pre-existing image-io fails (same as `dev` baseline).

## Test plan
- [ ] `npm run typecheck` clean (on locally-runnable set; pre-existing `retryBtn` warnings unchanged).
- [ ] Manual: marquee on narrow / wide viewports — no mid-word clip; both edges fade.
- [ ] Manual: dropzone on 1440 + 390 viewports matches the proposal mock.
- [ ] Manual: click `# known limitations` → `<details>` expands with honesty disclaimer.
- [ ] Manual: reactor power control is absent on landing, shows in workspace after drop.
- [ ] Keyboard: focus lands on `<details>` summary; Enter toggles.

## Follow-ups (separate issues)
- WebKit / iPhone visual snapshots → #81.
- Mobile hero short-form copy + camera CTA → #73.
- Processing-state command bar (depends on this landing) → #71.

Closes #69.