### PR TITLE
ui: editor basic — left rail at ≥ 900 px (partial #76)

### DIFF
--- a/src/components/ar-editor.ts
+++ b/src/components/ar-editor.ts
@@ -381,8 +381,55 @@ export class ArEditor extends HTMLElement {
         }
         @media (min-width: 900px) {
           .editor-body {
-            grid-template-columns: minmax(0, 1fr) 260px;
+            grid-template-columns: 200px minmax(0, 1fr) 260px;
           }
+        }
+        /* Left rail (#76 sub-task A). Vertical column at ≥ 900 px,
+           horizontal strip below so mobile keeps single-row flow. */
+        .editor-rail {
+          display: flex;
+          flex-wrap: wrap;
+          gap: 10px;
+          padding: 12px;
+          border: 1px solid var(--color-surface-border, #1a3a1a);
+          background: var(--color-bg-primary, #000);
+          font-family: 'JetBrains Mono', monospace;
+          font-size: 12px;
+          align-content: start;
+        }
+        @media (min-width: 900px) {
+          .editor-rail {
+            flex-direction: column;
+            flex-wrap: nowrap;
+          }
+        }
+        .editor-rail-group {
+          display: flex;
+          flex-direction: column;
+          gap: 4px;
+          min-width: 0;
+        }
+        .editor-rail-label {
+          color: var(--color-text-tertiary, #00b34a);
+          font-size: 11px;
+          letter-spacing: 0.04em;
+          text-transform: uppercase;
+        }
+        .editor-rail-select,
+        .editor-rail-range {
+          font-family: inherit;
+          font-size: 12px;
+          color: var(--color-accent-primary, #00ff41);
+          background: var(--color-bg-primary, #000);
+          border: 1px solid var(--color-surface-border, #1a3a1a);
+          border-radius: 0;
+          padding: 4px 6px;
+          cursor: pointer;
+          accent-color: var(--color-accent-primary, #00ff41);
+        }
+        .editor-rail-range { padding: 0; }
+        @media (pointer: coarse) {
+          .editor-rail-select { min-height: 44px; }
         }
         .editor-sidebar {
           display: none;
@@ -605,24 +652,6 @@ export class ArEditor extends HTMLElement {
 
       <div class="editor-container">
         <div class="toolbar">
-          <label id="ed-tool-label">${t('editor.tool')}</label>
-          <select id="brush-tool" aria-label="${t('editor.tool')}">
-            <option value="erase" selected>${t('editor.eraser')}</option>
-            <option value="restore">${t('editor.restore')}</option>
-          </select>
-
-          <label id="ed-brush-label">${t('editor.shape')}</label>
-          <select id="brush-shape" aria-label="${t('editor.shape')}">
-            <option value="circle" selected>${t('editor.eraserCircle')}</option>
-            <option value="square">${t('editor.eraserSquare')}</option>
-          </select>
-
-          <label id="ed-size-label">${t('editor.eraserSize')}</label>
-          <input type="range" id="brush-size" min="2" max="100" value="20" aria-label="${t('editor.eraserSize')}">
-          <span class="size-display" id="size-display">20px</span>
-
-          <div class="separator"></div>
-
           <button class="toolbar-btn" id="undo-btn" disabled aria-label="${t('editor.undo')}">${t('editor.undo')}</button>
           <button class="toolbar-btn" id="redo-btn" disabled aria-label="${t('editor.redo')}">${t('editor.redo')}</button>
 
@@ -664,6 +693,31 @@ export class ArEditor extends HTMLElement {
           </div>
         </div>
         <div class="editor-body">
+          <!-- Left rail (#76 sub-task A). At ≥ 900 px it stacks
+               tool + shape + size vertically next to the canvas.
+               Below 900 px it flattens to a horizontal row above
+               the canvas, keeping the controls reachable on mobile. -->
+          <aside class="editor-rail" aria-label="${t('editor.tool')}">
+            <div class="editor-rail-group">
+              <label id="ed-tool-label" class="editor-rail-label">${t('editor.tool')}</label>
+              <select id="brush-tool" class="editor-rail-select" aria-label="${t('editor.tool')}">
+                <option value="erase" selected>${t('editor.eraser')}</option>
+                <option value="restore">${t('editor.restore')}</option>
+              </select>
+            </div>
+            <div class="editor-rail-group">
+              <label id="ed-brush-label" class="editor-rail-label">${t('editor.shape')}</label>
+              <select id="brush-shape" class="editor-rail-select" aria-label="${t('editor.shape')}">
+                <option value="circle" selected>${t('editor.eraserCircle')}</option>
+                <option value="square">${t('editor.eraserSquare')}</option>
+              </select>
+            </div>
+            <div class="editor-rail-group">
+              <label id="ed-size-label" class="editor-rail-label">${t('editor.eraserSize')}</label>
+              <input type="range" id="brush-size" class="editor-rail-range" min="2" max="100" value="20" aria-label="${t('editor.eraserSize')}">
+              <span class="size-display" id="size-display">20px</span>
+            </div>
+          </aside>
           <div class="canvas-wrap" id="canvas-wrap">
             <canvas id="editor-canvas"></canvas>
             <div class="touch-indicator" id="touch-indicator"></div>

--- a/tests/components/ar-editor-rail.test.ts
+++ b/tests/components/ar-editor-rail.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+/**
+ * #76 sub-task A — editor basic left rail invariants.
+ */
+
+const ROOT = resolve(__dirname, '..', '..');
+const ED = readFileSync(resolve(ROOT, 'src/components/ar-editor.ts'), 'utf8');
+
+describe('ar-editor — left rail (#76-A)', () => {
+  it('renders <aside class="editor-rail"> with three groups (tool / shape / size)', () => {
+    expect(ED).toMatch(/<aside class="editor-rail"/);
+    const m = ED.match(/<aside class="editor-rail"[\s\S]*?<\/aside>/);
+    expect(m).not.toBeNull();
+    expect(m![0]).toMatch(/id="brush-tool"/);
+    expect(m![0]).toMatch(/id="brush-shape"/);
+    expect(m![0]).toMatch(/id="brush-size"/);
+    // Three .editor-rail-group containers
+    const groups = m![0].match(/class="editor-rail-group"/g) ?? [];
+    expect(groups.length).toBe(3);
+  });
+
+  it('the .toolbar no longer carries tool / shape / size controls (moved to rail)', () => {
+    const tb = ED.match(/<div class="toolbar">[\s\S]*?<\/div>\s*<!-- Mini command/);
+    expect(tb).not.toBeNull();
+    expect(tb![0]).not.toMatch(/id="brush-tool"/);
+    expect(tb![0]).not.toMatch(/id="brush-shape"/);
+    expect(tb![0]).not.toMatch(/id="brush-size"/);
+  });
+
+  it('CSS flattens the rail to a horizontal strip below 900 px and stacks it vertically at/over', () => {
+    // Default (mobile): flex-direction wraps via flex-wrap
+    expect(ED).toMatch(/\.editor-rail \{[\s\S]*?flex-wrap: wrap/);
+    // Desktop: flex-direction: column
+    expect(ED).toMatch(
+      /@media \(min-width: 900px\) \{[\s\S]*?\.editor-rail \{[\s\S]*?flex-direction: column/,
+    );
+  });
+
+  it('grid goes 3-col at ≥ 900 px (rail | canvas | sidebar)', () => {
+    expect(ED).toMatch(
+      /@media \(min-width: 900px\) \{[\s\S]*?\.editor-body \{[\s\S]*?grid-template-columns: 200px minmax\(0, 1fr\) 260px/,
+    );
+  });
+
+  it('coarse-pointer rule bumps rail selects to ≥ 44 px', () => {
+    expect(ED).toMatch(
+      /@media \(pointer: coarse\) \{[\s\S]*?\.editor-rail-select \{ min-height: 44px/,
+    );
+  });
+});

--- a/tests/components/ar-editor-sidebar.test.ts
+++ b/tests/components/ar-editor-sidebar.test.ts
@@ -48,10 +48,12 @@ describe('ar-editor — permanent shortcuts sidebar (#76-B)', () => {
     );
   });
 
-  it('.editor-body becomes a 2-col grid at ≥ 900 px', () => {
+  it('.editor-body becomes a multi-col grid at ≥ 900 px', () => {
     expect(ED).toMatch(/\.editor-body \{[\s\S]*?display: grid/);
+    // Sub-task A added a left rail so the grid is now 3-col
+    // (200 px rail | fluid canvas | 260 px sidebar) instead of 2-col.
     expect(ED).toMatch(
-      /@media \(min-width: 900px\) \{[\s\S]*?\.editor-body \{[\s\S]*?grid-template-columns: minmax\(0, 1fr\) 260px/,
+      /@media \(min-width: 900px\) \{[\s\S]*?\.editor-body \{[\s\S]*?grid-template-columns: 200px minmax\(0, 1fr\) 260px/,
     );
   });
 });


### PR DESCRIPTION
## Summary
#76 sub-task **A**. Brush tool / shape / size leave the single-row toolbar and move into a dedicated \`<aside class="editor-rail">\` at the left of the canvas. Combined with sub-tasks B (right shortcuts sidebar) and C (top command bar), the editor now has the three-column desktop layout the design proposal asked for: **rail · canvas · sidebar** at 200 px · 1fr · 260 px.

- Below 900 px the rail flattens to a horizontal strip with \`flex-wrap\` so mobile flow stays single-row. No duplicate markup.
- \`.toolbar\` keeps undo / redo / zoom / help so it still serves as the secondary control strip on all viewports.
- Labels use the existing tertiary token, controls the accent-primary; coarse-pointer rule lifts selects to 44 px.

## Tests
- New: \`tests/components/ar-editor-rail.test.ts\` (5 invariants — rail markup + 3 groups, toolbar cleanup, flatten-at-narrow, 3-col grid, coarse-pointer rule).
- Updated: sidebar test's grid assertion (2-col → 3-col with explicit 200 px rail).
- Suite: 617 pass / 2 pre-existing image-io fails.

## #76 remaining
Only sub-task **D** (mobile bottom sheet) is left open.

Refs #76.