### PR TITLE
docs(security): document declined COEP (closes #41)

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -14,8 +14,15 @@ server {
     add_header Permissions-Policy "camera=(), microphone=(), geolocation=()" always;
     add_header Strict-Transport-Security "max-age=63072000; includeSubDomains; preload" always;
 
-    # COOP/COEP: credentialless enables SharedArrayBuffer for multi-threaded WASM
-    # Model is self-hosted (same-origin) so no cross-origin issues
+    # COOP-only (COEP intentionally NOT set — see #41 closure).
+    # App code does not use SharedArrayBuffer, and onnxruntime-web /
+    # transformers.js fall back to single-threaded WASM cleanly when
+    # crossOriginIsolated is false. Adding COEP would block the HF
+    # model fetches + jsdelivr CDN (they don't advertise CORP), so the
+    # performance gain isn't worth the fetch-path breakage. To enable
+    # multi-threaded WASM later, set
+    #   Cross-Origin-Embedder-Policy: credentialless
+    # here and verify all connect-src hosts accept credentialless.
     add_header Cross-Origin-Opener-Policy "same-origin" always;
     add_header X-DNS-Prefetch-Control "off" always;
 

--- a/tests/infra/coep-policy.test.ts
+++ b/tests/infra/coep-policy.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+/**
+ * #41 acceptance — "document.crossOriginIsolated === true OR the app
+ * documents it doesn't need to be". We declined crossOriginIsolated
+ * because onnxruntime-web + transformers.js fall back to single-thread
+ * WASM cleanly and enabling COEP would break HF/jsdelivr fetches.
+ *
+ * This test locks that decision: COEP must stay absent AND the
+ * rationale must be documented in nginx.conf so future maintainers
+ * don't accidentally re-add it without reading why.
+ */
+
+const ROOT = resolve(__dirname, '..', '..');
+const NGINX = readFileSync(resolve(ROOT, 'nginx.conf'), 'utf8');
+const HEADERS = readFileSync(resolve(ROOT, 'public/_headers'), 'utf8');
+
+describe('COEP policy — #41', () => {
+  it('nginx.conf does NOT set Cross-Origin-Embedder-Policy', () => {
+    expect(NGINX).not.toMatch(/add_header\s+Cross-Origin-Embedder-Policy/);
+  });
+
+  it('_headers does NOT set Cross-Origin-Embedder-Policy', () => {
+    expect(HEADERS).not.toMatch(/Cross-Origin-Embedder-Policy/);
+  });
+
+  it('nginx.conf documents the rationale for not enabling COEP', () => {
+    expect(NGINX).toMatch(/COEP intentionally NOT set/);
+    expect(NGINX).toMatch(/#41/);
+    expect(NGINX).toMatch(/SharedArrayBuffer/);
+  });
+
+  it('Cross-Origin-Opener-Policy IS set (COOP-only mode)', () => {
+    expect(NGINX).toMatch(/Cross-Origin-Opener-Policy "same-origin"/);
+    expect(HEADERS).toMatch(/Cross-Origin-Opener-Policy:\s*same-origin/);
+  });
+});


### PR DESCRIPTION
## Summary
Last open acceptance item from #41 was \"document.crossOriginIsolated OR document we don't need it\". The old \`nginx.conf\` comment misleadingly implied COEP was set when it wasn't. Rewrote the comment to explain why we stay in COOP-only mode (no SAB usage, HF + jsdelivr can't satisfy COEP require-corp, onnxruntime-web/transformers.js fall back cleanly).

## Test plan
- [x] \`tests/infra/coep-policy.test.ts\` — 4 invariants lock the decision: COEP absent, rationale present, COOP set

## Prior art closing the rest of #41
- Magic-byte validation: #53
- 80 MB / 100 MP caps: already in \`image-io.ts\`
- Hard pipeline timeout: #61
- AbortController plumbing: #58