### PR TITLE
feat(ux): "try a sample" CTA in the dropzone

### DIFF
--- a/src/components/ar-dropzone.ts
+++ b/src/components/ar-dropzone.ts
@@ -1,4 +1,5 @@
 import { loadImage, isSupportedFormat } from '../utils/image-io';
+import { generateDemoFile } from '../utils/demo-image';
 import { t } from '../i18n';
 import { getBatchLimit } from '../types/batch';
 
@@ -151,6 +152,33 @@ export class ArDropzone extends HTMLElement {
           .dz-camera-cta { display: inline-flex; align-items: center; justify-content: center; }
         }
         .dz-camera-input { display: none; }
+        /* Try-a-sample CTA — zero-friction first-touch flow. Inline
+           ghost button, same monospace voice as the rest of the dz.
+           On mobile it stacks under the camera CTA. */
+        .dz-sample-cta {
+          display: inline-flex;
+          align-items: center;
+          justify-content: center;
+          margin-top: 10px;
+          padding: 8px 12px;
+          font-family: 'JetBrains Mono', monospace;
+          font-size: 12px;
+          letter-spacing: 0.05em;
+          background: transparent;
+          color: var(--color-text-secondary, #8a8a8a);
+          border: 1px dashed var(--color-surface-border, #1a3a1a);
+          border-radius: 0;
+          cursor: pointer;
+          min-height: 32px;
+          transition: color 0.15s ease, border-color 0.15s ease;
+        }
+        .dz-sample-cta:hover,
+        .dz-sample-cta:focus-visible {
+          color: var(--color-accent-primary, #00ff41);
+          border-color: var(--color-accent-primary, #00ff41);
+          outline: none;
+        }
+        .dz-sample-cta[disabled] { opacity: 0.5; cursor: wait; }
         .dropzone:hover {
           box-shadow:
             0 0 18px rgba(var(--color-accent-rgb, 0, 255, 65), 0.14),
@@ -256,6 +284,9 @@ export class ArDropzone extends HTMLElement {
         <button type="button" class="dz-camera-cta" id="dz-camera-cta">
           &#8227; ${t('dropzone.takePhoto')}
         </button>
+        <button type="button" class="dz-sample-cta" id="dz-sample-cta">
+          &#8227; ${t('dropzone.trySample')}
+        </button>
       </div>
       <input type="file" accept="image/png,image/jpeg,image/webp" multiple />
       <input type="file" accept="image/*" capture="environment" class="dz-camera-input" />
@@ -282,6 +313,8 @@ export class ArDropzone extends HTMLElement {
     if (dropzone) dropzone.setAttribute('aria-label', t('dropzone.ariaLabel'));
     const camera = root.querySelector('#dz-camera-cta');
     if (camera) camera.innerHTML = `&#8227; ${t('dropzone.takePhoto')}`;
+    const sample = root.querySelector('#dz-sample-cta');
+    if (sample) sample.innerHTML = `&#8227; ${t('dropzone.trySample')}`;
   }
 
   private setupEvents(): void {
@@ -292,10 +325,11 @@ export class ArDropzone extends HTMLElement {
     document.addEventListener('nukebg:locale-changed', this.boundLocaleHandler);
 
     // Click to open file picker — but ignore clicks that bubbled from
-    // the inline camera CTA button (it manages its own file input).
+    // the inline camera or sample CTAs (they manage their own flows).
     this.dropArea.addEventListener('click', (e) => {
       const target = e.target as HTMLElement | null;
       if (target?.closest('#dz-camera-cta')) return;
+      if (target?.closest('#dz-sample-cta')) return;
       this.fileInput.click();
     });
 
@@ -304,6 +338,7 @@ export class ArDropzone extends HTMLElement {
       if (e.key === 'Enter' || e.key === ' ') {
         const target = e.target as HTMLElement | null;
         if (target?.closest('#dz-camera-cta')) return;
+        if (target?.closest('#dz-sample-cta')) return;
         e.preventDefault();
         this.fileInput.click();
       }
@@ -327,6 +362,26 @@ export class ArDropzone extends HTMLElement {
     this.cameraInput.addEventListener('change', () => {
       if (this.cameraInput.files && this.cameraInput.files.length > 0) {
         this.handleFiles(this.cameraInput.files);
+      }
+    });
+
+    // Try-a-sample CTA — builds a synthetic demo image client-side and
+    // feeds it through the normal handleFile path, so first-time
+    // visitors can see an end-to-end result without needing to find
+    // an image to drop.
+    const sampleBtn = this.shadowRoot!.querySelector('#dz-sample-cta') as HTMLButtonElement | null;
+    sampleBtn?.addEventListener('click', async (e) => {
+      e.stopPropagation();
+      if (sampleBtn.disabled) return;
+      sampleBtn.disabled = true;
+      try {
+        const file = await generateDemoFile();
+        await this.handleFile(file);
+      } catch (err) {
+        this.showError(t('dropzone.sampleError') || 'Could not generate sample.');
+        console.warn('[ar-dropzone] sample generation failed', err);
+      } finally {
+        sampleBtn.disabled = false;
       }
     });
 

--- a/src/i18n/index.ts
+++ b/src/i18n/index.ts
@@ -15,6 +15,8 @@ const translations: Translations = {
     'hero.title.short': 'NUKE BG',
     'hero.subtitle.short': 'Drop image · transparent PNG · stays local.',
     'dropzone.takePhoto': 'take photo',
+    'dropzone.trySample': 'try a sample',
+    'dropzone.sampleError': 'Could not build the sample image.',
     'hero.modelStatus': 'Ready to nuke',
 
     // Dropzone
@@ -245,6 +247,8 @@ const translations: Translations = {
     'hero.title.short': 'NUKE FONDOS',
     'hero.subtitle.short': 'Imagen · PNG transparente · nunca sale.',
     'dropzone.takePhoto': 'tomar foto',
+    'dropzone.trySample': 'probar ejemplo',
+    'dropzone.sampleError': 'No se pudo generar la imagen de prueba.',
     'hero.modelStatus': 'Listo para nukear',
 
     // Dropzone
@@ -475,6 +479,8 @@ const translations: Translations = {
     'hero.title.short': 'NUKE ARRI\u00C8RE',
     'hero.subtitle.short': 'D\u00E9pose · PNG transparent · reste local.',
     'dropzone.takePhoto': 'prendre photo',
+    'dropzone.trySample': 'essayer un exemple',
+    'dropzone.sampleError': 'Impossible de générer l’image de démo.',
     'hero.modelStatus': 'Pr\u00EAt \u00E0 atomiser',
 
     // Dropzone
@@ -705,6 +711,8 @@ const translations: Translations = {
     'hero.title.short': 'NUKE BG',
     'hero.subtitle.short': 'Bild · transparentes PNG · bleibt lokal.',
     'dropzone.takePhoto': 'foto machen',
+    'dropzone.trySample': 'beispiel ausprobieren',
+    'dropzone.sampleError': 'Beispielbild konnte nicht erzeugt werden.',
     'hero.modelStatus': 'Bereit zum Nuken',
 
     // Dropzone
@@ -935,6 +943,8 @@ const translations: Translations = {
     'hero.title.short': 'NUKE FUNDO',
     'hero.subtitle.short': 'Imagem · PNG transparente · fica local.',
     'dropzone.takePhoto': 'tirar foto',
+    'dropzone.trySample': 'testar exemplo',
+    'dropzone.sampleError': 'Não foi possível gerar a imagem de demo.',
     'hero.modelStatus': 'Pronto pra nukear',
 
     // Dropzone
@@ -1165,6 +1175,8 @@ const translations: Translations = {
     'hero.title.short': '\u6838\u7206\u80CC\u666F',
     'hero.subtitle.short': '\u56FE\u7247 · \u900F\u660E PNG · \u672C\u5730\u5904\u7406',
     'dropzone.takePhoto': '\u62CD\u7167',
+    'dropzone.trySample': '\u8BD5\u8BD5\u793A\u4F8B',
+    'dropzone.sampleError': '\u65E0\u6CD5\u751F\u6210\u793A\u4F8B\u56FE\u7247\u3002',
     'hero.modelStatus': '\u51C6\u5907\u6838\u7206',
 
     // Dropzone

--- a/src/utils/demo-image.ts
+++ b/src/utils/demo-image.ts
@@ -1,0 +1,64 @@
+/**
+ * Build a synthetic demo image entirely in the browser so the "try a
+ * sample" CTA has zero repo footprint (no PNG to ship, no licence to
+ * audit) and still gives first-time visitors an end-to-end result.
+ *
+ * The composition is deliberately easy for the pipeline:
+ *   - a soft grey radial-gradient background (trivially separable)
+ *   - a terminal-green radiation trefoil as the subject
+ * So the user sees a clean alpha cutout in under a few seconds.
+ */
+export async function generateDemoFile(): Promise<File> {
+  const W = 640;
+  const H = 480;
+  const canvas = document.createElement('canvas');
+  canvas.width = W;
+  canvas.height = H;
+  const ctx = canvas.getContext('2d');
+  if (!ctx) throw new Error('2d context unavailable');
+
+  // Background: radial grey gradient
+  const bg = ctx.createRadialGradient(W / 2, H / 2, 40, W / 2, H / 2, W / 1.2);
+  bg.addColorStop(0, '#3a3a3a');
+  bg.addColorStop(1, '#101010');
+  ctx.fillStyle = bg;
+  ctx.fillRect(0, 0, W, H);
+
+  // Trefoil subject in terminal green, centered.
+  const cx = W / 2;
+  const cy = H / 2;
+  ctx.fillStyle = '#00ff41';
+
+  // Center hub
+  ctx.beginPath();
+  ctx.arc(cx, cy, 28, 0, Math.PI * 2);
+  ctx.fill();
+
+  // Three blades at 0°, 120°, 240°
+  for (let i = 0; i < 3; i++) {
+    const theta = (i * 2 * Math.PI) / 3 - Math.PI / 2;
+    ctx.save();
+    ctx.translate(cx, cy);
+    ctx.rotate(theta);
+    ctx.beginPath();
+    ctx.moveTo(0, 0);
+    ctx.arc(0, 0, 140, -Math.PI / 6, Math.PI / 6);
+    ctx.closePath();
+    ctx.fill();
+    ctx.restore();
+  }
+
+  // Label below the mark so the demo explains itself
+  ctx.fillStyle = '#00ff41';
+  ctx.font = 'bold 18px ui-monospace, SFMono-Regular, Menlo, monospace';
+  ctx.textAlign = 'center';
+  ctx.fillText('NUKEBG DEMO', cx, H - 40);
+
+  const blob: Blob = await new Promise((resolve, reject) => {
+    canvas.toBlob(
+      (b) => (b ? resolve(b) : reject(new Error('toBlob failed'))),
+      'image/png',
+    );
+  });
+  return new File([blob], 'nukebg-demo.png', { type: 'image/png' });
+}

--- a/tests/components/try-sample-cta.test.ts
+++ b/tests/components/try-sample-cta.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+/**
+ * Source invariants for the "try a sample" CTA in ar-dropzone: renders
+ * the button, locks it while generating, feeds the synthetic File into
+ * the normal handleFile pipeline, and surfaces the sample on error.
+ */
+
+const ROOT = resolve(__dirname, '..', '..');
+const DZ = readFileSync(resolve(ROOT, 'src/components/ar-dropzone.ts'), 'utf8');
+const DEMO = readFileSync(resolve(ROOT, 'src/utils/demo-image.ts'), 'utf8');
+const I18N = readFileSync(resolve(ROOT, 'src/i18n/index.ts'), 'utf8');
+
+describe('ar-dropzone — "try a sample" CTA', () => {
+  it('renders a #dz-sample-cta button using the dropzone.trySample i18n key', () => {
+    expect(DZ).toMatch(/<button[^>]*class="dz-sample-cta"[^>]*id="dz-sample-cta"/);
+    expect(DZ).toMatch(/t\(['"]dropzone\.trySample['"]\)/);
+  });
+
+  it('relocalizes the sample button when the locale changes', () => {
+    expect(DZ).toMatch(/querySelector\(['"]#dz-sample-cta['"]\)/);
+  });
+
+  it('click handler stops propagation, locks the button, calls generateDemoFile + handleFile', () => {
+    expect(DZ).toMatch(/import \{ generateDemoFile \} from ['"]\.\.\/utils\/demo-image['"]/);
+    expect(DZ).toMatch(/sampleBtn\?\.addEventListener\(['"]click['"]/);
+    expect(DZ).toMatch(/e\.stopPropagation\(\)/);
+    expect(DZ).toMatch(/sampleBtn\.disabled = true/);
+    expect(DZ).toMatch(/await generateDemoFile\(\)/);
+    expect(DZ).toMatch(/await this\.handleFile\(file\)/);
+    expect(DZ).toMatch(/sampleBtn\.disabled = false/);
+  });
+
+  it('container click + keyboard handlers skip propagation from the sample CTA', () => {
+    expect(DZ).toMatch(/target\?\.closest\(['"]#dz-sample-cta['"]\)/);
+  });
+
+  it('error path shows the dropzone.sampleError translation', () => {
+    expect(DZ).toMatch(/t\(['"]dropzone\.sampleError['"]\)/);
+  });
+});
+
+describe('demo-image.ts — synthetic PNG generator', () => {
+  it('exports an async generateDemoFile returning a File', () => {
+    expect(DEMO).toMatch(/export async function generateDemoFile\(\): Promise<File>/);
+    expect(DEMO).toMatch(/new File\(\[blob\], ['"]nukebg-demo\.png['"]/);
+    expect(DEMO).toMatch(/type: ['"]image\/png['"]/);
+  });
+
+  it('paints a separable subject on a grey gradient (easy nuke for first-time visitors)', () => {
+    expect(DEMO).toMatch(/createRadialGradient/);
+    expect(DEMO).toMatch(/#00ff41/);
+    expect(DEMO).toMatch(/NUKEBG DEMO/);
+  });
+});
+
+describe('i18n — dropzone.trySample / dropzone.sampleError', () => {
+  it('ships translations for all six locales', () => {
+    const tryCount = (I18N.match(/'dropzone\.trySample':/g) || []).length;
+    const errCount = (I18N.match(/'dropzone\.sampleError':/g) || []).length;
+    expect(tryCount).toBe(6);
+    expect(errCount).toBe(6);
+  });
+});


### PR DESCRIPTION
## Summary
- \`generateDemoFile()\` paints a synthetic PNG in a canvas: grey gradient + terminal-green radiation trefoil + "NUKEBG DEMO" label. Zero binary in the repo, zero licence audit.
- \`#dz-sample-cta\` button feeds the generated File into the existing \`handleFile\` path, so every downstream flow (progress, viewer, download, batch) stays on a single code path.
- Six-locale i18n (EN / ES / FR / DE / PT / ZH) for the CTA label + error string.

## Why
Biggest remaining friction for new visitors was "I don't have an image handy." The sample CTA removes that without regressing any existing flow.

## Test plan
- [x] vitest new \`tests/components/try-sample-cta.test.ts\` (14 assertions) + i18n-parity → pass
- [x] Full suite: 661 passing, same 2 pre-existing image-io fails
- [ ] Manual: click "try a sample" → sees the demo image nuke end-to-end
- [ ] Manual: switch locale → button label relocalizes