### PR TITLE
ui: prefers-reduced-motion audit across animations (partial #35)

### DIFF
--- a/src/components/ar-editor-advanced.ts
+++ b/src/components/ar-editor-advanced.ts
@@ -739,6 +739,15 @@ export class ArEditorAdvanced extends HTMLElement {
           to { opacity: 1; transform: translateY(0); }
         }
 
+        /* #35 — honor prefers-reduced-motion on any JS/CSS anim that
+           ar-editor-advanced owns. Keeps hint-pulse + confirmFadeIn
+           from firing for users who opted out of motion effects. */
+        @media (prefers-reduced-motion: reduce) {
+          .hint { animation: none !important; }
+          .confirm-bar,
+          .confirm-bar.visible { animation: none !important; }
+        }
+
         @media (pointer: coarse) {
           .toolbar {
             position: fixed;

--- a/src/components/ar-viewer.ts
+++ b/src/components/ar-viewer.ts
@@ -420,8 +420,11 @@ export class ArViewer extends HTMLElement {
     this.resultCanvas.height = imageData.height;
     ctx.putImageData(imageData, 0, 0);
 
-    // Animate slider reveal (respect prefers-reduced-motion)
-    if (window.matchMedia('(prefers-reduced-motion: reduce)').matches) {
+    // Animate slider reveal. Skip if either OS reports reduced-motion
+    // OR the user has toggled quiet mode via the footer (#79).
+    const reducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+    const quietMode = document.documentElement.dataset.playful === 'false';
+    if (reducedMotion || quietMode) {
       this.sliderPos = 0;
       this.updateSlider();
     } else {

--- a/tests/components/reduced-motion-audit.test.ts
+++ b/tests/components/reduced-motion-audit.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+/**
+ * #35 — Ensure every component that ships an animation (@keyframes in
+ * its inline <style>) also carries a `prefers-reduced-motion: reduce`
+ * guard that turns it off, and that the viewer's JS-driven slider
+ * reveal respects both reduced-motion and the user-toggled quiet mode.
+ */
+
+const ROOT = resolve(__dirname, '..', '..');
+const COMPONENTS = [
+  'ar-app.ts',
+  'ar-editor.ts',
+  'ar-editor-advanced.ts',
+  'ar-dropzone.ts',
+  'ar-batch-item.ts',
+  'ar-progress.ts',
+  'ar-viewer.ts',
+];
+
+describe('reduced-motion audit (#35)', () => {
+  for (const f of COMPONENTS) {
+    const src = readFileSync(resolve(ROOT, 'src/components', f), 'utf8');
+    it(`${f}: every @keyframes owner has a prefers-reduced-motion guard`, () => {
+      const hasKeyframes = /@keyframes/.test(src);
+      if (!hasKeyframes) return;
+      expect(src, `${f} declares keyframes but no prefers-reduced-motion guard`).toMatch(
+        /@media \(prefers-reduced-motion: reduce\)/,
+      );
+    });
+  }
+
+  it('ar-viewer slider reveal skips when reduced-motion OR quiet-mode is active', () => {
+    const v = readFileSync(resolve(ROOT, 'src/components/ar-viewer.ts'), 'utf8');
+    expect(v).toMatch(/matchMedia\(['"]\(prefers-reduced-motion: reduce\)['"]\)/);
+    expect(v).toMatch(/document\.documentElement\.dataset\.playful === ['"]false['"]/);
+    expect(v).toMatch(/if \(reducedMotion \|\| quietMode\)/);
+  });
+
+  it('ar-app defaults data-playful="false" when OS reports reduced-motion', () => {
+    const a = readFileSync(resolve(ROOT, 'src/components/ar-app.ts'), 'utf8');
+    expect(a).toMatch(
+      /reducedMotion = window\.matchMedia\(['"]\(prefers-reduced-motion: reduce\)['"]\)/,
+    );
+    expect(a).toMatch(/dataset\.playful = reducedMotion \? ['"]false['"] : ['"]true['"]/);
+  });
+
+  it('ar-editor-advanced gates hint-pulse + confirmFadeIn under reduced-motion', () => {
+    const e = readFileSync(resolve(ROOT, 'src/components/ar-editor-advanced.ts'), 'utf8');
+    expect(e).toMatch(
+      /@media \(prefers-reduced-motion: reduce\) \{[\s\S]*?\.hint \{ animation: none/,
+    );
+    expect(e).toMatch(
+      /@media \(prefers-reduced-motion: reduce\) \{[\s\S]*?\.confirm-bar[\s\S]*?animation: none/,
+    );
+  });
+});


### PR DESCRIPTION
## Summary
Completes reduced-motion coverage for every animation-owning component.

- **ar-editor-advanced.ts**: added a \`@media (prefers-reduced-motion: reduce)\` block that disables \`hint-pulse\` + \`confirmFadeIn\`. Were the only two keyframes shipping without a guard.
- **ar-viewer.ts**: slider reveal checks both \`prefers-reduced-motion\` AND the footer quiet-mode (\`data-playful === 'false'\`), so user-toggled quiet mode stops JS animation even on engines that don't report reduced-motion.

## Tests
\`tests/components/reduced-motion-audit.test.ts\` — 10 invariants auditing every component for `@keyframes`/reduced-motion parity, the viewer's dual-gate, and the boot priority from #79.

Suite: 622 pass / 2 pre-existing image-io fails.

## #35 remaining
- Keyboard navigation on canvas surfaces.
- aria-live error regions.

Both require UX passes, not mechanical guards; deferred.

Refs #35.