### PR TITLE
ui: editor basic — permanent shortcuts sidebar at ≥ 900 px (partial #76)

### DIFF
--- a/src/components/ar-editor.ts
+++ b/src/components/ar-editor.ts
@@ -301,6 +301,68 @@ export class ArEditor extends HTMLElement {
           height: 20px;
           background: var(--color-surface-border, #1a3a1a);
         }
+        /* Editor body — canvas + optional sidebar at ≥ 900 px.
+           Single column below that breakpoint, the shortcuts move
+           back behind the "?" tooltip. (#76 sub-task B) */
+        .editor-body {
+          display: grid;
+          grid-template-columns: 1fr;
+          gap: var(--space-3, 0.75rem);
+          align-items: start;
+        }
+        @media (min-width: 900px) {
+          .editor-body {
+            grid-template-columns: minmax(0, 1fr) 260px;
+          }
+        }
+        .editor-sidebar {
+          display: none;
+          flex-direction: column;
+          gap: var(--space-3, 0.75rem);
+          padding: 12px;
+          border: 1px solid var(--color-surface-border, #1a3a1a);
+          background: var(--color-bg-primary, #000);
+          font-family: 'JetBrains Mono', monospace;
+          font-size: 12px;
+          color: var(--color-text-secondary, #00dd44);
+        }
+        @media (min-width: 900px) {
+          .editor-sidebar { display: flex; }
+        }
+        .editor-sidebar h4 {
+          margin: 0;
+          padding: 0;
+          color: var(--color-accent-primary, #00ff41);
+          font-size: 12px;
+          font-weight: 600;
+          letter-spacing: 0.04em;
+          text-transform: uppercase;
+        }
+        .editor-shortcuts {
+          display: flex;
+          flex-direction: column;
+          gap: 6px;
+          font-size: 12px;
+          color: var(--color-text-secondary, #00dd44);
+        }
+        .editor-shortcuts kbd {
+          display: inline-block;
+          min-width: 14px;
+          padding: 2px 6px;
+          margin-right: 6px;
+          background: var(--color-bg-primary, #000);
+          border: 1px solid var(--color-surface-border, #1a3a1a);
+          border-radius: 0;
+          color: var(--color-accent-primary, #00ff41);
+          font-family: 'JetBrains Mono', monospace;
+          font-size: 11px;
+        }
+        /* At ≥ 900 px the "?" popover becomes redundant — sidebar
+           owns the shortcuts. Keep the button for keyboard
+           discoverability below the breakpoint. */
+        @media (min-width: 900px) {
+          .help-wrap { display: none; }
+        }
         .canvas-wrap {
           position: relative;
           border: 1px solid var(--color-surface-border, #1a3a1a);
@@ -522,9 +584,23 @@ export class ArEditor extends HTMLElement {
           </div>
         </div>
 
-        <div class="canvas-wrap" id="canvas-wrap">
-          <canvas id="editor-canvas"></canvas>
-          <div class="touch-indicator" id="touch-indicator"></div>
+        <div class="editor-body">
+          <div class="canvas-wrap" id="canvas-wrap">
+            <canvas id="editor-canvas"></canvas>
+            <div class="touch-indicator" id="touch-indicator"></div>
+          </div>
+          <aside class="editor-sidebar" aria-labelledby="ed-shortcuts-title">
+            <h4 id="ed-shortcuts-title">${t('editor.shortcuts')}</h4>
+            <div class="editor-shortcuts">
+              <div><kbd>Click</kbd> ${t('editor.shortcutErase')}</div>
+              <div><kbd>[ ]</kbd> ${t('editor.shortcutEraserSize')}</div>
+              <div><kbd>Scroll</kbd> ${t('editor.shortcutZoom')}</div>
+              <div><kbd>Middle drag</kbd> ${t('editor.shortcutPan')}</div>
+              <div><kbd>0</kbd> ${t('editor.shortcutResetView')}</div>
+              <div><kbd>Ctrl+Z</kbd> ${t('editor.shortcutUndo')}</div>
+              <div><kbd>Ctrl+Shift+Z</kbd> ${t('editor.shortcutRedo')}</div>
+            </div>
+          </aside>
         </div>
 
         <div class="editor-footer">

--- a/tests/components/ar-editor-sidebar.test.ts
+++ b/tests/components/ar-editor-sidebar.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+/**
+ * #76 sub-task B — permanent shortcuts sidebar on the basic editor.
+ * Source invariants: sidebar + shortcuts exist, the ? popover hides
+ * at ≥ 900 px, sidebar only shows at ≥ 900 px.
+ */
+
+const ROOT = resolve(__dirname, '..', '..');
+const ED = readFileSync(resolve(ROOT, 'src/components/ar-editor.ts'), 'utf8');
+
+describe('ar-editor — permanent shortcuts sidebar (#76-B)', () => {
+  it('renders an <aside class="editor-sidebar"> with shortcuts list', () => {
+    expect(ED).toMatch(/<aside class="editor-sidebar"[^>]*aria-labelledby="ed-shortcuts-title"/);
+    expect(ED).toMatch(/<h4 id="ed-shortcuts-title">\$\{t\(['"]editor\.shortcuts['"]\)\}<\/h4>/);
+    expect(ED).toMatch(/<div class="editor-shortcuts">/);
+  });
+
+  it('sidebar contains all seven shortcut rows from the popover', () => {
+    expect(ED).toMatch(/t\(['"]editor\.shortcutErase['"]\)/);
+    expect(ED).toMatch(/t\(['"]editor\.shortcutEraserSize['"]\)/);
+    expect(ED).toMatch(/t\(['"]editor\.shortcutZoom['"]\)/);
+    expect(ED).toMatch(/t\(['"]editor\.shortcutPan['"]\)/);
+    expect(ED).toMatch(/t\(['"]editor\.shortcutResetView['"]\)/);
+    expect(ED).toMatch(/t\(['"]editor\.shortcutUndo['"]\)/);
+    expect(ED).toMatch(/t\(['"]editor\.shortcutRedo['"]\)/);
+  });
+
+  it('canvas is wrapped in .editor-body alongside the sidebar', () => {
+    const m = ED.match(/<div class="editor-body">[\s\S]*?<\/aside>\s*<\/div>/);
+    expect(m).not.toBeNull();
+    expect(m![0]).toMatch(/class="canvas-wrap"/);
+    expect(m![0]).toMatch(/class="editor-sidebar"/);
+  });
+
+  it('CSS hides the sidebar under 900 px and shows it at/over the breakpoint', () => {
+    expect(ED).toMatch(/\.editor-sidebar \{[\s\S]*?display: none;/);
+    expect(ED).toMatch(
+      /@media \(min-width: 900px\) \{[\s\S]*?\.editor-sidebar \{ display: flex; \}/,
+    );
+  });
+
+  it('CSS hides .help-wrap popover at ≥ 900 px (sidebar owns shortcuts)', () => {
+    expect(ED).toMatch(
+      /@media \(min-width: 900px\) \{[\s\S]*?\.help-wrap \{ display: none; \}/,
+    );
+  });
+
+  it('.editor-body becomes a 2-col grid at ≥ 900 px', () => {
+    expect(ED).toMatch(/\.editor-body \{[\s\S]*?display: grid/);
+    expect(ED).toMatch(
+      /@media \(min-width: 900px\) \{[\s\S]*?\.editor-body \{[\s\S]*?grid-template-columns: minmax\(0, 1fr\) 260px/,
+    );
+  });
+});


### PR DESCRIPTION
## Summary
#76 sub-task **B** of four. At ≥ 900 px the basic editor's keyboard shortcuts now render in a permanent sidebar next to the canvas instead of hiding behind the \`?\` popover. Popover stays below the breakpoint as a mobile fallback.

## What changed
- `ar-editor.ts` render wraps `<canvas-wrap>` into `<div class="editor-body">` alongside a new `<aside class="editor-sidebar">` with the same 7 shortcut rows (Click / [ ] / Scroll / Middle drag / 0 / Ctrl+Z / Ctrl+Shift+Z).
- CSS: `.editor-body { display: grid }`, single column by default, `minmax(0, 1fr) 260px` at ≥ 900 px. `.editor-sidebar { display: none }` flips to `display: flex` at the breakpoint. `.help-wrap` hides at ≥ 900 px.
- No new i18n keys — reuses existing `editor.shortcuts*` across six locales.

## Tests
- `tests/components/ar-editor-sidebar.test.ts`: 6 source invariants (sidebar markup, all 7 shortcut tokens, grid structure, visibility media queries, `.help-wrap` hiding).
- Full suite: 588 pass / 2 pre-existing `image-io` fails.

## Not in this PR
- Sub-task A: left rail with tool + shape + size
- Sub-task C: mini command bar above canvas
- Sub-task D: mobile bottom sheet

Refs #76.