### PR TITLE
feat(a11y): global keyboard shortcuts + ? hint overlay

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -35,24 +35,116 @@ function initKeyboardShortcuts(): void {
     toastTimeout = setTimeout(() => toast.classList.remove('visible'), 1800);
   };
 
+  // Global shortcut overlay: lists every shortcut the app exposes.
+  // Toggled by `?`, dismissed by Escape or overlay click. Lives in
+  // light DOM so it sits on top of every shadow tree without z-index
+  // wars.
+  const overlay = createShortcutOverlay();
+  document.body.appendChild(overlay);
+  const openOverlay = () => { overlay.hidden = false; overlay.focus(); };
+  const closeOverlay = () => { overlay.hidden = true; };
+  overlay.addEventListener('click', (e) => {
+    if (e.target === overlay) closeOverlay();
+  });
+  overlay.querySelector<HTMLButtonElement>('[data-close]')?.addEventListener('click', closeOverlay);
+
+  /** True when the user is typing in an input / textarea / contenteditable. */
+  const inFormField = (el: EventTarget | null): boolean => {
+    const n = el as HTMLElement | null;
+    if (!n) return false;
+    if (n.isContentEditable) return true;
+    const tag = n.tagName?.toLowerCase();
+    return tag === 'input' || tag === 'textarea' || tag === 'select';
+  };
+
   document.addEventListener('keydown', (e: KeyboardEvent) => {
     const ctrl = e.ctrlKey || e.metaKey;
 
     // Ctrl+S: download result
     if (ctrl && e.key === 's') {
       e.preventDefault();
-      // Find the download link in ar-download shadow DOM
       const arApp = document.querySelector('ar-app');
       if (!arApp?.shadowRoot) return;
       const arDownload = arApp.shadowRoot.querySelector('ar-download');
       if (!arDownload?.shadowRoot) return;
-      const link = arDownload.shadowRoot.querySelector('#download-btn') as HTMLAnchorElement | null;
-      if (link?.hasAttribute('href')) {
+      // #72 — primary download is now the PNG anchor in dl-png.
+      const link = arDownload.shadowRoot.querySelector('#dl-png') as HTMLAnchorElement | null;
+      if (link && !link.hidden && link.hasAttribute('href')) {
         link.click();
-        showToast('Downloading result...');
+        showToast('Downloading PNG...');
       }
+      return;
+    }
+
+    // Skip rest of global shortcuts while the user is typing.
+    if (inFormField(e.target)) return;
+
+    // `/` focus the dropzone file picker so keyboard users can drop
+    // a file without tabbing through the header every time.
+    if (e.key === '/') {
+      const arApp = document.querySelector('ar-app');
+      const dz = arApp?.shadowRoot?.querySelector('ar-dropzone');
+      const target = dz?.shadowRoot?.querySelector('.dropzone') as HTMLElement | null;
+      if (target) {
+        e.preventDefault();
+        target.focus();
+        showToast('Drop an image or press Enter to browse');
+      }
+      return;
+    }
+
+    // `?` toggles the shortcut overlay (Shift+/ in most layouts).
+    if (e.key === '?' || (e.shiftKey && e.key === '?')) {
+      e.preventDefault();
+      overlay.hidden ? openOverlay() : closeOverlay();
+      return;
+    }
+
+    // `Escape`: if overlay is open, close it. Otherwise let the
+    // shadow-root handlers process it (progress cancel, editor close,
+    // etc).
+    if (e.key === 'Escape' && !overlay.hidden) {
+      e.preventDefault();
+      closeOverlay();
     }
   });
+}
+
+/**
+ * Build the app-level shortcut help overlay. Not an ar-app component
+ * because it needs to sit above every shadow tree (viewer, editor,
+ * error modal) regardless of its stacking context.
+ */
+function createShortcutOverlay(): HTMLDivElement {
+  const overlay = document.createElement('div');
+  overlay.className = 'kbd-overlay';
+  overlay.hidden = true;
+  overlay.tabIndex = -1;
+  overlay.setAttribute('role', 'dialog');
+  overlay.setAttribute('aria-modal', 'true');
+  overlay.setAttribute('aria-label', 'Keyboard shortcuts');
+  overlay.innerHTML = `
+    <div class="kbd-overlay-card">
+      <h2 class="kbd-overlay-title"># keyboard shortcuts</h2>
+      <dl class="kbd-overlay-list">
+        <dt><kbd>/</kbd></dt><dd>Focus the drop zone</dd>
+        <dt><kbd>Ctrl</kbd>+<kbd>S</kbd></dt><dd>Download PNG result</dd>
+        <dt><kbd>Ctrl</kbd>+<kbd>V</kbd></dt><dd>Paste image from clipboard</dd>
+        <dt><kbd>Esc</kbd></dt><dd>Cancel current action · close dialogs</dd>
+        <dt><kbd>?</kbd></dt><dd>Toggle this panel</dd>
+      </dl>
+      <h3 class="kbd-overlay-sub"># editor</h3>
+      <dl class="kbd-overlay-list">
+        <dt><kbd>B</kbd> / <kbd>E</kbd></dt><dd>Brush · Eraser</dd>
+        <dt><kbd>[</kbd> / <kbd>]</kbd></dt><dd>Brush size −/+</dd>
+        <dt><kbd>0</kbd></dt><dd>Reset view</dd>
+        <dt><kbd>Ctrl</kbd>+<kbd>Z</kbd></dt><dd>Undo</dd>
+        <dt><kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>Z</kbd></dt><dd>Redo</dd>
+      </dl>
+      <button type="button" class="kbd-overlay-close" data-close>close</button>
+    </div>
+  `;
+  return overlay;
 }
 
 // === Easter Egg: Console ASCII Logo ===

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -661,6 +661,84 @@ body::after {
   transform: translateY(0);
 }
 
