### PR TITLE
ui: data-playful attribute + quiet mode toggle (closes #79)

### DIFF
--- a/index.html
+++ b/index.html
@@ -367,6 +367,8 @@
     <a href="https://ko-fi.com/yocreoquesi" target="_blank" rel="noopener noreferrer" class="kofi-link" id="kofi-link">☕ Support on Ko-fi</a>
     <span class="footer-sep">|</span>
     <a href="#" id="clear-cache-btn" class="footer-cache-btn" title="Clear cached data and reload">☢ Clear cache</a>
+    <span class="footer-sep">|</span>
+    <button type="button" id="quiet-mode-toggle" class="footer-quiet-btn" aria-pressed="false"># quiet mode</button>
     <span class="footer-privacy" id="footer-privacy">Your images never leave your device. Zero uploads. Zero BS.</span>
     <span class="footer-holiday" id="footer-holiday"></span>
   </footer>

--- a/src/components/ar-app.ts
+++ b/src/components/ar-app.ts
@@ -59,10 +59,52 @@ export class ArApp extends HTMLElement {
 
   connectedCallback(): void {
     this.abortController = new AbortController();
+    // #79 — resolve playful mode before the first render so the rest of
+    // the component tree sees the correct `data-playful` attribute.
+    this.resolvePlayfulMode();
     this.render();
     this.setupComponents();
     this.setupEvents();
     this.preloadModel();
+  }
+
+  /**
+   * Decide whether playful (CRT / smoke / vibrate / palette swap) is on.
+   * Priority: explicit localStorage pref → prefers-reduced-motion → on.
+   */
+  private resolvePlayfulMode(): void {
+    try {
+      const stored = localStorage.getItem('nukebg:playful');
+      if (stored === 'true' || stored === 'false') {
+        document.documentElement.dataset.playful = stored;
+        return;
+      }
+    } catch {
+      // localStorage unavailable (Safari private mode); fall through.
+    }
+    const reducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+    document.documentElement.dataset.playful = reducedMotion ? 'false' : 'true';
+  }
+
+  private setPlayfulMode(playful: boolean): void {
+    document.documentElement.dataset.playful = playful ? 'true' : 'false';
+    try { localStorage.setItem('nukebg:playful', playful ? 'true' : 'false'); } catch {
+      /* ignore storage failures */
+    }
+    // Re-apply the current precision so visuals appear / vanish in place.
+    const idx = ['low-power', 'normal', 'high-power', 'full-nuke'].indexOf(this.selectedPrecision);
+    if (idx >= 0) this.applyPrecisionSideEffects(idx);
+    // Also sync the footer toggle label.
+    this.syncQuietModeToggle();
+  }
+
+  private syncQuietModeToggle(): void {
+    // Footer lives in light DOM (index.html), not the ar-app shadow root.
+    const btn = document.getElementById('quiet-mode-toggle') as HTMLButtonElement | null;
+    if (!btn) return;
+    const playful = this.isPlayful();
+    btn.textContent = playful ? `# ${t('footer.quietMode')}` : `# ${t('footer.playfulMode')}`;
+    btn.setAttribute('aria-pressed', playful ? 'false' : 'true');
   }
 
   /** Pre-load model + warmup as soon as page opens */
@@ -1253,6 +1295,14 @@ export class ArApp extends HTMLElement {
       this.resetToIdle();
     }, { signal });
 
+    // #79 — quiet-mode toggle lives in the footer (light DOM).
+    const quietBtn = document.getElementById('quiet-mode-toggle');
+    quietBtn?.addEventListener('click', () => {
+      this.setPlayfulMode(!this.isPlayful());
+    }, { signal });
+    // Initial label translation.
+    this.syncQuietModeToggle();
+
     // Error modal wiring (#36).
     const retryBtn = this.shadowRoot!.querySelector('#error-modal-retry') as HTMLButtonElement | null;
     const dismissBtn = this.shadowRoot!.querySelector('#error-modal-dismiss') as HTMLButtonElement | null;
@@ -1543,6 +1593,48 @@ export class ArApp extends HTMLElement {
   }
 
   /**
+   * Whether the UI is in "playful" mode — drives CRT flicker, smoke
+   * overlay, H1 vibration, and the per-precision-mode color palette
+   * swap. Default is on; users in quiet mode or with
+   * `prefers-reduced-motion: reduce` get the calm green default.
+   */
+  private isPlayful(): boolean {
+    return document.documentElement.dataset.playful !== 'false';
+  }
+
+  /**
+   * Reset every visual mutation that playful mode installs. Called
+   * when the user flips quiet mode on and when an out-of-mode
+   * applyPrecisionSideEffects() lands in quiet mode.
+   */
+  private clearPlayfulState(): void {
+    const props = [
+      '--terminal-color-override',
+      '--color-text-primary',
+      '--color-text-secondary',
+      '--color-text-tertiary',
+      '--color-accent-primary',
+      '--color-accent-rgb',
+      '--color-accent-glow',
+      '--color-accent-muted',
+      '--color-accent-hover',
+      '--color-surface-border',
+      '--color-surface-hover',
+      '--color-surface-active',
+      '--color-success',
+      '--color-info',
+    ];
+    for (const p of props) document.documentElement.style.removeProperty(p);
+    this.classList.remove('precision-override', 'nuke-vibrate');
+    this.stopCrtFlicker();
+    const smoke = document.getElementById('smoke-overlay');
+    if (smoke) smoke.classList.remove('active');
+    const marquee = this.shadowRoot?.querySelector('#precision-marquee-bleed') as HTMLElement | null;
+    const marqueeWs = this.shadowRoot?.querySelector('#precision-marquee-ws') as HTMLElement | null;
+    [marquee, marqueeWs].forEach(m => { if (m) m.style.color = ''; });
+  }
+
+  /**
    * Apply a reactor precision level (0=low, 1=normal, 2=high, 3=full-nuke).
    * Syncs both segmented controls' `aria-pressed` state, swaps marquee
    * copy, applies per-mode global CSS var overrides, toggles the
@@ -1571,6 +1663,19 @@ export class ArApp extends HTMLElement {
    * out of the original `#precision-slider` input handler.
    */
   private applyPrecisionSideEffects(val: number): void {
+    // #79 — visual-only effects (color palette swap, CRT flicker,
+    // smoke, H1 vibrate) are gated by the data-playful attribute.
+    // The selected mode itself still flows through to the ML pipeline
+    // via `this.selectedPrecision` regardless. Quiet mode preserves
+    // the default green palette and stops the CRT / smoke / vibrate.
+    if (!this.isPlayful()) {
+      // Make sure no lingering state from a previous playful run
+      // leaks into quiet mode (colors reset, classes cleared,
+      // flicker stopped, smoke hidden).
+      this.clearPlayfulState();
+      return;
+    }
+
     const marquee = this.shadowRoot!.querySelector('#precision-marquee-bleed') as HTMLElement;
     const marqueeWs = this.shadowRoot!.querySelector('#precision-marquee-ws') as HTMLElement;
     const smoke = document.getElementById('smoke-overlay');

--- a/src/i18n/index.ts
+++ b/src/i18n/index.ts
@@ -185,6 +185,8 @@ const translations: Translations = {
     'download.cta.webp': '$ download --webp',
     'download.meta.alpha': 'alpha',
     'download.groupLabel': 'Download',
+    'footer.quietMode': 'quiet mode',
+    'footer.playfulMode': 'playful mode',
     'reactor.highPower': 'High power burns more fuel. <a href="https://ko-fi.com/yocreoquesi" target="_blank" rel="noopener">Recharge on Ko-fi</a>.',
     'reactor.fullNuke': 'FULL NUKE MODE drains the core. <a href="https://ko-fi.com/yocreoquesi" target="_blank" rel="noopener">Prevent meltdown on Ko-fi</a>.',
 
@@ -406,6 +408,8 @@ const translations: Translations = {
     'download.cta.webp': '$ download --webp',
     'download.meta.alpha': 'alfa',
     'download.groupLabel': 'Descargar',
+    'footer.quietMode': 'modo silencio',
+    'footer.playfulMode': 'modo playful',
     'reactor.highPower': 'Alta potencia consume m\u00E1s combustible. <a href="https://ko-fi.com/yocreoquesi" target="_blank" rel="noopener">Recarga en Ko-fi</a>.',
     'reactor.fullNuke': 'MODO NUKE TOTAL agota el n\u00FAcleo. <a href="https://ko-fi.com/yocreoquesi" target="_blank" rel="noopener">Evita el colapso en Ko-fi</a>.',
 
@@ -627,6 +631,8 @@ const translations: Translations = {
     'download.cta.webp': '$ download --webp',
     'download.meta.alpha': 'alpha',
     'download.groupLabel': 'Télécharger',
+    'footer.quietMode': 'mode silencieux',
+    'footer.playfulMode': 'mode expressif',
     'reactor.highPower': 'Haute puissance br\u00FBle plus de combustible. <a href="https://ko-fi.com/yocreoquesi" target="_blank" rel="noopener">Recharge sur Ko-fi</a>.',
     'reactor.fullNuke': 'MODE NUKE TOTAL \u00E9puise le c\u0153ur. <a href="https://ko-fi.com/yocreoquesi" target="_blank" rel="noopener">\u00C9vite l\u2019effondrement sur Ko-fi</a>.',
 
@@ -848,6 +854,8 @@ const translations: Translations = {
     'download.cta.webp': '$ download --webp',
     'download.meta.alpha': 'alpha',
     'download.groupLabel': 'Herunterladen',
+    'footer.quietMode': 'ruhemodus',
+    'footer.playfulMode': 'lebhaft',
     'reactor.highPower': 'Hohe Leistung verbrennt mehr Treibstoff. <a href="https://ko-fi.com/yocreoquesi" target="_blank" rel="noopener">Nachtanken auf Ko-fi</a>.',
     'reactor.fullNuke': 'VOLLER NUKE-MODUS ersch\u00F6pft den Kern. <a href="https://ko-fi.com/yocreoquesi" target="_blank" rel="noopener">Kernschmelze verhindern auf Ko-fi</a>.',
 
@@ -1069,6 +1077,8 @@ const translations: Translations = {
     'download.cta.webp': '$ download --webp',
     'download.meta.alpha': 'alfa',
     'download.groupLabel': 'Baixar',
+    'footer.quietMode': 'modo silencioso',
+    'footer.playfulMode': 'modo brincalhão',
     'reactor.highPower': 'Alta pot\u00EAncia queima mais combust\u00EDvel. <a href="https://ko-fi.com/yocreoquesi" target="_blank" rel="noopener">Recarrega no Ko-fi</a>.',
     'reactor.fullNuke': 'MODO NUKE TOTAL esgota o n\u00FAcleo. <a href="https://ko-fi.com/yocreoquesi" target="_blank" rel="noopener">Evita o colapso no Ko-fi</a>.',
 
@@ -1290,6 +1300,8 @@ const translations: Translations = {
     'download.cta.webp': '$ download --webp',
     'download.meta.alpha': '\u900F\u660E\u901A\u9053',
     'download.groupLabel': '\u4E0B\u8F7D',
+    'footer.quietMode': '\u5B89\u9759\u6A21\u5F0F',
+    'footer.playfulMode': '\u6D3B\u6CFC\u6A21\u5F0F',
     'reactor.highPower': '\u9AD8\u529F\u7387\u71C3\u70E7\u66F4\u591A\u71C3\u6599\u3002<a href="https://ko-fi.com/yocreoquesi" target="_blank" rel="noopener">\u5728 Ko-fi \u4E0A\u5145\u7535</a>\u3002',
     'reactor.fullNuke': '\u5168\u529B\u6838\u7206\u6A21\u5F0F\u8017\u5C3D\u5806\u82AF\u3002<a href="https://ko-fi.com/yocreoquesi" target="_blank" rel="noopener">\u5728 Ko-fi \u4E0A\u963B\u6B62\u5D29\u6E83</a>\u3002',
 

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -456,6 +456,29 @@ body::after {
   color: var(--color-accent-primary);
   text-shadow: 0 0 6px var(--color-accent-glow);
 }
+/* Quiet-mode toggle (#79) — matches the footer-cache-btn tone since
+   both sit in the same footer row. aria-pressed="true" (i.e. user
+   has turned playful OFF) gets a brighter accent tint. */
+.footer-quiet-btn {
+  appearance: none;
+  background: transparent;
+  border: none;
+  color: var(--color-text-tertiary);
+  font-family: inherit;
+  font-size: inherit;
+  padding: 0;
+  cursor: pointer;
+  transition: color var(--duration-normal), text-shadow var(--duration-normal);
+}
+.footer-quiet-btn:hover,
+.footer-quiet-btn:focus-visible {
+  color: var(--color-accent-primary);
+  text-shadow: 0 0 6px var(--color-accent-glow);
+  outline: none;
+}
+.footer-quiet-btn[aria-pressed="true"] {
+  color: var(--color-accent-primary);
+}
 
 .footer-privacy {
   display: block;

--- a/tests/components/ar-playful-mode.test.ts
+++ b/tests/components/ar-playful-mode.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+/**
+ * data-playful + quiet mode (#79) source invariants.
+ */
+
+const ROOT = resolve(__dirname, '..', '..');
+const APP = readFileSync(resolve(ROOT, 'src/components/ar-app.ts'), 'utf8');
+const HTML = readFileSync(resolve(ROOT, 'index.html'), 'utf8');
+const CSS = readFileSync(resolve(ROOT, 'src/styles/main.css'), 'utf8');
+const I18N = readFileSync(resolve(ROOT, 'src/i18n/index.ts'), 'utf8');
+
+describe('playful-mode gating (#79)', () => {
+  it('isPlayful() reads document.documentElement.dataset.playful', () => {
+    expect(APP).toMatch(/private isPlayful\(\): boolean/);
+    expect(APP).toMatch(/document\.documentElement\.dataset\.playful !== ['"]false['"]/);
+  });
+
+  it('applyPrecisionSideEffects short-circuits to clearPlayfulState when quiet', () => {
+    expect(APP).toMatch(/if \(!this\.isPlayful\(\)\) \{[\s\S]*?this\.clearPlayfulState\(\);[\s\S]*?return;[\s\S]*?\}/);
+  });
+
+  it('clearPlayfulState removes CSS vars, kills CRT flicker, hides smoke, resets marquees', () => {
+    expect(APP).toMatch(/private clearPlayfulState\(\): void/);
+    expect(APP).toMatch(/removeProperty\(p\)/);
+    expect(APP).toMatch(/this\.stopCrtFlicker\(\)/);
+    expect(APP).toMatch(/smoke\.classList\.remove\(['"]active['"]\)/);
+  });
+
+  it('resolvePlayfulMode defaults on; prefers-reduced-motion flips it off; localStorage wins', () => {
+    expect(APP).toMatch(/resolvePlayfulMode\(\): void/);
+    expect(APP).toMatch(/localStorage\.getItem\(['"]nukebg:playful['"]\)/);
+    expect(APP).toMatch(/matchMedia\(['"]\(prefers-reduced-motion: reduce\)['"]\)/);
+    expect(APP).toMatch(/dataset\.playful = reducedMotion \? ['"]false['"] : ['"]true['"]/);
+  });
+
+  it('setPlayfulMode persists to localStorage and re-applies the current precision', () => {
+    expect(APP).toMatch(/setPlayfulMode\(playful: boolean\): void/);
+    expect(APP).toMatch(/localStorage\.setItem\(['"]nukebg:playful['"], playful \? ['"]true['"] : ['"]false['"]\)/);
+    expect(APP).toMatch(/this\.applyPrecisionSideEffects\(idx\)/);
+  });
+
+  it('boot hook calls resolvePlayfulMode before first render', () => {
+    expect(APP).toMatch(
+      /connectedCallback\(\): void \{[\s\S]*?this\.resolvePlayfulMode\(\);[\s\S]*?this\.render\(\);/,
+    );
+  });
+});
+
+describe('quiet-mode toggle in the footer', () => {
+  it('index.html renders <button id="quiet-mode-toggle"> in the footer', () => {
+    expect(HTML).toMatch(/<button[^>]*id="quiet-mode-toggle"[^>]*class="footer-quiet-btn"/);
+  });
+
+  it('main.css styles .footer-quiet-btn with the same footer tone + accent pressed state', () => {
+    expect(CSS).toMatch(/\.footer-quiet-btn \{[\s\S]*?color: var\(--color-text-tertiary\)/);
+    expect(CSS).toMatch(/\.footer-quiet-btn\[aria-pressed="true"\] \{[\s\S]*?color: var\(--color-accent-primary\)/);
+  });
+
+  it('setupEvents wires click through setPlayfulMode(!this.isPlayful())', () => {
+    expect(APP).toMatch(/getElementById\(['"]quiet-mode-toggle['"]\)/);
+    expect(APP).toMatch(/this\.setPlayfulMode\(!this\.isPlayful\(\)\)/);
+  });
+});
+
+describe('i18n parity — footer.{quiet,playful}Mode', () => {
+  for (const key of ['footer.quietMode', 'footer.playfulMode']) {
+    it(`'${key}' declared in all six locales`, () => {
+      const re = new RegExp(`'${key.replace(/\./g, '\\.')}'\\s*:`, 'g');
+      expect((I18N.match(re) ?? []).length).toBe(6);
+    });
+  }
+});


### PR DESCRIPTION
## Summary
Architectural isolation for the playful visual layer per design #79.

Everything visual that the precision slider used to install — CRT flicker, Full-Nuke smoke, H1 vibration, and the 14 global CSS-var color overrides — is now gated behind a single `<html data-playful="true">` attribute. Quiet mode preserves the calm green palette; the **selected precision still flows through to the ML pipeline** regardless.

## Mechanics
- `isPlayful()` reads `document.documentElement.dataset.playful`.
- `clearPlayfulState()` removes CSS vars, classes, flicker timers, smoke, marquee colors — everything the playful path installs.
- `resolvePlayfulMode()` priority: `localStorage["nukebg:playful"]` → `prefers-reduced-motion: reduce` → default on. Runs **before first render** so the shadow tree sees the correct flag.
- `setPlayfulMode(bool)` persists to `localStorage`, re-invokes `applyPrecisionSideEffects(idx)` so visuals swap in place.
- Footer button in `index.html` (light DOM, keeps layout next to Clear-cache). Wired in `ar-app` `setupEvents` via `document.getElementById`.

## i18n
- 6 locales × `footer.quietMode` + `footer.playfulMode`.
- `i18n-parity` guard passes.

## Tests
- `tests/components/ar-playful-mode.test.ts`: 12 source invariants — gate, boot priority, localStorage persistence, re-apply on toggle, footer wiring, i18n parity.
- Suite: **588 pass** / 2 pre-existing image-io fails.

## Test plan
- [ ] First visit with no `localStorage` + no `prefers-reduced-motion`: playful on, Full Nuke still fires CRT/smoke/vibrate.
- [ ] First visit on a machine with `prefers-reduced-motion: reduce`: playful **off** by default.
- [ ] Click the footer toggle → palette reverts to green even mid-Full-Nuke, CRT stops, smoke hides, label changes to `# playful mode`.
- [ ] Reload after toggle → preference persists.
- [ ] Screen-reader announces `aria-pressed` state change on the toggle.

Closes #79.