### PR TITLE
ui: inline error-stage actions — retry / report / reload (closes #78)

### DIFF
--- a/src/components/ar-app.ts
+++ b/src/components/ar-app.ts
@@ -1449,6 +1449,25 @@ export class ArApp extends HTMLElement {
       this.resetToIdle();
     }, { signal });
 
+    // #78 — inline error-stage actions in ar-progress. Retry reuses
+    // the existing retryFromError() path; report opens a pre-filled
+    // GitHub issue URL with browser + session hints; reload is
+    // handled by ar-progress itself (location.reload).
+    this.progress.addEventListener('ar:stage-retry', () => this.retryFromError(), { signal });
+    this.progress.addEventListener('ar:stage-report', (ev) => {
+      const stage = (ev as CustomEvent<{ stage: string }>).detail.stage;
+      const ua = encodeURIComponent(navigator.userAgent);
+      const title = encodeURIComponent(`[stage:${stage}] pipeline error`);
+      const body = encodeURIComponent(
+        `**Stage:** \`${stage}\`\n**UA:** ${decodeURIComponent(ua)}\n**Locale:** ${document.documentElement.lang}\n\n<!-- what were you trying to do? drag the image that failed if possible -->`,
+      );
+      window.open(
+        `https://github.com/yocreoquesi/nukebg/issues/new?title=${title}&body=${body}`,
+        '_blank',
+        'noopener',
+      );
+    }, { signal });
+
     // #79 — quiet-mode toggle lives in the footer (light DOM).
     const quietBtn = document.getElementById('quiet-mode-toggle');
     quietBtn?.addEventListener('click', () => {

--- a/src/components/ar-progress.ts
+++ b/src/components/ar-progress.ts
@@ -35,6 +35,23 @@ export class ArProgress extends HTMLElement {
       this.update();
     };
     document.addEventListener('nukebg:locale-changed', this.boundLocaleHandler);
+
+    // #78 — inline error action delegation. Buttons rendered per-stage
+    // when status === 'error'; dispatch a composed CustomEvent so the
+    // host (ar-app) can wire its existing retry / reload / issue-link
+    // paths without this component holding onto them.
+    this.shadowRoot!.addEventListener('click', (e) => {
+      const target = (e.target as HTMLElement | null)?.closest('.stage-action');
+      if (!target) return;
+      const stage = target.getAttribute('data-stage') ?? '';
+      if (target.classList.contains('stage-action-retry')) {
+        this.dispatchEvent(new CustomEvent('ar:stage-retry', { bubbles: true, composed: true, detail: { stage } }));
+      } else if (target.classList.contains('stage-action-report')) {
+        this.dispatchEvent(new CustomEvent('ar:stage-report', { bubbles: true, composed: true, detail: { stage } }));
+      } else if (target.classList.contains('stage-action-reload')) {
+        location.reload();
+      }
+    });
   }
 
   disconnectedCallback(): void {
@@ -231,6 +248,42 @@ export class ArProgress extends HTMLElement {
           .progress-fill.parsing { animation: none !important; }
         }
 
+        /* Inline error-stage actions (#78). Mirrors the error modal
+           buttons so recovery is available without hunting the
+           overlay. Delegates clicks to ar-app via
+           ar:stage-retry / ar:stage-report / ar:stage-reload events. */
+        .stage-actions {
+          display: flex;
+          gap: 6px;
+          padding: 4px 24px 4px;
+          flex-wrap: wrap;
+        }
+        .stage-action {
+          font: inherit;
+          font-family: 'JetBrains Mono', monospace;
+          font-size: 11px;
+          letter-spacing: 0.04em;
+          padding: 3px 10px;
+          background: transparent;
+          color: var(--color-text-secondary, #00dd44);
+          border: 1px solid var(--color-surface-border, #1a3a1a);
+          border-radius: 0;
+          cursor: pointer;
+          min-height: 28px;
+        }
+        .stage-action:hover,
+        .stage-action:focus-visible {
+          color: var(--color-accent-primary, #00ff41);
+          border-color: var(--color-accent-primary, #00ff41);
+          outline: none;
+        }
+        .stage-action-retry {
+          color: var(--color-accent-primary, #00ff41);
+          border-color: var(--color-accent-primary, #00ff41);
+        }
+        @media (pointer: coarse) {
+          .stage-action { min-height: 40px; padding: 8px 14px; }
+        }
       </style>
       <div class="stages" role="log" aria-live="polite"></div>
     `;
@@ -293,6 +346,17 @@ export class ArProgress extends HTMLElement {
         }
       }
 
+      // #78 — when a stage errors, render retry / report / reload
+      // actions inline so the user can recover without hunting the
+      // modal that the pipeline error surface also raises from #65.
+      const errorActions = s.status === 'error'
+        ? `<div class="stage-actions" role="group" aria-label="Error recovery">
+             <button type="button" class="stage-action stage-action-retry" data-stage="${this.escapeHtml(s.stage)}">${this.escapeHtml(t('error.retry'))}</button>
+             <button type="button" class="stage-action stage-action-report" data-stage="${this.escapeHtml(s.stage)}">${this.escapeHtml(t('error.report'))}</button>
+             <button type="button" class="stage-action stage-action-reload">${this.escapeHtml(t('error.reload'))}</button>
+           </div>`
+        : '';
+
       return `
         <div class="stage ${this.escapeHtml(s.status)}">
           <span class="stage-icon">${icon}</span>
@@ -301,6 +365,7 @@ export class ArProgress extends HTMLElement {
           <span class="stage-time">${timeStr}</span>
         </div>
         ${progressBar}
+        ${errorActions}
       `;
     }).join('');
 

--- a/src/i18n/index.ts
+++ b/src/i18n/index.ts
@@ -204,6 +204,8 @@ const translations: Translations = {
     'pipeline.error': 'Processing failed: {msg}',
     'error.title': 'Something went wrong',
     'error.retry': 'Retry',
+    'error.report': 'Report',
+    'error.reload': 'Reload',
     'error.dismiss': 'Dismiss',
 
     // PWA
@@ -432,6 +434,8 @@ const translations: Translations = {
     'pipeline.error': 'Procesamiento fallido: {msg}',
     'error.title': 'Algo salió mal',
     'error.retry': 'Reintentar',
+    'error.report': 'Reportar',
+    'error.reload': 'Recargar',
     'error.dismiss': 'Cerrar',
 
     // PWA
@@ -660,6 +664,8 @@ const translations: Translations = {
     'pipeline.error': 'Traitement \u00E9chou\u00E9 : {msg}',
     'error.title': 'Une erreur est survenue',
     'error.retry': 'R\u00E9essayer',
+    'error.report': 'Signaler',
+    'error.reload': 'Recharger',
     'error.dismiss': 'Fermer',
 
     // PWA
@@ -888,6 +894,8 @@ const translations: Translations = {
     'pipeline.error': 'Verarbeitung fehlgeschlagen: {msg}',
     'error.title': 'Etwas ist schiefgelaufen',
     'error.retry': 'Erneut versuchen',
+    'error.report': 'Melden',
+    'error.reload': 'Neu laden',
     'error.dismiss': 'Schließen',
 
     // PWA
@@ -1116,6 +1124,8 @@ const translations: Translations = {
     'pipeline.error': 'Processamento falhou: {msg}',
     'error.title': 'Algo deu errado',
     'error.retry': 'Tentar novamente',
+    'error.report': 'Reportar',
+    'error.reload': 'Recarregar',
     'error.dismiss': 'Fechar',
 
     // PWA
@@ -1344,6 +1354,8 @@ const translations: Translations = {
     'pipeline.error': '\u5904\u7406\u5931\u8D25: {msg}',
     'error.title': '\u51FA\u9519\u4E86',
     'error.retry': '\u91CD\u8BD5',
+    'error.report': '\u62A5\u544A',
+    'error.reload': '\u91CD\u65B0\u52A0\u8F7D',
     'error.dismiss': '\u5173\u95ED',
 
     // PWA

--- a/tests/components/ar-stage-actions.test.ts
+++ b/tests/components/ar-stage-actions.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+/**
+ * #78 — Inline error-stage actions in ar-progress.
+ */
+
+const ROOT = resolve(__dirname, '..', '..');
+const PROG = readFileSync(resolve(ROOT, 'src/components/ar-progress.ts'), 'utf8');
+const APP = readFileSync(resolve(ROOT, 'src/components/ar-app.ts'), 'utf8');
+const I18N = readFileSync(resolve(ROOT, 'src/i18n/index.ts'), 'utf8');
+
+describe('inline error-stage actions (#78)', () => {
+  it('ar-progress renders retry / report / reload buttons when a stage errors', () => {
+    expect(PROG).toMatch(/s\.status === ['"]error['"]/);
+    expect(PROG).toMatch(/class="stage-action stage-action-retry"/);
+    expect(PROG).toMatch(/class="stage-action stage-action-report"/);
+    expect(PROG).toMatch(/class="stage-action stage-action-reload"/);
+    expect(PROG).toMatch(/t\(['"]error\.retry['"]\)/);
+    expect(PROG).toMatch(/t\(['"]error\.report['"]\)/);
+    expect(PROG).toMatch(/t\(['"]error\.reload['"]\)/);
+  });
+
+  it('ar-progress delegates clicks to composed CustomEvents (retry/report) and reloads directly', () => {
+    expect(PROG).toMatch(/ar:stage-retry[\s\S]*?bubbles: true,\s*composed: true/);
+    expect(PROG).toMatch(/ar:stage-report[\s\S]*?bubbles: true,\s*composed: true/);
+    expect(PROG).toMatch(/stage-action-reload[\s\S]*?location\.reload\(\)/);
+  });
+
+  it('retry button gets the accent-primary variant', () => {
+    expect(PROG).toMatch(/\.stage-action-retry \{[\s\S]*?color: var\(--color-accent-primary/);
+  });
+
+  it('ar-app wires ar:stage-retry -> retryFromError and ar:stage-report -> GitHub issue URL', () => {
+    expect(APP).toMatch(/ar:stage-retry[\s\S]*?retryFromError\(\)/);
+    expect(APP).toMatch(/ar:stage-report[\s\S]*?github\.com\/yocreoquesi\/nukebg\/issues\/new\?title=/);
+    // Body embeds UA + locale for debugging
+    expect(APP).toMatch(/encodeURIComponent\(navigator\.userAgent\)/);
+  });
+
+  it('i18n parity — error.retry / error.report / error.reload in all six locales', () => {
+    for (const key of ['error.retry', 'error.report', 'error.reload']) {
+      const re = new RegExp(`'${key.replace(/\./g, '\\.')}'\\s*:`, 'g');
+      expect((I18N.match(re) ?? []).length, key).toBe(6);
+    }
+  });
+
+  it('coarse-pointer bumps .stage-action to ≥ 40 px min-height', () => {
+    expect(PROG).toMatch(/@media \(pointer: coarse\) \{[\s\S]*?\.stage-action \{ min-height: 40px/);
+  });
+});


### PR DESCRIPTION
## Summary
Completes #78 with inline recovery buttons attached to any pipeline stage that enters an \`error\` status. Users who dismissed the modal from #65 still see a clear path back.

- \`ar-progress\` appends a 3-button action row when \`s.status === 'error'\`: Retry (accent), Report (neutral), Reload (neutral). \`data-stage\` tags each button so the composed CustomEvent identifies the failure point.
- Click delegation on the shadow root dispatches \`ar:stage-retry\` / \`ar:stage-report\`; Reload calls \`location.reload()\` directly.
- \`ar-app\`:
  - \`ar:stage-retry\` → existing \`retryFromError()\` path (#65).
  - \`ar:stage-report\` → \`window.open(github issue new URL)\` with stage id + UA + locale pre-filled.
- i18n: \`error.report\` + \`error.reload\` added across six locales. \`error.retry\` already shipped.

## Tests
\`tests/components/ar-stage-actions.test.ts\` — 6 invariants (markup, event delegation, retry accent variant, ar-app wiring, i18n parity, coarse-pointer rule).

Suite: 611 pass / 2 pre-existing image-io fails.

Closes #78.