### PR TITLE
ui: mobile hero short-form + camera CTA (closes #73)

### DIFF
--- a/src/components/ar-app.ts
+++ b/src/components/ar-app.ts
@@ -194,9 +194,16 @@ export class ArApp extends HTMLElement {
           text-align: left;
           line-height: var(--leading-relaxed, 1.625);
         }
-        .subline::before {
+        .subline-long::before {
           content: '# ';
           color: var(--color-text-tertiary, #00b34a);
+        }
+        /* Hero copy swap per design #73: show the short form at ≤480 px
+           so the dropzone gets more vertical room on phones. */
+        .hero-title-short, .subline-short { display: none; }
+        @media (max-width: 480px) {
+          .hero-title-long, .subline-long { display: none; }
+          .hero-title-short, .subline-short { display: inline; }
         }
         .model-status {
           font-family: 'JetBrains Mono', monospace;
@@ -1023,9 +1030,13 @@ export class ArApp extends HTMLElement {
       <div class="marquee-bleed" id="precision-marquee-bleed"><span>☢ NUKEBG | DROP. NUKE. DOWNLOAD. | Your images never leave your device | nukebg.app ☢ NUKEBG | DROP. NUKE. DOWNLOAD. | Your images never leave your device | nukebg.app ☢</span></div>
 
       <section class="hero" id="hero">
-        <h1><span class="accent">${t('hero.title.accent')}</span> ${t('hero.title.rest')}</h1>
+        <h1>
+          <span class="hero-title-long"><span class="accent">${t('hero.title.accent')}</span> ${t('hero.title.rest')}</span>
+          <span class="hero-title-short"><span class="accent">$ </span>${t('hero.title.short')}</span>
+        </h1>
         <p class="subline">
-          ${t('hero.subtitle').replace(/\n/g, ' ')}
+          <span class="subline-long">${t('hero.subtitle').replace(/\n/g, ' ')}</span>
+          <span class="subline-short"># ${t('hero.subtitle.short')}</span>
         </p>
         <ar-dropzone></ar-dropzone>
         <ar-batch-grid id="batch-grid" style="display:none"></ar-batch-grid>
@@ -1126,9 +1137,13 @@ export class ArApp extends HTMLElement {
   private updateTexts(): void {
     const root = this.shadowRoot!;
     const h1 = root.querySelector('h1');
-    if (h1) h1.innerHTML = `<span class="accent">${t('hero.title.accent')}</span> ${t('hero.title.rest')}`;
+    if (h1) h1.innerHTML =
+      `<span class="hero-title-long"><span class="accent">${t('hero.title.accent')}</span> ${t('hero.title.rest')}</span>` +
+      `<span class="hero-title-short"><span class="accent">$ </span>${t('hero.title.short')}</span>`;
     const subline = root.querySelector('.subline');
-    if (subline) subline.textContent = t('hero.subtitle').replace(/\n/g, ' ');
+    if (subline) subline.innerHTML =
+      `<span class="subline-long">${t('hero.subtitle').replace(/\n/g, ' ')}</span>` +
+      `<span class="subline-short"># ${t('hero.subtitle.short')}</span>`;
     const statusReactor = root.querySelector('#status-reactor');
     if (statusReactor) statusReactor.textContent = t('status.reactor.online');
     const statusModel = root.querySelector('#status-model');

--- a/src/components/ar-dropzone.ts
+++ b/src/components/ar-dropzone.ts
@@ -4,6 +4,7 @@ import { getBatchLimit } from '../types/batch';
 
 export class ArDropzone extends HTMLElement {
   private fileInput!: HTMLInputElement;
+  private cameraInput!: HTMLInputElement;
   private dropArea!: HTMLDivElement;
   private boundLocaleHandler: (() => void) | null = null;
   private boundPasteHandler: ((e: ClipboardEvent) => void) | null = null;
@@ -122,6 +123,34 @@ export class ArDropzone extends HTMLElement {
           content: '[*] ';
           color: var(--color-accent-primary, #00ff41);
         }
+        /* Camera CTA — mobile-only (#73). Triggers a second file input
+           with capture="environment" so iOS / Android opens the camera
+           directly instead of the photo library. */
+        .dz-camera-cta {
+          display: none;
+          margin-top: 10px;
+          padding: 10px 14px;
+          font-family: 'JetBrains Mono', monospace;
+          font-size: 13px;
+          letter-spacing: 0.05em;
+          background: transparent;
+          color: var(--color-accent-primary, #00ff41);
+          border: 1px solid var(--color-accent-primary, #00ff41);
+          border-radius: 0;
+          cursor: pointer;
+          min-height: 44px;
+          transition: background 0.15s ease, box-shadow 0.15s ease;
+        }
+        .dz-camera-cta:hover,
+        .dz-camera-cta:focus-visible {
+          background: rgba(var(--color-accent-rgb, 0, 255, 65), 0.08);
+          box-shadow: 0 0 8px rgba(var(--color-accent-rgb, 0, 255, 65), 0.2);
+          outline: none;
+        }
+        @media (pointer: coarse), (max-width: 480px) {
+          .dz-camera-cta { display: inline-flex; align-items: center; justify-content: center; }
+        }
+        .dz-camera-input { display: none; }
         .dropzone:hover {
           box-shadow:
             0 0 18px rgba(var(--color-accent-rgb, 0, 255, 65), 0.14),
@@ -224,12 +253,17 @@ export class ArDropzone extends HTMLElement {
           <span id="dz-formats">${t('dropzone.formats')}</span>
           <span class="hint-multi" id="dz-multi">${t('dropzone.multi')}</span>
         </div>
+        <button type="button" class="dz-camera-cta" id="dz-camera-cta">
+          &#8227; ${t('dropzone.takePhoto')}
+        </button>
       </div>
       <input type="file" accept="image/png,image/jpeg,image/webp" multiple />
+      <input type="file" accept="image/*" capture="environment" class="dz-camera-input" />
     `;
 
     this.dropArea = this.shadowRoot!.querySelector('.dropzone')!;
-    this.fileInput = this.shadowRoot!.querySelector('input[type="file"]')!;
+    this.fileInput = this.shadowRoot!.querySelector('input[type="file"]:not(.dz-camera-input)')!;
+    this.cameraInput = this.shadowRoot!.querySelector('input.dz-camera-input')!;
   }
 
   private updateTexts(): void {
@@ -246,6 +280,8 @@ export class ArDropzone extends HTMLElement {
     if (dragover) dragover.textContent = t('dropzone.dragover');
     const dropzone = root.querySelector('.dropzone');
     if (dropzone) dropzone.setAttribute('aria-label', t('dropzone.ariaLabel'));
+    const camera = root.querySelector('#dz-camera-cta');
+    if (camera) camera.innerHTML = `&#8227; ${t('dropzone.takePhoto')}`;
   }
 
   private setupEvents(): void {
@@ -255,12 +291,19 @@ export class ArDropzone extends HTMLElement {
     };
     document.addEventListener('nukebg:locale-changed', this.boundLocaleHandler);
 
-    // Click to open file picker
-    this.dropArea.addEventListener('click', () => this.fileInput.click());
+    // Click to open file picker — but ignore clicks that bubbled from
+    // the inline camera CTA button (it manages its own file input).
+    this.dropArea.addEventListener('click', (e) => {
+      const target = e.target as HTMLElement | null;
+      if (target?.closest('#dz-camera-cta')) return;
+      this.fileInput.click();
+    });
 
     // Keyboard support
     this.dropArea.addEventListener('keydown', (e) => {
       if (e.key === 'Enter' || e.key === ' ') {
+        const target = e.target as HTMLElement | null;
+        if (target?.closest('#dz-camera-cta')) return;
         e.preventDefault();
         this.fileInput.click();
       }
@@ -270,6 +313,20 @@ export class ArDropzone extends HTMLElement {
     this.fileInput.addEventListener('change', () => {
       if (this.fileInput.files && this.fileInput.files.length > 0) {
         this.handleFiles(this.fileInput.files);
+      }
+    });
+
+    // Camera CTA (#73). Opens a second file input with
+    // capture="environment" so iOS / Android treat it as a camera
+    // intent instead of the photo library picker.
+    const cameraBtn = this.shadowRoot!.querySelector('#dz-camera-cta') as HTMLButtonElement | null;
+    cameraBtn?.addEventListener('click', (e) => {
+      e.stopPropagation();
+      this.cameraInput.click();
+    });
+    this.cameraInput.addEventListener('change', () => {
+      if (this.cameraInput.files && this.cameraInput.files.length > 0) {
+        this.handleFiles(this.cameraInput.files);
       }
     });
 

--- a/src/i18n/index.ts
+++ b/src/i18n/index.ts
@@ -12,6 +12,9 @@ const translations: Translations = {
     'hero.title.accent': 'Nuke',
     'hero.title.rest': 'Any Background',
     'hero.subtitle': 'Drop any image. Get a clean transparent PNG.\nNo upload. No account. No BS.',
+    'hero.title.short': 'NUKE BG',
+    'hero.subtitle.short': 'Drop image · transparent PNG · stays local.',
+    'dropzone.takePhoto': 'take photo',
     'hero.modelStatus': 'Ready to nuke',
 
     // Dropzone
@@ -230,6 +233,9 @@ const translations: Translations = {
     'hero.title.accent': 'Nukea',
     'hero.title.rest': 'Cualquier Fondo',
     'hero.subtitle': 'Arrastra una imagen. Obt\u00E9n un PNG transparente.\nSin subidas. Sin cuenta. Sin complicaciones.',
+    'hero.title.short': 'NUKE FONDOS',
+    'hero.subtitle.short': 'Imagen · PNG transparente · nunca sale.',
+    'dropzone.takePhoto': 'tomar foto',
     'hero.modelStatus': 'Listo para nukear',
 
     // Dropzone
@@ -448,6 +454,9 @@ const translations: Translations = {
     'hero.title.accent': 'Atomise',
     'hero.title.rest': "N'importe Quel Fond",
     'hero.subtitle': "Balance ton image. R\u00E9cup\u00E8re un PNG transparent.\nZ\u00E9ro upload. Z\u00E9ro compte. Z\u00E9ro baratin.",
+    'hero.title.short': 'NUKE ARRI\u00C8RE',
+    'hero.subtitle.short': 'D\u00E9pose · PNG transparent · reste local.',
+    'dropzone.takePhoto': 'prendre photo',
     'hero.modelStatus': 'Pr\u00EAt \u00E0 atomiser',
 
     // Dropzone
@@ -666,6 +675,9 @@ const translations: Translations = {
     'hero.title.accent': 'Nuke',
     'hero.title.rest': 'Jeden Hintergrund',
     'hero.subtitle': 'Bild reinwerfen. Transparentes PNG kriegen.\nKein Upload. Kein Konto. Kein Bullshit.',
+    'hero.title.short': 'NUKE BG',
+    'hero.subtitle.short': 'Bild · transparentes PNG · bleibt lokal.',
+    'dropzone.takePhoto': 'foto machen',
     'hero.modelStatus': 'Bereit zum Nuken',
 
     // Dropzone
@@ -884,6 +896,9 @@ const translations: Translations = {
     'hero.title.accent': 'Nukeia',
     'hero.title.rest': 'Qualquer Fundo',
     'hero.subtitle': 'Joga a imagem. Pega o PNG transparente.\nSem upload. Sem conta. Sem frescura.',
+    'hero.title.short': 'NUKE FUNDO',
+    'hero.subtitle.short': 'Imagem · PNG transparente · fica local.',
+    'dropzone.takePhoto': 'tirar foto',
     'hero.modelStatus': 'Pronto pra nukear',
 
     // Dropzone
@@ -1102,6 +1117,9 @@ const translations: Translations = {
     'hero.title.accent': '\u6838\u7206',
     'hero.title.rest': '\u4EFB\u4F55\u80CC\u666F',
     'hero.subtitle': '\u4E22\u5F20\u56FE\u7247\u8FDB\u6765\u3002\u62FF\u8D70\u900F\u660E PNG\u3002\n\u96F6\u4E0A\u4F20\u3002\u96F6\u6CE8\u518C\u3002\u96F6\u5E9F\u8BDD\u3002',
+    'hero.title.short': '\u6838\u7206\u80CC\u666F',
+    'hero.subtitle.short': '\u56FE\u7247 · \u900F\u660E PNG · \u672C\u5730\u5904\u7406',
+    'dropzone.takePhoto': '\u62CD\u7167',
     'hero.modelStatus': '\u51C6\u5907\u6838\u7206',
 
     // Dropzone

--- a/tests/components/ar-mobile-hero.test.ts
+++ b/tests/components/ar-mobile-hero.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+/**
+ * Mobile hero + camera CTA (#73) source invariants.
+ */
+
+const ROOT = resolve(__dirname, '..', '..');
+const APP = readFileSync(resolve(ROOT, 'src/components/ar-app.ts'), 'utf8');
+const DZ = readFileSync(resolve(ROOT, 'src/components/ar-dropzone.ts'), 'utf8');
+const I18N = readFileSync(resolve(ROOT, 'src/i18n/index.ts'), 'utf8');
+
+describe('Mobile hero — short-form copy swap (#73)', () => {
+  it('renders both long and short title + subtitle spans', () => {
+    expect(APP).toMatch(/class="hero-title-long"/);
+    expect(APP).toMatch(/class="hero-title-short"/);
+    expect(APP).toMatch(/class="subline-long"/);
+    expect(APP).toMatch(/class="subline-short"/);
+    expect(APP).toMatch(/t\(['"]hero\.title\.short['"]\)/);
+    expect(APP).toMatch(/t\(['"]hero\.subtitle\.short['"]\)/);
+  });
+
+  it('CSS swaps which variant renders at ≤ 480 px', () => {
+    expect(APP).toMatch(/\.hero-title-short, \.subline-short \{ display: none; \}/);
+    expect(APP).toMatch(/@media \(max-width: 480px\)\s*\{[\s\S]*?\.hero-title-long, \.subline-long \{ display: none/);
+  });
+
+  it('updateTexts renders both spans so locale-change keeps the swap working', () => {
+    expect(APP).toMatch(/hero-title-long[\s\S]*?hero-title-short/);
+    expect(APP).toMatch(/subline-long[\s\S]*?subline-short/);
+  });
+});
+
+describe('Dropzone camera CTA (#73)', () => {
+  it('renders a second <input type="file" capture="environment">', () => {
+    expect(DZ).toMatch(/<input[^>]*type="file"[^>]*capture="environment"[^>]*class="dz-camera-input"/);
+  });
+
+  it('renders a #dz-camera-cta button with takePhoto label', () => {
+    expect(DZ).toMatch(/id="dz-camera-cta"/);
+    expect(DZ).toMatch(/t\(['"]dropzone\.takePhoto['"]\)/);
+  });
+
+  it('camera CTA is visible only on coarse pointer OR ≤ 480 px', () => {
+    expect(DZ).toMatch(/\.dz-camera-cta \{[\s\S]*?display: none;/);
+    expect(DZ).toMatch(/@media \(pointer: coarse\), \(max-width: 480px\) \{[\s\S]*?\.dz-camera-cta \{ display: inline-flex/);
+  });
+
+  it('camera CTA click stops propagation + triggers the camera input, not the main one', () => {
+    expect(DZ).toMatch(/cameraBtn\?\.addEventListener\(['"]click['"],[\s\S]*?stopPropagation\(\)[\s\S]*?this\.cameraInput\.click\(\)/);
+  });
+
+  it('main dropzone click ignores events bubbling from the camera CTA', () => {
+    expect(DZ).toMatch(/target\?\.closest\(['"]#dz-camera-cta['"]\)\) return/);
+  });
+
+  it('cameraInput "change" handler routes into the existing handleFiles path', () => {
+    expect(DZ).toMatch(/this\.cameraInput\.addEventListener\(['"]change['"],[\s\S]*?this\.handleFiles\(this\.cameraInput\.files\)/);
+  });
+});
+
+describe('i18n parity — hero.*.short + dropzone.takePhoto', () => {
+  const keys = ['hero.title.short', 'hero.subtitle.short', 'dropzone.takePhoto'];
+  for (const key of keys) {
+    it(`'${key}' declared in all six locales`, () => {
+      const re = new RegExp(`'${key.replace(/\./g, '\\.')}'\\s*:`, 'g');
+      expect((I18N.match(re) ?? []).length).toBe(6);
+    });
+  }
+});


### PR DESCRIPTION
## Summary
Two coordinated mobile polish hits from design #73:

1. **Short-form hero copy at ≤ 480 px.** Both the long and short variants of title + subtitle ship in the DOM; CSS swaps which one renders. Desktop / tablet keep the full poetic title; phones get `\$ NUKE BG` + a one-line subtitle, freeing vertical room for the dropzone (already sized `min-height: 44vh` from #69).
2. **Take-photo CTA + camera intent on mobile.** New `#dz-camera-cta` button + second `<input type="file" capture="environment">`. Clicking the CTA opens the device camera (iOS / Android treat `capture="environment"` as a camera intent) — no photo-library detour. Same file goes through the existing `handleFiles()` validation path.

## i18n (6 locales)
- `hero.title.short`, `hero.subtitle.short`, `dropzone.takePhoto` — `i18n-parity` guard passes.
- `updateTexts()` renders both title/subtitle spans so locale change keeps the media-query swap working.

## Tests
- `tests/components/ar-mobile-hero.test.ts`: 11 source invariants covering HTML structure, CSS swap, camera attribute, visibility media query, CTA handler isolation, and `handleFiles` routing.
- Full suite: 577 pass / 2 pre-existing image-io fails (unchanged from `dev`).

## Test plan
- [ ] Load at 1440 px: hero shows long title + 3-sentence subtitle (unchanged).
- [ ] Load at 390 px: hero shows `\$ NUKE BG` + one-line subtitle; dropzone starts much higher.
- [ ] Locale toggle at 390 px: short copy translates without changing media-query behaviour.
- [ ] Mobile Chrome / iOS Safari: tap "take photo" → camera opens (not gallery).
- [ ] Desktop cursor: no camera CTA visible.
- [ ] Keyboard: Tab reaches the camera CTA only on coarse pointers; Enter fires the camera input.

## Follow-ups
- WebKit visual regression snapshots → #81.
- Mobile share sheet + 2-col batch grid + mobile result view → #74.

Closes #73.