### PR TITLE
ui: polish — typography tokens + progress height + tablet header (closes #80)

### DIFF
--- a/src/components/ar-progress.ts
+++ b/src/components/ar-progress.ts
@@ -112,17 +112,15 @@ export class ArProgress extends HTMLElement {
           max-width: 600px;
           margin: 0 auto;
         }
+        /* Pipeline always emits 3-4 stages (inpaint skips when no
+           watermark). The legacy 80px cap silently clipped the last
+           stage behind a hidden scrollbar — dropped per #80. Keep
+           min-height so the log row doesn't jump when stages populate. */
         .stages {
           display: flex;
           flex-direction: column;
           gap: 4px;
-          max-height: 80px;
           min-height: 80px;
-          overflow-y: auto;
-          scrollbar-width: none;
-        }
-        .stages::-webkit-scrollbar {
-          display: none;
         }
         .stage {
           display: flex;

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -68,9 +68,11 @@
   --font-sans: 'JetBrains Mono', 'Fira Code', 'Cascadia Code', monospace;
   --font-mono: 'JetBrains Mono', 'Fira Code', 'Cascadia Code', monospace;
 
-  --text-xs: 0.8125rem;
-  --text-sm: 0.9375rem;
-  --text-base: 1.0625rem;
+  /* Compressed per design #80 to a clean three-step scale so the low
+     end isn't four near-identical sizes doing the same visual job. */
+  --text-xs: 0.75rem;   /* 12px — timestamps, quiet meta */
+  --text-sm: 0.875rem;  /* 14px — body secondary, subline */
+  --text-base: 1rem;    /* 16px — body */
   --text-lg: 1.25rem;
   --text-xl: 1.4375rem;
   --text-2xl: 1.75rem;
@@ -649,6 +651,12 @@ body::after {
   }
   .terminal-prompt {
     display: none;
+  }
+  /* Header would otherwise have a big empty gap between the logo and
+     the lang/share cluster — show the portable-mode tagline so the
+     header keeps its monospace voice. (#80) */
+  .mobile-mode-label {
+    display: inline !important;
   }
   .main-content {
     border-left: none;


### PR DESCRIPTION
## Summary
Three discrete polish items from design #80:

- **Typography tokens**: `--text-xs` 0.8125rem → 0.75rem (12px), `--text-sm` 0.9375rem → 0.875rem (14px), `--text-base` 1.0625rem → 1rem (16px). Snaps the scale to clean px values.
- **Progress stages height**: drop the `max-height: 80px; overflow-y: auto` cap that silently clipped the 4th stage behind a hidden scrollbar. Keep `min-height: 80px` so the row doesn't jump on populate.
- **Tablet header**: show `.mobile-mode-label` (`> portable mode_`) at 481–768 px so the header isn't a big empty gap between logo and lang/share.

## Deliberately deferred
- OG card image asset — binary work; not code.
- CRT flicker scope audit — overlaps with #79 (`data-playful`).

## Tests
577 pass / 2 pre-existing `image-io` fails (unchanged from `dev`).

Closes #80.