### PR TITLE
feat(pwa): shortcuts + launch_handler + deep-link handler

### DIFF
--- a/public/manifest.webmanifest
+++ b/public/manifest.webmanifest
@@ -1,18 +1,46 @@
 {
+  "id": "/",
   "name": "NukeBG: Nuke Any Background",
   "short_name": "NukeBG",
   "description": "Remove backgrounds from any image. 100% private, runs in your browser. Free, open source.",
   "start_url": "/",
   "scope": "/",
+  "lang": "en",
+  "dir": "ltr",
   "display": "standalone",
+  "display_override": ["window-controls-overlay", "standalone", "minimal-ui"],
   "background_color": "#000000",
   "theme_color": "#000000",
   "orientation": "any",
   "categories": ["graphics", "utilities", "photo"],
+  "prefer_related_applications": false,
+  "handle_links": "preferred",
+  "launch_handler": {
+    "client_mode": ["focus-existing", "auto"]
+  },
+  "edge_side_panel": {
+    "preferred_width": 480
+  },
   "icons": [
     { "src": "/favicon.svg", "sizes": "any", "type": "image/svg+xml" },
     { "src": "/icon-192.png", "sizes": "192x192", "type": "image/png" },
     { "src": "/icon-512.png", "sizes": "512x512", "type": "image/png" },
     { "src": "/icon-512-maskable.png", "sizes": "512x512", "type": "image/png", "purpose": "maskable" }
+  ],
+  "shortcuts": [
+    {
+      "name": "New image",
+      "short_name": "New",
+      "description": "Drop a new image to nuke its background",
+      "url": "/?action=new",
+      "icons": [{ "src": "/icon-192.png", "sizes": "192x192", "type": "image/png" }]
+    },
+    {
+      "name": "Keyboard shortcuts",
+      "short_name": "Shortcuts",
+      "description": "Show the full keyboard shortcut cheat-sheet",
+      "url": "/?help=1",
+      "icons": [{ "src": "/icon-192.png", "sizes": "192x192", "type": "image/png" }]
+    }
   ]
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -845,6 +845,35 @@ function initShareButton(): void {
   });
 }
 
+/**
+ * Handle PWA manifest shortcut deep-links:
+ *   /?help=1     → open the keyboard shortcut overlay
+ *   /?action=new → focus the dropzone so the user can start immediately
+ * Re-dispatches the matching keyboard event so the shortcut layer stays
+ * the single source of truth for open/close state and focus behavior.
+ */
+function initDeepLinks(): void {
+  const params = new URLSearchParams(window.location.search);
+  if (!params.has('help') && !params.has('action')) return;
+
+  const waitForArApp = (onReady: () => void, tries = 20) => {
+    const arApp = document.querySelector('ar-app');
+    if (arApp?.shadowRoot) return onReady();
+    if (tries <= 0) return;
+    setTimeout(() => waitForArApp(onReady, tries - 1), 50);
+  };
+
+  if (params.get('help') === '1') {
+    document.dispatchEvent(new KeyboardEvent('keydown', { key: '?', bubbles: true }));
+  }
+
+  if (params.get('action') === 'new') {
+    waitForArApp(() => {
+      document.dispatchEvent(new KeyboardEvent('keydown', { key: '/', bubbles: true }));
+    });
+  }
+}
+
 // Init on DOMContentLoaded
 function init(): void {
   initI18n();
@@ -852,6 +881,7 @@ function init(): void {
   initTerminalPrompt();
   initClearCacheButton();
   initShareButton();
+  initDeepLinks();
   showConsoleLogo();
   initHolidayEasterEgg();
   initKonamiCode();

--- a/tests/pwa-manifest.test.ts
+++ b/tests/pwa-manifest.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+const ROOT = resolve(__dirname, '..');
+const MANIFEST = JSON.parse(
+  readFileSync(resolve(ROOT, 'public/manifest.webmanifest'), 'utf8'),
+);
+const MAIN = readFileSync(resolve(ROOT, 'src/main.ts'), 'utf8');
+
+describe('PWA manifest — install experience', () => {
+  it('declares a stable id + lang + dir', () => {
+    expect(MANIFEST.id).toBe('/');
+    expect(MANIFEST.lang).toBe('en');
+    expect(MANIFEST.dir).toBe('ltr');
+  });
+
+  it('opts into richer display modes via display_override', () => {
+    expect(Array.isArray(MANIFEST.display_override)).toBe(true);
+    expect(MANIFEST.display_override).toContain('window-controls-overlay');
+    expect(MANIFEST.display_override).toContain('standalone');
+    expect(MANIFEST.display).toBe('standalone');
+  });
+
+  it('uses launch_handler.client_mode focus-existing so a second launch reuses the open instance', () => {
+    expect(MANIFEST.launch_handler).toBeTruthy();
+    expect(MANIFEST.launch_handler.client_mode).toContain('focus-existing');
+  });
+
+  it('declares handle_links preferred + prefer_related_applications false + edge_side_panel', () => {
+    expect(MANIFEST.handle_links).toBe('preferred');
+    expect(MANIFEST.prefer_related_applications).toBe(false);
+    expect(MANIFEST.edge_side_panel).toBeTruthy();
+    expect(typeof MANIFEST.edge_side_panel.preferred_width).toBe('number');
+  });
+
+  it('exposes app shortcuts for "new image" and "keyboard shortcuts"', () => {
+    expect(Array.isArray(MANIFEST.shortcuts)).toBe(true);
+    expect(MANIFEST.shortcuts.length).toBeGreaterThanOrEqual(2);
+    const urls = MANIFEST.shortcuts.map((s: { url: string }) => s.url);
+    expect(urls).toContain('/?action=new');
+    expect(urls).toContain('/?help=1');
+    for (const s of MANIFEST.shortcuts) {
+      expect(s.name).toBeTruthy();
+      expect(Array.isArray(s.icons)).toBe(true);
+      expect(s.icons.length).toBeGreaterThan(0);
+    }
+  });
+
+  it('main.ts wires a deep-link handler that consumes ?help=1 and ?action=new', () => {
+    expect(MAIN).toMatch(/function initDeepLinks\(\)/);
+    expect(MAIN).toMatch(/^\s*initDeepLinks\(\);\s*$/m);
+    expect(MAIN).toMatch(/params\.get\(['"]help['"]\) === ['"]1['"]/);
+    expect(MAIN).toMatch(/params\.get\(['"]action['"]\) === ['"]new['"]/);
+    expect(MAIN).toMatch(/new KeyboardEvent\(['"]keydown['"], \{ key: ['"]\?['"]/);
+    expect(MAIN).toMatch(/new KeyboardEvent\(['"]keydown['"], \{ key: ['"]\/['"]/);
+  });
+});


### PR DESCRIPTION
## Summary
- PWA shortcuts: long-press the installed app → "New image" / "Keyboard shortcuts"
- \`launch_handler.client_mode: focus-existing\` → reuse open tab instead of duplicating
- \`display_override\`, \`edge_side_panel\`, \`handle_links: preferred\` round out install UX
- \`initDeepLinks()\` handles \`?help=1\` / \`?action=new\` by re-dispatching the shortcut keys (single source of truth)

## Test plan
- [x] 6 new source invariants in tests/pwa-manifest.test.ts — pass
- [x] kbd-shortcuts + pwa-manifest suite: 14/14 pass
- [ ] Manual: visit \`/?help=1\` → overlay opens
- [ ] Manual: visit \`/?action=new\` → dropzone is focused
- [ ] Manual (installed PWA): long-press app icon → shortcuts appear