### PR TITLE
feat(a11y): Alt+1..4 reactor power shortcuts

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -106,6 +106,27 @@ function initKeyboardShortcuts(): void {
     if (e.key === 'Escape' && !overlay.hidden) {
       e.preventDefault();
       closeOverlay();
+      return;
+    }
+
+    // Alt+1..4 → Reactor Power levels (LOW / NORMAL / HIGH / FULL-NUKE).
+    // Power-user shortcut so you can compare quality/speed without
+    // leaving the keyboard.
+    if (e.altKey && !e.ctrlKey && !e.metaKey && ['1', '2', '3', '4'].includes(e.key)) {
+      const arApp = document.querySelector('ar-app');
+      if (!arApp?.shadowRoot) return;
+      const level = Number(e.key) - 1;
+      const seg = arApp.shadowRoot.querySelector<HTMLButtonElement>(
+        `.reactor-segment[data-precision="${level}"][data-scope="hero"]`,
+      ) ?? arApp.shadowRoot.querySelector<HTMLButtonElement>(
+        `.reactor-segment[data-precision="${level}"]`,
+      );
+      if (seg) {
+        e.preventDefault();
+        seg.click();
+        const labels = ['LOW-POWER', 'NORMAL', 'HIGH-POWER', 'FULL-NUKE'];
+        showToast(`> reactor: ${labels[level]}`);
+      }
     }
   });
 }
@@ -132,6 +153,13 @@ function createShortcutOverlay(): HTMLDivElement {
         <dt><kbd>Ctrl</kbd>+<kbd>V</kbd></dt><dd>Paste image from clipboard</dd>
         <dt><kbd>Esc</kbd></dt><dd>Cancel current action · close dialogs</dd>
         <dt><kbd>?</kbd></dt><dd>Toggle this panel</dd>
+      </dl>
+      <h3 class="kbd-overlay-sub"># reactor power</h3>
+      <dl class="kbd-overlay-list">
+        <dt><kbd>Alt</kbd>+<kbd>1</kbd></dt><dd>LOW-POWER (fastest)</dd>
+        <dt><kbd>Alt</kbd>+<kbd>2</kbd></dt><dd>NORMAL (default)</dd>
+        <dt><kbd>Alt</kbd>+<kbd>3</kbd></dt><dd>HIGH-POWER</dd>
+        <dt><kbd>Alt</kbd>+<kbd>4</kbd></dt><dd>FULL-NUKE (best quality)</dd>
       </dl>
       <h3 class="kbd-overlay-sub"># editor</h3>
       <dl class="kbd-overlay-list">

--- a/tests/components/kbd-shortcuts.test.ts
+++ b/tests/components/kbd-shortcuts.test.ts
@@ -50,10 +50,17 @@ describe('global keyboard shortcuts (src/main.ts)', () => {
     expect(MAIN).toMatch(/if \(inFormField\(e\.target\)\) return;/);
   });
 
-  it('overlay cheat-sheet lists every global + editor binding', () => {
-    for (const k of ['/', 'Ctrl', 'Esc', '\\?', 'B', 'E', '\\[', '\\]', '0', 'Z']) {
+  it('overlay cheat-sheet lists every global + reactor + editor binding', () => {
+    for (const k of ['/', 'Ctrl', 'Esc', '\\?', 'B', 'E', '\\[', '\\]', '0', 'Z', 'Alt', '1', '2', '3', '4']) {
       expect(MAIN).toMatch(new RegExp(`<kbd>${k}</kbd>`));
     }
+  });
+
+  it('Alt+1..4 clicks the matching reactor segment', () => {
+    expect(MAIN).toMatch(/e\.altKey && !e\.ctrlKey && !e\.metaKey/);
+    expect(MAIN).toMatch(/\['1', '2', '3', '4'\]\.includes\(e\.key\)/);
+    expect(MAIN).toMatch(/\.reactor-segment\[data-precision="\$\{level\}"/);
+    expect(MAIN).toMatch(/seg\.click\(\)/);
   });
 
   it('main.css defines .kbd-overlay with a high z-index so it sits over every shadow tree', () => {


### PR DESCRIPTION
## Summary
- Alt+1/2/3/4 → LOW-POWER / NORMAL / HIGH-POWER / FULL-NUKE
- Programmatically clicks the visible reactor segment so every existing side-effect (aria-pressed, marquee copy, CRT flicker, smoke overlay) stays in sync — no duplicate state path
- Toast feedback on switch; cheat-sheet overlay lists the new bindings

## Test plan
- [x] \`vitest run tests/components/kbd-shortcuts.test.ts\` → 9/9 pass
- [ ] Manual: press Alt+4 → reactor goes FULL-NUKE, smoke overlay kicks in
- [ ] Manual: press Alt+1 → reactor back to LOW-POWER, side-effects cleared