### PR TITLE
ui: editor basic — mini command bar above canvas (partial #76)

### DIFF
--- a/src/components/ar-editor.ts
+++ b/src/components/ar-editor.ts
@@ -301,6 +301,75 @@ export class ArEditor extends HTMLElement {
           height: 20px;
           background: var(--color-surface-border, #1a3a1a);
         }
+        /* Editor command bar above the canvas (#76 sub-task C).
+           Mirrors the ar-app workspace command bar pattern so the
+           vocabulary stays consistent: $ action · meta · [cancel] [apply]. */
+        .editor-cmd-bar {
+          display: flex;
+          align-items: center;
+          justify-content: space-between;
+          gap: 12px;
+          padding: 8px 12px;
+          margin-bottom: 10px;
+          border: 1px solid var(--color-surface-border, #1a3a1a);
+          background: var(--color-bg-primary, #000);
+          font-family: 'JetBrains Mono', monospace;
+          font-size: 12px;
+          min-height: 40px;
+          flex-wrap: wrap;
+        }
+        .editor-cmd-left {
+          display: flex;
+          align-items: center;
+          gap: 6px;
+          color: var(--color-text-secondary, #00dd44);
+          min-width: 0;
+          flex: 1 1 auto;
+        }
+        .editor-cmd-prompt { color: var(--color-text-tertiary, #00b34a); }
+        .editor-cmd-action { color: var(--color-accent-primary, #00ff41); font-weight: 600; }
+        .editor-cmd-meta { color: var(--color-text-tertiary, #00b34a); }
+        .editor-cmd-right {
+          display: flex;
+          align-items: center;
+          gap: 6px;
+          flex-shrink: 0;
+        }
+        .editor-cmd-btn {
+          font: inherit;
+          font-size: 11px;
+          letter-spacing: 0.04em;
+          padding: 4px 10px;
+          background: transparent;
+          color: var(--color-text-secondary, #00dd44);
+          border: 1px solid var(--color-surface-border, #1a3a1a);
+          border-radius: 0;
+          cursor: pointer;
+          min-height: 32px;
+          transition: color 0.15s ease, border-color 0.15s ease, background 0.15s ease;
+        }
+        .editor-cmd-btn:hover:not(:disabled),
+        .editor-cmd-btn:focus-visible {
+          color: var(--color-accent-primary, #00ff41);
+          border-color: var(--color-accent-primary, #00ff41);
+          outline: none;
+        }
+        .editor-cmd-btn-primary {
+          color: var(--color-accent-primary, #00ff41);
+          border-color: var(--color-accent-primary, #00ff41);
+          background: rgba(var(--color-accent-rgb, 0, 255, 65), 0.05);
+        }
+        .editor-cmd-btn-primary:hover:not(:disabled),
+        .editor-cmd-btn-primary:focus-visible {
+          background: rgba(var(--color-accent-rgb, 0, 255, 65), 0.12);
+          box-shadow: 0 0 8px var(--color-accent-glow, rgba(0, 255, 65, 0.25));
+        }
+        @media (pointer: coarse) {
+          .editor-cmd-btn { min-height: 44px; min-width: 88px; }
+        }
+        @media (max-width: 480px) {
+          .editor-cmd-bar { padding: 6px 10px; gap: 8px; }
+        }
         /* Editor body — canvas + optional sidebar at ≥ 900 px.
            Single column below that breakpoint, the shortcuts move
            back behind the "?" tooltip. (#76 sub-task B) */
@@ -564,11 +633,6 @@ export class ArEditor extends HTMLElement {
             <button class="toolbar-btn" id="zoom-fit" aria-label="${t('editor.zoomFit')}">${t('editor.zoomFit')}</button>
           </div>
 
-          <div class="separator"></div>
-
-          <button class="toolbar-btn" id="cancel-btn">${t('editor.cancel')}</button>
-          <button class="toolbar-btn primary" id="done-btn">${t('editor.apply')}</button>
-
           <div class="help-wrap">
             <button class="toolbar-btn" id="help-btn" aria-label="${t('editor.shortcuts')}">?</button>
             <div class="help-tooltip" id="help-tooltip">
@@ -584,6 +648,21 @@ export class ArEditor extends HTMLElement {
           </div>
         </div>
 
+        <!-- Mini command bar above the canvas (#76 sub-task C).
+             Promotes Apply / Cancel out of the generic toolbar row
+             and adds a "$ edit --brush · brush=N · tool=E/R" live
+             status line so the user always knows what Apply will do. -->
+        <div class="editor-cmd-bar">
+          <div class="editor-cmd-left">
+            <span class="editor-cmd-prompt">$</span>
+            <span class="editor-cmd-action">edit --brush</span>
+            <span class="editor-cmd-meta" id="editor-cmd-meta">·&nbsp;brush=${this.brushSize}·&nbsp;tool=E</span>
+          </div>
+          <div class="editor-cmd-right">
+            <button class="editor-cmd-btn" id="cancel-btn">${t('editor.cancel')}</button>
+            <button class="editor-cmd-btn editor-cmd-btn-primary" id="done-btn">${t('editor.apply')}</button>
+          </div>
+        </div>
         <div class="editor-body">
           <div class="canvas-wrap" id="canvas-wrap">
             <canvas id="editor-canvas"></canvas>
@@ -641,6 +720,7 @@ export class ArEditor extends HTMLElement {
     this.shadowRoot!.querySelector('#brush-tool')!.addEventListener('change', (e) => {
       this.tool = (e.target as HTMLSelectElement).value as 'erase' | 'restore';
       this.updateCursor();
+      this.syncCmdBarMeta();
     }, { signal });
 
     this.shadowRoot!.querySelector('#brush-shape')!.addEventListener('change', (e) => {
@@ -655,6 +735,7 @@ export class ArEditor extends HTMLElement {
       this.brushSize = parseInt(sizeInput.value);
       sizeDisplay.textContent = `${this.brushSize}px`;
       this.updateCursor();
+      this.syncCmdBarMeta();
     }, { signal });
 
     // Undo/Redo
@@ -756,6 +837,20 @@ export class ArEditor extends HTMLElement {
     const sizeDisplay = this.shadowRoot!.querySelector('#size-display')!;
     sizeInput.value = String(this.brushSize);
     sizeDisplay.textContent = `${this.brushSize}px`;
+    this.syncCmdBarMeta();
+  }
+
+  /**
+   * Keep the editor command bar's live meta line in sync with the
+   * current brush size + active tool (#76 sub-task C). Called from
+   * every mutation site — tool select, size slider, keyboard [ / ]
+   * shortcut — so the header always matches what Apply will do.
+   */
+  private syncCmdBarMeta(): void {
+    const meta = this.shadowRoot?.querySelector('#editor-cmd-meta');
+    if (!meta) return;
+    const letter = this.tool === 'erase' ? 'E' : 'R';
+    meta.innerHTML = `·&nbsp;brush=${this.brushSize}&nbsp;·&nbsp;tool=${letter}`;
   }
 
   /**

--- a/tests/components/ar-editor-cmd-bar.test.ts
+++ b/tests/components/ar-editor-cmd-bar.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+/**
+ * #76 sub-task C — editor mini command bar source invariants.
+ */
+
+const ROOT = resolve(__dirname, '..', '..');
+const ED = readFileSync(resolve(ROOT, 'src/components/ar-editor.ts'), 'utf8');
+
+describe('ar-editor — mini command bar (#76-C)', () => {
+  it('renders <div class="editor-cmd-bar"> above .editor-body', () => {
+    const rx = /<div class="editor-cmd-bar">[\s\S]*?<div class="editor-body">/;
+    expect(ED).toMatch(rx);
+  });
+
+  it('command bar has prompt + action + live meta + Cancel + Apply', () => {
+    const bar = ED.match(/<div class="editor-cmd-bar">[\s\S]*?<\/div>\s*<div class="editor-body">/);
+    expect(bar).not.toBeNull();
+    expect(bar![0]).toMatch(/class="editor-cmd-prompt">\$</);
+    expect(bar![0]).toMatch(/class="editor-cmd-action">edit --brush</);
+    expect(bar![0]).toMatch(/id="editor-cmd-meta"/);
+    expect(bar![0]).toMatch(/id="cancel-btn"/);
+    expect(bar![0]).toMatch(/id="done-btn"/);
+  });
+
+  it('Apply button uses the primary modifier; Cancel uses the neutral variant', () => {
+    const bar = ED.match(/<div class="editor-cmd-bar">[\s\S]*?<\/div>\s*<div class="editor-body">/);
+    expect(bar).not.toBeNull();
+    expect(bar![0]).toMatch(/class="editor-cmd-btn" id="cancel-btn"/);
+    expect(bar![0]).toMatch(/class="editor-cmd-btn editor-cmd-btn-primary" id="done-btn"/);
+  });
+
+  it('cancel-btn + done-btn removed from the .toolbar block', () => {
+    const m = ED.match(/<div class="toolbar">[\s\S]*?<\/div>\s*<\/div>/);
+    expect(m).not.toBeNull();
+    expect(m![0]).not.toMatch(/id="cancel-btn"/);
+    expect(m![0]).not.toMatch(/id="done-btn"/);
+  });
+
+  it('syncCmdBarMeta keeps the live meta line in sync', () => {
+    expect(ED).toMatch(/private syncCmdBarMeta\(\): void/);
+    // Tool select + size slider + keyboard shortcuts all route through it.
+    expect(ED).toMatch(/#brush-tool[\s\S]*?this\.syncCmdBarMeta\(\)/);
+    expect(ED).toMatch(/sizeInput\.addEventListener\(['"]input['"],[\s\S]*?this\.syncCmdBarMeta\(\)/);
+    expect(ED).toMatch(/updateSizeUI\(\)[\s\S]*?this\.syncCmdBarMeta\(\)/);
+  });
+
+  it('CSS styles command bar buttons with ≥ 44 px min-height on coarse pointers', () => {
+    expect(ED).toMatch(
+      /@media \(pointer: coarse\) \{[\s\S]*?\.editor-cmd-btn \{ min-height: 44px/,
+    );
+  });
+});


### PR DESCRIPTION
## Summary
#76 sub-task **C**. Apply + Cancel leave the flat toolbar and move into a dedicated command bar strip above the canvas: \`\$ edit --brush · brush=N · tool=E/R  [cancel] [apply]\`. Matches the ar-app workspace command bar pattern from #71 so the terminal vocabulary stays consistent.

- New \`<div class="editor-cmd-bar">\` with prompt + action + live meta + Cancel + Apply. Apply uses the accent-primary variant, Cancel the tertiary-neutral.
- \`syncCmdBarMeta()\` keeps the meta in lockstep with tool select, size slider, and [ / ] keyboard shortcut.
- CSS: tokens + 40 px base / 44 px coarse-pointer tap heights.

## Tests
`tests/components/ar-editor-cmd-bar.test.ts`: 6 invariants — bar above body, content rows, Apply primary variant, old toolbar buttons removed, three syncCmdBarMeta call sites, coarse-pointer rule.

Suite: 594 pass / 2 pre-existing `image-io` fails.

## Not in this PR
- Sub-task A: left rail with tool + shape + size
- Sub-task D: mobile bottom sheet

Refs #76.