### PR TITLE
ci: Safari cross-engine validation — WebKit matrix + iPhone + BrowserStack hook (closes #81)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,15 +81,24 @@ jobs:
           path: test-results/
           retention-days: 7
 
-  e2e-webkit:
-    name: Playwright pipeline e2e (WebKit)
+  # Safari-engine coverage — runs the Playwright suite against both the
+  # desktop WebKit profile and the iPhone 15 Pro touch profile. Same
+  # engine Apple ships in Safari on macOS / iOS (≈ 85 % bug parity with
+  # real Safari). Non-blocking today because:
+  #   1. The iOS Safari warmup hang documented in playwright.config.ts:9
+  #      causes ML-touching specs to skip.
+  #   2. Some fixtures produce slightly different hinting / alpha on
+  #      WebKit — visual snapshots get a `-webkit` suffix baseline.
+  # Flip `continue-on-error` to false once the ML specs stabilize.
+  e2e-safari:
+    name: Playwright e2e (${{ matrix.project }})
     runs-on: ubuntu-latest
     needs: test
-    # Non-blocking for now — the iOS Safari warmup hang documented in
-    # playwright.config.ts:9 still causes pipeline specs to skip on
-    # WebKit. Tracking that separately; this job is here to surface
-    # regressions in the non-ML WebKit specs (smoke etc).
     continue-on-error: true
+    strategy:
+      fail-fast: false
+      matrix:
+        project: [webkit, iphone]
     steps:
       - uses: actions/checkout@v4
 
@@ -104,13 +113,13 @@ jobs:
       - name: Install Playwright WebKit
         run: npx playwright install --with-deps webkit
 
-      - name: Run Playwright (WebKit)
-        run: npx playwright test --project=webkit
+      - name: Run Playwright (${{ matrix.project }})
+        run: npx playwright test --project=${{ matrix.project }}
 
       - name: Upload trace on failure
         if: failure()
         uses: actions/upload-artifact@v4
         with:
-          name: playwright-trace-webkit
+          name: playwright-trace-${{ matrix.project }}
           path: test-results/
           retention-days: 7

--- a/.github/workflows/safari-real-device.yml
+++ b/.github/workflows/safari-real-device.yml
@@ -1,0 +1,91 @@
+name: Safari real-device (manual)
+
+# Manual-trigger workflow to run the Playwright smoke + landing specs
+# against real iOS Safari via BrowserStack. Kept OFF the per-PR path
+# to stay within the 100 min/month free tier — triggered before each
+# release cut, not on every push.
+#
+# Required repo secrets (add in Settings → Secrets):
+#   BROWSERSTACK_USERNAME
+#   BROWSERSTACK_ACCESS_KEY
+#
+# If the secrets are not set the workflow reports missing-config and
+# exits cleanly (non-failing) so accidental triggers don't consume
+# free-tier minutes.
+
+on:
+  workflow_dispatch:
+    inputs:
+      device:
+        description: 'BrowserStack device (e.g. "iPhone 15 Pro Max")'
+        required: false
+        default: 'iPhone 15 Pro'
+      os_version:
+        description: 'iOS version (e.g. "17" / "18")'
+        required: false
+        default: '17'
+      spec_filter:
+        description: 'Playwright spec filter (e.g. smoke|landing)'
+        required: false
+        default: 'smoke'
+
+permissions:
+  contents: read
+
+jobs:
+  safari-real-device:
+    name: BrowserStack iOS Safari (${{ inputs.device }} · iOS ${{ inputs.os_version }})
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'npm'
+
+      - name: Verify BrowserStack credentials are set
+        id: creds
+        env:
+          BS_USER: ${{ secrets.BROWSERSTACK_USERNAME }}
+          BS_KEY: ${{ secrets.BROWSERSTACK_ACCESS_KEY }}
+        run: |
+          if [ -z "$BS_USER" ] || [ -z "$BS_KEY" ]; then
+            echo "::warning::BROWSERSTACK_USERNAME / BROWSERSTACK_ACCESS_KEY not set in repo secrets."
+            echo "::warning::Add them to Settings → Secrets → Actions to enable this workflow."
+            echo "configured=false" >> $GITHUB_OUTPUT
+          else
+            echo "configured=true" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Install dependencies
+        if: steps.creds.outputs.configured == 'true'
+        run: npm ci
+
+      - name: Install BrowserStack Playwright SDK
+        if: steps.creds.outputs.configured == 'true'
+        run: npm install --no-save browserstack-node-sdk@latest
+
+      - name: Run smoke spec on BrowserStack
+        if: steps.creds.outputs.configured == 'true'
+        env:
+          BROWSERSTACK_USERNAME: ${{ secrets.BROWSERSTACK_USERNAME }}
+          BROWSERSTACK_ACCESS_KEY: ${{ secrets.BROWSERSTACK_ACCESS_KEY }}
+          BROWSERSTACK_DEVICE: ${{ inputs.device }}
+          BROWSERSTACK_OS_VERSION: ${{ inputs.os_version }}
+        run: |
+          # The `browserstack-node-sdk` launcher routes Playwright's
+          # chromium project at a remote real device instead.
+          # The spec_filter input lets us run just smoke / just landing.
+          npx browserstack-node-sdk playwright test \
+            --grep "${{ inputs.spec_filter }}" \
+            --reporter=list
+
+      - name: Report result
+        if: always()
+        run: |
+          if [ "${{ steps.creds.outputs.configured }}" = "false" ]; then
+            echo "Skipped — BrowserStack credentials not configured."
+          else
+            echo "BrowserStack run finished. See the BrowserStack dashboard for the session recording."
+          fi

--- a/docs/safari-testing.md
+++ b/docs/safari-testing.md
@@ -1,0 +1,108 @@
+# Safari testing strategy
+
+NukeBG targets three tiers of Safari-engine coverage at increasing
+fidelity and cost.
+
+## Tier 1 — Playwright WebKit (free, per-PR)
+
+Playwright ships its own WebKit build (same engine Apple uses on macOS
+and iOS). On every PR, CI runs the `e2e-safari` matrix with two
+projects:
+
+| Project  | Playwright preset      | Why                                    |
+|----------|------------------------|----------------------------------------|
+| `webkit` | `Desktop Safari`       | Catches desktop Safari rendering bugs. |
+| `iphone` | `iPhone 15 Pro`        | Touch + viewport + iOS-ish behaviour.  |
+
+The job is `continue-on-error: true` today because:
+
+- ML-touching specs (`pipeline.spec.ts`, `*-capture.spec.ts`) hit the
+  iOS Safari warmup hang documented at `playwright.config.ts:9`.
+- JetBrains Mono hinting differs between Chromium and WebKit, so visual
+  snapshots need a `-webkit` / `-iphone` baseline (Playwright handles
+  this automatically when running the project).
+
+When adding a visual snapshot, run once locally to generate baselines:
+
+```bash
+npx playwright test --project=webkit --update-snapshots
+npx playwright test --project=iphone --update-snapshots
+git add e2e/*.spec.ts-snapshots/
+```
+
+## Tier 2 — Local WebKit (free, optional)
+
+- **macOS**: Safari Technology Preview against `npm run dev`. Same
+  WebKit2 that ships in iOS Safari a few months later. Best trade-off
+  for manual smoke testing before a release.
+- **Linux**: `playwright install --with-deps webkit` bundles
+  `webkit2gtk`. Same layout engine as Layer 1 but you can inspect it
+  interactively with `PWDEBUG=1 npx playwright test --project=webkit`.
+
+## Tier 3 — Real iOS Safari via BrowserStack (paid, manual)
+
+For final release verification on real iPhone hardware.
+
+- BrowserStack free tier: **100 min/month**, real iPhone 15 / 14 / 13
+  on iOS 16–18. Use `.github/workflows/safari-real-device.yml` (manual
+  trigger).
+- Alternatives: LambdaTest (60 min/month free), Sauce Labs (trial).
+
+**Setup**:
+
+1. Create a BrowserStack account, grab username + access key.
+2. Add as repo secrets: `BROWSERSTACK_USERNAME`,
+   `BROWSERSTACK_ACCESS_KEY`.
+3. Trigger via `Actions → Safari real-device (manual) → Run workflow`.
+4. Watch the session recording on the BrowserStack dashboard.
+
+The workflow exits cleanly (non-failing) if the secrets are missing —
+safe to leave in the repo without pay-per-run surprises.
+
+**Do this before each release**, not on every PR. Free tier would
+drain in an afternoon otherwise.
+
+## What each tier catches
+
+| Class of bug                                        | Tier 1 | Tier 2 | Tier 3 |
+|-----------------------------------------------------|--------|--------|--------|
+| CSS / layout rendering                              | ✅     | ✅     | ✅     |
+| Font hinting / kerning                              | ≈      | ✅     | ✅     |
+| WebKit-specific JS engine quirks                    | ✅     | ✅     | ✅     |
+| Touch gesture timing (synthetic vs native)          | ≈      | ≈      | ✅     |
+| ITP / Intelligent Tracking Prevention / storage     | ❌     | ≈      | ✅     |
+| `navigator.share` behaviour                         | ❌     | ❌     | ✅     |
+| `capture="environment"` on `<input type="file">`    | ❌     | ❌     | ✅     |
+| PWA "Add to Home Screen"                            | ❌     | ❌     | ✅     |
+| SharedArrayBuffer + COOP / COEP                     | ≈      | ✅     | ✅     |
+| iOS Safari warmup hang at 96 % (real ML)            | ❌     | ≈      | ✅     |
+
+Legend: ✅ reliable · ≈ partial · ❌ not testable.
+
+## Known gaps on dev
+
+- The ML pipeline on real iOS Safari hangs at ~96 % warmup — repros
+  inconsistently on BrowserStack; the root cause (Transformers.js + ORT
+  WASM threading on iOS) is tracked separately.
+- `navigator.share` with `files` support varies across iOS versions —
+  mobile share sheet (#74) guards with `canShare({ files })`.
+
+## When to add a visual snapshot
+
+Add one whenever a PR changes the landing, workspace, editor, or
+anything that materially affects what the user sees. Use both the
+`chromium` and `webkit` projects in the spec so we catch hinting /
+kerning drift:
+
+```ts
+test('landing matches snapshot', async ({ page }) => {
+  await page.goto('/');
+  await expect(page).toHaveScreenshot('landing.png', {
+    maxDiffPixelRatio: 0.015,
+  });
+});
+```
+
+Playwright stores baselines per-project automatically, so running the
+same spec under `chromium` and `webkit` produces two files in
+`e2e/<spec>.spec.ts-snapshots/`.

--- a/e2e/visual-landing.spec.ts
+++ b/e2e/visual-landing.spec.ts
@@ -1,0 +1,41 @@
+import { test, expect } from '@playwright/test';
+
+/**
+ * Visual regression seed for the landing page (#81).
+ *
+ * Runs on every Playwright project — `chromium`, `webkit`, `iphone` —
+ * and each captures its own baseline so hinting / kerning drift
+ * between engines doesn't flag a false positive. `maxDiffPixelRatio`
+ * allows ~1.5 % pixel noise to tolerate anti-aliasing differences
+ * between CI runs.
+ *
+ * Regenerate baselines after intentional landing changes:
+ *   npx playwright test --project=chromium --update-snapshots
+ *   npx playwright test --project=webkit --update-snapshots
+ *   npx playwright test --project=iphone --update-snapshots
+ */
+test.describe('landing visual regression', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/');
+    // Wait for fonts + the marquee opening paint so the snapshot is stable.
+    await page.evaluate(() => document.fonts?.ready);
+    await page.waitForTimeout(500);
+    // Pause the marquee animation so snapshots are deterministic across
+    // runs. CSS animations tick at different phases otherwise.
+    await page.addStyleTag({
+      content: `
+        .marquee-bleed span,
+        .precision-marquee span { animation: none !important; }
+        .cmd-state-dot { animation: none !important; }
+      `,
+    });
+  });
+
+  test('above-the-fold landing matches baseline', async ({ page }) => {
+    await expect(page).toHaveScreenshot('landing-above-fold.png', {
+      fullPage: false,
+      maxDiffPixelRatio: 0.015,
+      animations: 'disabled',
+    });
+  });
+});


