### PR TITLE
fix(pipeline): plug pendingTimers leak on worker responses (closes #44)

### DIFF
--- a/src/pipeline/orchestrator.ts
+++ b/src/pipeline/orchestrator.ts
@@ -59,7 +59,15 @@ export class PipelineOrchestrator {
   private mlWorker: Worker;
   private inpaintWorker: Worker | null = null;
   private lamaWorker: Worker | null = null;
-  private pendingRequests = new Map<string, { resolve: (val: unknown) => void; reject: (err: Error) => void; expectedType: string }>();
+  private pendingRequests = new Map<string, {
+    resolve: (val: unknown) => void;
+    reject: (err: Error) => void;
+    expectedType: string;
+    /** Timeout handle associated with this request, so response handlers
+     *  can clear it promptly instead of waiting for the timer to fire
+     *  empty-handed. */
+    timer?: ReturnType<typeof setTimeout>;
+  }>();
   private pendingTimers = new Set<ReturnType<typeof setTimeout>>();
   private onStageChange: StageCallback;
   private activeSignalCleanup: (() => void) | null = null;
@@ -84,7 +92,7 @@ export class PipelineOrchestrator {
       const msg = e.data;
       const pending = this.pendingRequests.get(msg.id);
       if (pending) {
-        this.pendingRequests.delete(msg.id);
+        this.settlePending(msg.id);
         if (msg.type === 'error') {
           pending.reject(new Error(msg.error));
         } else {
@@ -147,7 +155,7 @@ export class PipelineOrchestrator {
       const pending = this.pendingRequests.get(msg.id);
       if (pending) {
         if (msg.type === 'error') {
-          this.pendingRequests.delete(msg.id);
+          this.settlePending(msg.id);
           pending.reject(new Error(msg.error));
         } else if (msg.type === 'segment-result') {
           // Only resolve if the request was actually for a segment call
@@ -155,7 +163,7 @@ export class PipelineOrchestrator {
             console.warn(`[NukeBG] segment-result arrived for a '${pending.expectedType}' request - ignoring`);
             return;
           }
-          this.pendingRequests.delete(msg.id);
+          this.settlePending(msg.id);
           pending.resolve(msg.result);
         } else if (msg.type === 'model-ready') {
           // Only resolve if the request was for load-model, NOT segment.
@@ -165,7 +173,7 @@ export class PipelineOrchestrator {
             console.warn(`[NukeBG] model-ready arrived for a '${pending.expectedType}' request - ignoring`);
             return;
           }
-          this.pendingRequests.delete(msg.id);
+          this.settlePending(msg.id);
           pending.resolve(msg);
         }
       }
@@ -194,6 +202,23 @@ export class PipelineOrchestrator {
       pending.reject(new Error(message));
     }
     this.pendingRequests.clear();
+  }
+
+  /**
+   * Settle a pending request (resolve or reject): clear its watchdog
+   * timer, drop the timer from pendingTimers, and remove the entry from
+   * pendingRequests. Call this from every response handler so the
+   * pendingTimers set stays tight — without it, timers linger until
+   * they fire empty-handed (#44 leak).
+   */
+  private settlePending(id: string): void {
+    const pending = this.pendingRequests.get(id);
+    if (!pending) return;
+    if (pending.timer !== undefined) {
+      clearTimeout(pending.timer);
+      this.pendingTimers.delete(pending.timer);
+    }
+    this.pendingRequests.delete(id);
   }
 
   /**
@@ -233,7 +258,6 @@ export class PipelineOrchestrator {
   private cvCall<T>(type: string, payload: Record<string, unknown>): Promise<T> {
     return new Promise((resolve, reject) => {
       const id = generateUUID();
-      this.pendingRequests.set(id, { resolve: resolve as (val: unknown) => void, reject, expectedType: type });
       const transferables = PipelineOrchestrator.extractTransferables(payload);
       this.cvWorker.postMessage({ id, type, payload }, transferables);
 
@@ -245,13 +269,13 @@ export class PipelineOrchestrator {
         }
       }, CV_TIMEOUT_MS);
       this.pendingTimers.add(timer);
+      this.pendingRequests.set(id, { resolve: resolve as (val: unknown) => void, reject, expectedType: type, timer });
     });
   }
 
   private mlCall<T>(type: string, payload?: Record<string, unknown>, extra?: Record<string, unknown>): Promise<T> {
     return new Promise((resolve, reject) => {
       const id = generateUUID();
-      this.pendingRequests.set(id, { resolve: resolve as (val: unknown) => void, reject, expectedType: type });
       const transferables = PipelineOrchestrator.extractTransferables(payload);
       this.mlWorker.postMessage({ id, type, payload, ...extra }, transferables);
 
@@ -263,6 +287,7 @@ export class PipelineOrchestrator {
         }
       }, ML_TIMEOUT_MS);
       this.pendingTimers.add(timer);
+      this.pendingRequests.set(id, { resolve: resolve as (val: unknown) => void, reject, expectedType: type, timer });
     });
   }
 
@@ -287,13 +312,13 @@ export class PipelineOrchestrator {
       const pending = this.pendingRequests.get(msg.id);
       if (pending) {
         if (msg.type === 'error') {
-          this.pendingRequests.delete(msg.id);
+          this.settlePending(msg.id);
           pending.reject(new Error(msg.error));
         } else if (msg.type === 'inpaint-result') {
-          this.pendingRequests.delete(msg.id);
+          this.settlePending(msg.id);
           pending.resolve(msg.result);
         } else if (msg.type === 'disposed') {
-          this.pendingRequests.delete(msg.id);
+          this.settlePending(msg.id);
           pending.resolve(undefined);
         }
       }
@@ -304,7 +329,6 @@ export class PipelineOrchestrator {
     if (!this.inpaintWorker) throw new Error('Inpaint worker not created');
     return new Promise((resolve, reject) => {
       const id = generateUUID();
-      this.pendingRequests.set(id, { resolve: resolve as (val: unknown) => void, reject, expectedType: type });
       const transferables = PipelineOrchestrator.extractTransferables(payload);
       this.inpaintWorker!.postMessage({ id, type, payload }, transferables);
 
@@ -316,6 +340,7 @@ export class PipelineOrchestrator {
         }
       }, INPAINT_TIMEOUT_MS);
       this.pendingTimers.add(timer);
+      this.pendingRequests.set(id, { resolve: resolve as (val: unknown) => void, reject, expectedType: type, timer });
     });
   }
 
@@ -357,13 +382,13 @@ export class PipelineOrchestrator {
       const pending = this.pendingRequests.get(msg.id);
       if (pending) {
         if (msg.type === 'error') {
-          this.pendingRequests.delete(msg.id);
+          this.settlePending(msg.id);
           pending.reject(new Error(msg.error));
         } else if (msg.type === 'lama-inpaint-result') {
-          this.pendingRequests.delete(msg.id);
+          this.settlePending(msg.id);
           pending.resolve(msg.result);
         } else if (msg.type === 'lama-disposed') {
-          this.pendingRequests.delete(msg.id);
+          this.settlePending(msg.id);
           pending.resolve(undefined);
         }
       }
@@ -374,7 +399,6 @@ export class PipelineOrchestrator {
     if (!this.lamaWorker) throw new Error('LaMa worker not created');
     return new Promise((resolve, reject) => {
       const id = generateUUID();
-      this.pendingRequests.set(id, { resolve: resolve as (val: unknown) => void, reject, expectedType: type });
       const transferables = PipelineOrchestrator.extractTransferables(payload);
       this.lamaWorker!.postMessage({ id, type, payload }, transferables);
 
@@ -386,6 +410,7 @@ export class PipelineOrchestrator {
         }
       }, LAMA_TIMEOUT_MS);
       this.pendingTimers.add(timer);
+      this.pendingRequests.set(id, { resolve: resolve as (val: unknown) => void, reject, expectedType: type, timer });
     });
   }
 
@@ -770,9 +795,16 @@ export class PipelineOrchestrator {
     this.activeSignalCleanup = null;
     for (const timer of this.pendingTimers) clearTimeout(timer);
     this.pendingTimers.clear();
+    this.pendingRequests.clear();
     this.cvWorker.terminate();
     this.mlWorker.terminate();
     this.disposeInpaintWorker();
     this.disposeLamaWorker();
   }
+
+  /** Test-only accessors so unit tests can assert the #44 leak is fixed
+   *  without touching private state. Cheap in production — the getters
+   *  forward straight to the existing collections. */
+  get _pendingTimersSize(): number { return this.pendingTimers.size; }
+  get _pendingRequestsSize(): number { return this.pendingRequests.size; }
 }

--- a/tests/pipeline/pending-timers.test.ts
+++ b/tests/pipeline/pending-timers.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+/**
+ * #44 — pendingTimers leak: response handlers used to only delete
+ * from pendingRequests, leaving the watchdog timer in pendingTimers
+ * until it fired empty-handed. This guards the fix: every response
+ * handler goes through settlePending() which clears the timer AND
+ * drops it from pendingTimers in one place.
+ */
+
+const ORCH = readFileSync(
+  resolve(__dirname, '..', '..', 'src', 'pipeline', 'orchestrator.ts'),
+  'utf8',
+);
+
+describe('orchestrator — pending-timer bookkeeping (#44)', () => {
+  it('PendingRequest entries carry the timer handle so response handlers can clear it', () => {
+    expect(ORCH).toMatch(/timer\?: ReturnType<typeof setTimeout>/);
+  });
+
+  it('settlePending() clears the watchdog + drops from pendingTimers before removing the entry', () => {
+    expect(ORCH).toMatch(/private settlePending\(id: string\): void/);
+    expect(ORCH).toMatch(/clearTimeout\(pending\.timer\)/);
+    expect(ORCH).toMatch(/this\.pendingTimers\.delete\(pending\.timer\)/);
+  });
+
+  it('every response handler calls settlePending, not pendingRequests.delete directly', () => {
+    // Response handlers (CV/ML/Inpaint/LaMa) live inside .onmessage
+    // blocks. The only remaining pendingRequests.delete calls are
+    // inside setTimeout callbacks (when the timer actually fires) +
+    // rejectAllPending + abort + destroy — those are intentional.
+    const onmessageBlocks = ORCH.match(/onmessage = [\s\S]*?^\s{4}\};/gm) ?? [];
+    expect(onmessageBlocks.length).toBeGreaterThan(0);
+    for (const block of onmessageBlocks) {
+      expect(block).not.toMatch(/pendingRequests\.delete/);
+      expect(block).toMatch(/settlePending/);
+    }
+  });
+
+  it('every Call path attaches the timer to the pending request so settlePending can find it', () => {
+    const calls = ['cvCall', 'mlCall', 'inpaintCall', 'lamaCall'];
+    for (const fn of calls) {
+      // Find the function body (greedy until the matching closing brace
+      // of the surrounding method).
+      const m = ORCH.match(new RegExp(`private ${fn}[\\s\\S]*?^  \\}$`, 'm'));
+      expect(m, `${fn} body not matched`).not.toBeNull();
+      expect(m![0], `${fn} should attach timer to pendingRequests entry`).toMatch(
+        /pendingRequests\.set\(id, \{[^}]*\btimer\b[^}]*\}\)/,
+      );
+    }
+  });
+
+  it('destroy() clears both pendingTimers AND pendingRequests', () => {
+    const destroyBody = ORCH.match(/destroy\(\): void \{[\s\S]*?^  \}$/m);
+    expect(destroyBody).not.toBeNull();
+    expect(destroyBody![0]).toMatch(/pendingTimers\.clear\(\)/);
+    expect(destroyBody![0]).toMatch(/pendingRequests\.clear\(\)/);
+  });
+
+  it('exposes _pendingTimersSize / _pendingRequestsSize read-only getters for tests', () => {
+    expect(ORCH).toMatch(/get _pendingTimersSize\(\): number/);
+    expect(ORCH).toMatch(/get _pendingRequestsSize\(\): number/);
+  });
+});


### PR DESCRIPTION
## Summary
Every worker response handler (CV/ML/Inpaint/LaMa) used to drop the entry from \`pendingRequests\` but leave the watchdog timer alive in \`pendingTimers\` until it fired empty-handed. Under sustained traffic (batches, long sessions) the set grew unbounded.

Fix: each \`PendingRequest\` now carries its \`timer\` handle, a new \`settlePending(id)\` helper clears the watchdog and drops it from \`pendingTimers\` before removing the entry, and every response handler routes through it.

## Why
Closes #44's "pendingTimers leak" acceptance criterion. PipelineResult was already frozen + readonly (from #56), and LaMa download validation exists today, so this was the last correctness gap for that issue.

## Test plan
- [x] \`tests/pipeline/pending-timers.test.ts\` — 6 source invariants, pass
- [x] Full suite: 667 passing, same 2 pre-existing image-io fails unchanged
- [ ] Manual: run a batch of 10 images → inspect memory / no retained timers