+/* === Keyboard shortcuts overlay ===
+   Light-DOM modal — must sit above every shadow tree, so it can't live
+   inside ar-app. Terminal-green card, Esc / overlay-click to dismiss. */
+.kbd-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.75);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: var(--space-4);
+  z-index: 10000;
+}
+.kbd-overlay[hidden] { display: none; }
+.kbd-overlay-card {
+  background: #0a0a0a;
+  border: 1px solid var(--color-accent-primary, #00ff41);
+  color: var(--color-accent-primary, #00ff41);
+  font-family: var(--font-mono);
+  font-size: var(--text-sm);
+  padding: var(--space-5) var(--space-5) var(--space-4);
+  max-width: 480px;
+  width: 100%;
+  max-height: 90vh;
+  overflow-y: auto;
+  box-shadow: var(--shadow-lg);
+}
+.kbd-overlay-title {
+  font-size: var(--text-base);
+  margin: 0 0 var(--space-4);
+  letter-spacing: 0.04em;
+}
+.kbd-overlay-sub {
+  font-size: var(--text-sm);
+  margin: var(--space-4) 0 var(--space-2);
+  letter-spacing: 0.04em;
+  opacity: 0.85;
+}
+.kbd-overlay-list {
+  display: grid;
+  grid-template-columns: max-content 1fr;
+  gap: var(--space-2) var(--space-4);
+  margin: 0;
+}
+.kbd-overlay-list dt {
+  white-space: nowrap;
+  display: flex;
+  align-items: center;
+  gap: 4px;
+}
+.kbd-overlay-list dd { margin: 0; opacity: 0.9; }
+.kbd-overlay-list kbd {
+  display: inline-block;
+  padding: 1px 6px;
+  border: 1px solid var(--color-surface-border, #1a3a1a);
+  border-radius: 2px;
+  background: #000;
+  font-family: var(--font-mono);
+  font-size: 0.85em;
+  line-height: 1.2;
+}
+.kbd-overlay-close {
+  margin-top: var(--space-4);
+  background: transparent;
+  border: 1px solid var(--color-accent-primary, #00ff41);
+  color: var(--color-accent-primary, #00ff41);
+  font-family: var(--font-mono);
+  font-size: var(--text-sm);
+  padding: var(--space-2) var(--space-4);
+  cursor: pointer;
+}
+.kbd-overlay-close:hover,
+.kbd-overlay-close:focus-visible {
+  background: var(--color-accent-primary, #00ff41);
+  color: #000;
+  outline: none;
+}
+
 /* === Smoke overlay (Full Nuke mode) === */
 .smoke-overlay {
   display: none;

--- a/tests/components/kbd-shortcuts.test.ts
+++ b/tests/components/kbd-shortcuts.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+/**
+ * Source invariants for the global keyboard shortcut layer in
+ * src/main.ts — the `/` focus-dropzone binding, `?` overlay toggle,
+ * Esc dismiss, and the Ctrl+S download path that must target the
+ * post-#72 `#dl-png` anchor (not the legacy `#download-btn`).
+ */
+
+const ROOT = resolve(__dirname, '..', '..');
+const MAIN = readFileSync(resolve(ROOT, 'src/main.ts'), 'utf8');
+const CSS = readFileSync(resolve(ROOT, 'src/styles/main.css'), 'utf8');
+
+describe('global keyboard shortcuts (src/main.ts)', () => {
+  it('initKeyboardShortcuts is declared and invoked at bootstrap', () => {
+    expect(MAIN).toMatch(/function initKeyboardShortcuts\(\): void/);
+    expect(MAIN).toMatch(/^\s*initKeyboardShortcuts\(\);\s*$/m);
+  });
+
+  it('creates and mounts the shortcut overlay on document.body', () => {
+    expect(MAIN).toMatch(/function createShortcutOverlay\(\): HTMLDivElement/);
+    expect(MAIN).toMatch(/document\.body\.appendChild\(overlay\)/);
+    expect(MAIN).toMatch(/overlay\.className = ['"]kbd-overlay['"]/);
+    expect(MAIN).toMatch(/role['"],\s*['"]dialog['"]/);
+    expect(MAIN).toMatch(/aria-modal['"],\s*['"]true['"]/);
+  });
+
+  it('Ctrl+S targets the post-#72 #dl-png anchor, not the legacy #download-btn', () => {
+    expect(MAIN).toMatch(/#dl-png/);
+    expect(MAIN).not.toMatch(/#download-btn/);
+  });
+
+  it('`/` focuses ar-dropzone .dropzone', () => {
+    expect(MAIN).toMatch(/e\.key === ['"]\/['"]/);
+    expect(MAIN).toMatch(/querySelector\(['"]ar-dropzone['"]\)/);
+    expect(MAIN).toMatch(/querySelector\(['"]\.dropzone['"]\)/);
+  });
+
+  it('`?` toggles the overlay and Esc closes it', () => {
+    expect(MAIN).toMatch(/e\.key === ['"]\?['"]/);
+    expect(MAIN).toMatch(/overlay\.hidden \? openOverlay\(\) : closeOverlay\(\)/);
+    expect(MAIN).toMatch(/e\.key === ['"]Escape['"] && !overlay\.hidden/);
+  });
+
+  it('skips non-ctrl bindings when the user is typing in a form field', () => {
+    expect(MAIN).toMatch(/const inFormField = /);
+    expect(MAIN).toMatch(/isContentEditable/);
+    expect(MAIN).toMatch(/if \(inFormField\(e\.target\)\) return;/);
+  });
+
+  it('overlay cheat-sheet lists every global + editor binding', () => {
+    for (const k of ['/', 'Ctrl', 'Esc', '\\?', 'B', 'E', '\\[', '\\]', '0', 'Z']) {
+      expect(MAIN).toMatch(new RegExp(`<kbd>${k}</kbd>`));
+    }
+  });
+
+  it('main.css defines .kbd-overlay with a high z-index so it sits over every shadow tree', () => {
+    expect(CSS).toMatch(/\.kbd-overlay \{[\s\S]*?position: fixed;[\s\S]*?z-index:\s*10000;/);
+    expect(CSS).toMatch(/\.kbd-overlay\[hidden\] \{ display: none; \}/);
+    expect(CSS).toMatch(/\.kbd-overlay-card \{/);
+    expect(CSS).toMatch(/\.kbd-overlay-close \{/);
+  });
+});


### PR DESCRIPTION
## Summary
- `/` focuses the dropzone so keyboard users can drop straight in
- `?` toggles a light-DOM cheat-sheet overlay (sits above every shadow tree)
- Esc / click-outside / close-button all dismiss the overlay
- `inFormField()` skips bindings while typing in inputs/textareas
- `Ctrl+S` now targets the post-#72 \`#dl-png\` anchor instead of the legacy \`#download-btn\`

## Why
Closes a major a11y / discoverability gap: existing per-editor shortcuts were invisible to new users, and there was no fast keyboard path from cold page to an image upload.

## Test plan
- [x] \`vitest run tests/components/kbd-shortcuts.test.ts\` — 8/8 pass
- [x] Full suite: 640 passing, 2 pre-existing image-io failures unchanged
- [ ] Manual: press \`?\` on the homepage → overlay appears, Esc closes
- [ ] Manual: press \`/\` on the homepage → dropzone focused, toast shows
- [ ] Manual: after processing → Ctrl+S downloads the PNG result