### PR DESCRIPTION
## Summary
Three-tier Safari coverage so every PR gets WebKit-engine feedback and we have a real-device escape hatch before releases.

### Tier 1 — Playwright WebKit matrix (per PR, non-blocking)
- Refactors `e2e-webkit` → `e2e-safari` with `strategy.matrix.project: [webkit, iphone]`. Same engine Apple ships in Safari on macOS / iOS, ~85 % bug parity.
- Both stay `continue-on-error: true` today (ML warmup hang on iOS; WebKit hinting differs). Flip to `false` after the warmup stabilizes.
- New `e2e/visual-landing.spec.ts` seeds the visual-regression pattern — captures above-the-fold, `maxDiffPixelRatio: 0.015`, marquee animations paused for determinism. Baselines generated per project.

### Tier 3 — Real iOS Safari (manual, paid)
- New `.github/workflows/safari-real-device.yml`, `workflow_dispatch` only. Reads `BROWSERSTACK_USERNAME` / `BROWSERSTACK_ACCESS_KEY` secrets, exits cleanly if missing.
- Workflow inputs: device, iOS version, spec filter.
- Use before each release cut; skips per-PR to stay inside the 100 min/mo free tier.

### Docs
`docs/safari-testing.md` — what each tier catches, how to regenerate snapshots, BrowserStack setup, known gaps.

## Test plan
- [ ] CI `e2e-safari` job fans out to `webkit` and `iphone` on this PR.
- [ ] Both show up as separate checks under the PR.
- [ ] First visual-regression run may fail on `webkit`/`iphone` until baselines are generated — commit baselines with `npx playwright test --project=<p> --update-snapshots`.
- [ ] Dispatching `Safari real-device (manual)` without secrets: workflow ends cleanly with a ::warning:: annotation, no billed minutes.

Closes #81.