### PR TITLE
ui: below-fold SEO block — how it works + vs alternatives (partial #78)

### DIFF
--- a/index.html
+++ b/index.html
@@ -357,6 +357,43 @@
     <ar-app></ar-app>
   </main>
 
+  <section class="seo-below-fold" id="seo-below-fold" aria-labelledby="seo-howto-title">
+    <div class="seo-grid">
+      <article class="seo-col" aria-labelledby="seo-howto-title">
+        <h2 id="seo-howto-title" class="seo-col-title"># How it works</h2>
+        <ol class="seo-steps">
+          <li><strong>Drop</strong> an image — PNG, JPG, or WebP, up to 100 MP.</li>
+          <li><strong>Classify</strong> — photo, illustration, signature, or icon (local, instant).</li>
+          <li><strong>Detect &amp; inpaint</strong> any Gemini sparkle or DALL-E bar watermark before segmentation.</li>
+          <li><strong>Segment</strong> the background with RMBG-1.4 in your browser. Download a clean transparent PNG.</li>
+        </ol>
+        <p class="seo-tag">Nothing leaves your device. Open DevTools &rarr; Network panel to verify.</p>
+      </article>
+      <article class="seo-col" aria-labelledby="seo-vs-title">
+        <h2 id="seo-vs-title" class="seo-col-title"># vs other tools</h2>
+        <table class="seo-table">
+          <thead>
+            <tr>
+              <th scope="col">Feature</th>
+              <th scope="col">NukeBG</th>
+              <th scope="col">remove.bg</th>
+              <th scope="col">Photoshop</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr><th scope="row">Runs locally</th><td class="yes">Yes</td><td class="no">No</td><td class="yes">Yes</td></tr>
+            <tr><th scope="row">Image uploaded</th><td class="no">Never</td><td class="yes">Every time</td><td class="no">Never</td></tr>
+            <tr><th scope="row">Free</th><td class="yes">Yes</td><td class="yes">Limited</td><td class="no">$22/mo</td></tr>
+            <tr><th scope="row">Works offline</th><td class="yes">Yes</td><td class="no">No</td><td class="yes">Yes</td></tr>
+            <tr><th scope="row">Kills AI checkerboards</th><td class="yes">Yes</td><td class="no">No</td><td class="no">Manual</td></tr>
+            <tr><th scope="row">Removes Gemini watermark</th><td class="yes">Yes</td><td class="no">No</td><td class="no">Manual</td></tr>
+            <tr><th scope="row">Open source</th><td class="yes">GPL-3.0</td><td class="no">No</td><td class="no">No</td></tr>
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </section>
+
   <footer class="footer hazard-border-top" role="contentinfo">
     <span>NukeBG <span style="color:var(--color-text-tertiary)">v2.7.3</span></span>
     <span class="footer-sep">|</span>

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -416,6 +416,101 @@ body::after {
   width: 100%;
 }
 
+/* === Below-fold SEO section (#78) === */
+.seo-below-fold {
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: var(--space-8) var(--space-6);
+  border-top: 1px solid var(--color-surface-border);
+  font-family: var(--font-mono);
+  color: var(--color-text-secondary);
+}
+.seo-grid {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: var(--space-6);
+}
+@media (min-width: 768px) {
+  .seo-grid {
+    grid-template-columns: 1fr 1fr;
+    gap: var(--space-8);
+  }
+}
+.seo-col {
+  min-width: 0;
+}
+.seo-col-title {
+  color: var(--color-accent-primary);
+  font-size: var(--text-base);
+  font-weight: 600;
+  margin: 0 0 var(--space-4);
+  letter-spacing: 0.04em;
+  text-shadow: 0 0 8px var(--color-accent-glow);
+}
+.seo-steps {
+  counter-reset: step;
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+}
+.seo-steps li {
+  counter-increment: step;
+  position: relative;
+  padding-left: 38px;
+  font-size: var(--text-sm);
+  line-height: 1.55;
+  color: var(--color-text-secondary);
+}
+.seo-steps li::before {
+  content: '[' counter(step) ']';
+  position: absolute;
+  left: 0;
+  top: 0;
+  color: var(--color-accent-primary);
+  font-family: var(--font-mono);
+}
+.seo-steps strong {
+  color: var(--color-accent-primary);
+  font-weight: 600;
+}
+.seo-tag {
+  margin-top: var(--space-4);
+  color: var(--color-text-tertiary);
+  font-size: var(--text-xs);
+}
+.seo-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: var(--text-xs);
+}
+.seo-table th,
+.seo-table td {
+  padding: 6px 8px;
+  text-align: left;
+  border-bottom: 1px solid var(--color-surface-border);
+}
+.seo-table thead th {
+  color: var(--color-accent-primary);
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  border-bottom-color: var(--color-accent-primary);
+}
+.seo-table tbody th {
+  color: var(--color-text-secondary);
+  font-weight: 500;
+}
+.seo-table td.yes { color: var(--color-accent-primary); }
+.seo-table td.no { color: var(--color-text-tertiary); }
+@media (max-width: 480px) {
+  .seo-below-fold { padding: var(--space-6) var(--space-4); }
+  .seo-table { font-size: 11px; }
+  .seo-table th, .seo-table td { padding: 4px 6px; }
+}
+
 /* === Footer === */
 .footer {
   border-top: 1px solid var(--color-surface-border, #1a3a1a);


### PR DESCRIPTION
## Summary
Adds a crawler-friendly section below the main app so SEO visits land on structured content.

- `<section class="seo-below-fold">` in light DOM between `<main>` and `<footer>`.
- Two columns at ≥ 768 px: "How it works" (4-step ordered list, `[n]` markers) + "vs other tools" (compact matrix vs remove.bg + Photoshop on 7 features).
- Single column on mobile, compacted table at ≤ 480 px.
- Styled with existing tokens — accent-primary headers + glow, tertiary tags, surface-border dividers. Zero new tokens.

## What's not in this PR
Deferred to a follow-up issue (I'll open one separately):
- First-run model download explainer — needs a new `ar-first-run` component + SW coordination.
- Inline error stage with retry / report / reload — complements the modal shipped in #65.

This PR closes the SEO slice of #78; the other two pieces stay open.

Full suite: 588 pass / 2 pre-existing `image-io` fails.