### PR TITLE
ui: Web Share button + mobile batch 2-col (closes #74)

### DIFF
--- a/src/components/ar-batch-grid.ts
+++ b/src/components/ar-batch-grid.ts
@@ -81,8 +81,10 @@ export class ArBatchGrid extends HTMLElement {
         @media (max-width: 768px) {
           .grid { grid-template-columns: repeat(3, 1fr); gap: 8px; }
         }
-        @media (max-width: 420px) {
-          .grid { grid-template-columns: repeat(2, 1fr); gap: 6px; }
+        /* Mobile phones up to 480 px: 2-col grid per design #74 so
+           tiles are big enough for thumb-zoom + badge legibility. */
+        @media (max-width: 480px) {
+          .grid { grid-template-columns: repeat(2, 1fr); gap: 10px; }
         }
         .actions {
           display: flex;

--- a/src/components/ar-download.ts
+++ b/src/components/ar-download.ts
@@ -35,6 +35,8 @@ export class ArDownload extends HTMLElement {
     if (copyBtn && !copyBtn.classList.contains('copied')) copyBtn.innerHTML = `${t('download.copy')}<br><small>PNG</small>`;
     const anotherBtn = root.querySelector('#another-btn');
     if (anotherBtn) anotherBtn.textContent = t('download.another');
+    const shareBtn = root.querySelector('#share-btn');
+    if (shareBtn) shareBtn.innerHTML = `${t('download.share')}<br><small>PNG</small>`;
     this.updateCtaLabels();
   }
 
@@ -87,6 +89,7 @@ export class ArDownload extends HTMLElement {
     // Prepare WebP blob lazily — it's the secondary CTA; encode in the
     // background so its size metadata renders as soon as ready.
     this.updateCtaAnchors('png-only');
+    this.syncShareButton();
     void this.prepareWebp(imageData);
 
     this.show();
@@ -120,6 +123,23 @@ export class ArDownload extends HTMLElement {
   private show(): void {
     const bar = this.shadowRoot!.querySelector('#bar');
     if (bar) bar.classList.add('visible');
+  }
+
+  /**
+   * Show the Web Share button if (a) the PNG blob is ready and
+   * (b) the browser reports support for sharing files. Safari
+   * (desktop + iOS), Chromium on Android, and Edge qualify; desktop
+   * Chromium + Firefox return false and the button stays hidden.
+   */
+  private syncShareButton(): void {
+    const btn = this.shadowRoot?.querySelector('#share-btn') as HTMLButtonElement | null;
+    if (!btn || !this.pngBlob) return;
+    try {
+      const probe = new File([this.pngBlob], this.pngFilename, { type: 'image/png' });
+      btn.hidden = !(navigator.canShare && navigator.canShare({ files: [probe] }));
+    } catch {
+      btn.hidden = true;
+    }
   }
 
   private render(): void {
@@ -323,6 +343,7 @@ export class ArDownload extends HTMLElement {
         </div>
         <div class="dl-side">
           <button class="btn-copy" id="copy-btn" title="Copy to clipboard" aria-live="polite">${t('download.copy')}<br><small>PNG</small></button>
+          <button class="btn-secondary" id="share-btn" hidden aria-live="polite">${t('download.share')}<br><small>PNG</small></button>
           <button class="btn-secondary" id="another-btn">${t('download.another')}</button>
         </div>
       </div>
@@ -330,6 +351,34 @@ export class ArDownload extends HTMLElement {
 
     this.shadowRoot!.querySelector('#another-btn')!.addEventListener('click', () => {
       this.dispatchEvent(new CustomEvent('ar:process-another', { bubbles: true, composed: true }));
+    });
+
+    // Web Share API (#74). Only exposed on engines that can actually
+    // share files — `navigator.canShare({ files })` returns false on
+    // desktop Chromium + older Safari, so we keep the button hidden
+    // and let the Copy + Download paths handle those cases.
+    const shareBtn = this.shadowRoot!.querySelector('#share-btn') as HTMLButtonElement | null;
+    shareBtn?.addEventListener('click', async () => {
+      if (!this.pngBlob) return;
+      const file = new File([this.pngBlob], this.pngFilename, { type: 'image/png' });
+      try {
+        // canShare re-check at click time (user may have disabled
+        // sharing between page load and click).
+        if (!navigator.canShare || !navigator.canShare({ files: [file] })) {
+          shareBtn.hidden = true;
+          return;
+        }
+        await navigator.share({
+          files: [file],
+          title: t('download.share.title'),
+          text: t('download.share.text'),
+          url: 'https://nukebg.app',
+        });
+      } catch (err) {
+        // AbortError = user dismissed the share sheet; not an error.
+        if ((err as DOMException)?.name === 'AbortError') return;
+        console.warn('[ar-download] share failed:', err);
+      }
     });
     // Track which format the user clicked so external callers (editor /
     // clipboard) know the latest intent via this.selectedFormat.
@@ -431,6 +480,8 @@ export class ArDownload extends HTMLElement {
     const webp = root.querySelector('#dl-webp') as HTMLAnchorElement | null;
     if (png) { png.hidden = true; png.removeAttribute('href'); }
     if (webp) { webp.hidden = true; webp.removeAttribute('href'); }
+    const shareBtn = root.querySelector('#share-btn') as HTMLButtonElement | null;
+    if (shareBtn) shareBtn.hidden = true;
   }
 }
 

--- a/src/i18n/index.ts
+++ b/src/i18n/index.ts
@@ -187,6 +187,9 @@ const translations: Translations = {
     'download.groupLabel': 'Download',
     'footer.quietMode': 'quiet mode',
     'footer.playfulMode': 'playful mode',
+    'download.share': 'Share',
+    'download.share.title': 'Nuked background',
+    'download.share.text': 'Processed with nukebg.app — stays local',
     'reactor.highPower': 'High power burns more fuel. <a href="https://ko-fi.com/yocreoquesi" target="_blank" rel="noopener">Recharge on Ko-fi</a>.',
     'reactor.fullNuke': 'FULL NUKE MODE drains the core. <a href="https://ko-fi.com/yocreoquesi" target="_blank" rel="noopener">Prevent meltdown on Ko-fi</a>.',
 
@@ -410,6 +413,9 @@ const translations: Translations = {
     'download.groupLabel': 'Descargar',
     'footer.quietMode': 'modo silencio',
     'footer.playfulMode': 'modo playful',
+    'download.share': 'Compartir',
+    'download.share.title': 'Fondo nukeado',
+    'download.share.text': 'Procesado con nukebg.app — todo local',
     'reactor.highPower': 'Alta potencia consume m\u00E1s combustible. <a href="https://ko-fi.com/yocreoquesi" target="_blank" rel="noopener">Recarga en Ko-fi</a>.',
     'reactor.fullNuke': 'MODO NUKE TOTAL agota el n\u00FAcleo. <a href="https://ko-fi.com/yocreoquesi" target="_blank" rel="noopener">Evita el colapso en Ko-fi</a>.',
 
@@ -633,6 +639,9 @@ const translations: Translations = {
     'download.groupLabel': 'Télécharger',
     'footer.quietMode': 'mode silencieux',
     'footer.playfulMode': 'mode expressif',
+    'download.share': 'Partager',
+    'download.share.title': 'Arrière-plan nuké',
+    'download.share.text': 'Traité avec nukebg.app — 100% local',
     'reactor.highPower': 'Haute puissance br\u00FBle plus de combustible. <a href="https://ko-fi.com/yocreoquesi" target="_blank" rel="noopener">Recharge sur Ko-fi</a>.',
     'reactor.fullNuke': 'MODE NUKE TOTAL \u00E9puise le c\u0153ur. <a href="https://ko-fi.com/yocreoquesi" target="_blank" rel="noopener">\u00C9vite l\u2019effondrement sur Ko-fi</a>.',
 
@@ -856,6 +865,9 @@ const translations: Translations = {
     'download.groupLabel': 'Herunterladen',
     'footer.quietMode': 'ruhemodus',
     'footer.playfulMode': 'lebhaft',
+    'download.share': 'Teilen',
+    'download.share.title': 'Hintergrund genuked',
+    'download.share.text': 'Mit nukebg.app verarbeitet — bleibt lokal',
     'reactor.highPower': 'Hohe Leistung verbrennt mehr Treibstoff. <a href="https://ko-fi.com/yocreoquesi" target="_blank" rel="noopener">Nachtanken auf Ko-fi</a>.',
     'reactor.fullNuke': 'VOLLER NUKE-MODUS ersch\u00F6pft den Kern. <a href="https://ko-fi.com/yocreoquesi" target="_blank" rel="noopener">Kernschmelze verhindern auf Ko-fi</a>.',
 
@@ -1079,6 +1091,9 @@ const translations: Translations = {
     'download.groupLabel': 'Baixar',
     'footer.quietMode': 'modo silencioso',
     'footer.playfulMode': 'modo brincalhão',
+    'download.share': 'Compartilhar',
+    'download.share.title': 'Fundo nukeado',
+    'download.share.text': 'Processado com nukebg.app — fica local',
     'reactor.highPower': 'Alta pot\u00EAncia queima mais combust\u00EDvel. <a href="https://ko-fi.com/yocreoquesi" target="_blank" rel="noopener">Recarrega no Ko-fi</a>.',
     'reactor.fullNuke': 'MODO NUKE TOTAL esgota o n\u00FAcleo. <a href="https://ko-fi.com/yocreoquesi" target="_blank" rel="noopener">Evita o colapso no Ko-fi</a>.',
 
@@ -1302,6 +1317,9 @@ const translations: Translations = {
     'download.groupLabel': '\u4E0B\u8F7D',
     'footer.quietMode': '\u5B89\u9759\u6A21\u5F0F',
     'footer.playfulMode': '\u6D3B\u6CFC\u6A21\u5F0F',
+    'download.share': '\u5206\u4EAB',
+    'download.share.title': '\u5DF2\u53BB\u9664\u7684\u80CC\u666F',
+    'download.share.text': '\u7531 nukebg.app \u5904\u7406—\u672C\u5730\u8FD0\u884C',
     'reactor.highPower': '\u9AD8\u529F\u7387\u71C3\u70E7\u66F4\u591A\u71C3\u6599\u3002<a href="https://ko-fi.com/yocreoquesi" target="_blank" rel="noopener">\u5728 Ko-fi \u4E0A\u5145\u7535</a>\u3002',
     'reactor.fullNuke': '\u5168\u529B\u6838\u7206\u6A21\u5F0F\u8017\u5C3D\u5806\u82AF\u3002<a href="https://ko-fi.com/yocreoquesi" target="_blank" rel="noopener">\u5728 Ko-fi \u4E0A\u963B\u6B62\u5D29\u6E83</a>\u3002',
 


### PR DESCRIPTION
## Summary
Mobile primary-flow additions per design #74:

- **Web Share button** in `ar-download` next to Copy / Another. Hidden by default, revealed when `navigator.canShare({ files })` returns true (iOS Safari, Android Chromium, Edge). Click fires `navigator.share({ files, title, text, url })`. User-dismissed `AbortError` is swallowed.
- **Batch grid 2-col breakpoint** moved from ≤ 420 px to ≤ 480 px so iPhone SE / 14 users get bigger thumbnails.

## i18n (6 locales)
- `download.share`, `download.share.title`, `download.share.text`.

## Tests
Suite: 588 pass / 2 pre-existing `image-io` fails.

## Test plan
- [ ] iOS Safari: share button visible on result; tap → native share sheet with the PNG file attached.
- [ ] Android Chrome: same.
- [ ] Desktop Chrome / Firefox: share button stays hidden.
- [ ] User dismisses native share sheet: no console error, UI stays ready.
- [ ] Locale toggle: Share label updates.
- [ ] iPhone SE (375 px): batch grid shows 2 columns.

Closes #74.