### PR TITLE
i18n: RTL scaffolding — getDirection() + auto-flip <html dir> (#38)

### DIFF
--- a/src/i18n/index.ts
+++ b/src/i18n/index.ts
@@ -1417,6 +1417,22 @@ const STORAGE_KEY = 'nukebg-locale';
 const SUPPORTED_LOCALES = Object.keys(translations);
 const DEFAULT_LOCALE = 'en';
 
+/**
+ * RTL scaffolding (#38). The actual translations for these locales
+ * aren't shipped yet — but the runtime and components must already
+ * cooperate with `dir="rtl"` so when we ship a translation for any of
+ * them, the layout flips without code changes. CSS uses logical
+ * properties (margin-inline, inset-inline-start) so the visual flip
+ * is automatic; this set just identifies which locales should drive
+ * the `dir` attribute.
+ */
+const RTL_LOCALES = new Set(['ar', 'he', 'fa', 'ur', 'ps', 'sd', 'yi', 'dv']);
+
+/** Returns 'rtl' for right-to-left locales, 'ltr' otherwise. */
+export function getDirection(locale: string): 'rtl' | 'ltr' {
+  return RTL_LOCALES.has(locale.split('-')[0]) ? 'rtl' : 'ltr';
+}
+
 /** Detects the browser language with fallback to 'en' */
 function detectLocale(): string {
   // First, check for a ?lang= URL parameter
@@ -1468,8 +1484,11 @@ export function setLocale(locale: string): void {
   currentLocale = locale;
   localStorage.setItem(STORAGE_KEY, locale);
 
-  // Update html lang attribute
+  // Update html lang + dir attributes. CSS uses logical properties
+  // throughout, so `dir="rtl"` on <html> is enough to flip the layout
+  // for an RTL locale once we ship one (#38).
   document.documentElement.lang = locale;
+  document.documentElement.dir = getDirection(locale);
 
   // Emit event so components re-render
   document.dispatchEvent(new CustomEvent('nukebg:locale-changed', {

--- a/src/main.ts
+++ b/src/main.ts
@@ -5,7 +5,7 @@ document.getElementById('seo-content')?.remove();
 import './styles/main.css';
 
 // i18n - importar antes de los componentes para que detecte el locale
-import { getLocale, setLocale, t } from './i18n';
+import { getLocale, setLocale, getDirection, t } from './i18n';
 
 // Register Web Components
 import './components/ar-dropzone';
@@ -567,8 +567,10 @@ function initShakeDetection(): void {
 function initI18n(): void {
   const locale = getLocale();
 
-  // Set html lang attribute on init
+  // Set html lang + dir attributes on init. dir flips automatically
+  // once we ship an RTL translation (#38 RTL scaffolding).
   document.documentElement.lang = locale;
+  document.documentElement.dir = getDirection(locale);
 
   // Sync the selector
   const langSelector = document.getElementById('lang-selector') as HTMLSelectElement | null;

--- a/tests/i18n/rtl-scaffold.test.ts
+++ b/tests/i18n/rtl-scaffold.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+/**
+ * #38 RTL scaffolding — actual translations aren't shipped, but the
+ * runtime must already cooperate with `dir="rtl"` so a future RTL
+ * locale flips the layout without code changes.
+ */
+
+import { getDirection } from '../../src/i18n';
+
+const ROOT = resolve(__dirname, '..', '..');
+const I18N = readFileSync(resolve(ROOT, 'src/i18n/index.ts'), 'utf8');
+const MAIN = readFileSync(resolve(ROOT, 'src/main.ts'), 'utf8');
+
+describe('i18n — getDirection', () => {
+  it('returns "rtl" for known RTL languages (ar, he, fa, ur)', () => {
+    expect(getDirection('ar')).toBe('rtl');
+    expect(getDirection('he')).toBe('rtl');
+    expect(getDirection('fa')).toBe('rtl');
+    expect(getDirection('ur')).toBe('rtl');
+  });
+
+  it('handles BCP-47 region tags (ar-EG, he-IL)', () => {
+    expect(getDirection('ar-EG')).toBe('rtl');
+    expect(getDirection('he-IL')).toBe('rtl');
+  });
+
+  it('returns "ltr" for every locale we currently ship', () => {
+    for (const l of ['en', 'es', 'fr', 'de', 'pt', 'zh']) {
+      expect(getDirection(l)).toBe('ltr');
+    }
+  });
+
+  it('falls back to "ltr" for unknown locales', () => {
+    expect(getDirection('xx')).toBe('ltr');
+    expect(getDirection('')).toBe('ltr');
+  });
+});
+
+describe('setLocale wires document.documentElement.dir (#38)', () => {
+  it('i18n module ships RTL_LOCALES + getDirection + dir assignment in setLocale', () => {
+    expect(I18N).toMatch(/RTL_LOCALES = new Set\(\[/);
+    expect(I18N).toMatch(/export function getDirection\(locale: string\): ['"]rtl['"] \| ['"]ltr['"]/);
+    expect(I18N).toMatch(/document\.documentElement\.dir = getDirection\(locale\)/);
+  });
+
+  it('main.ts initI18n sets dir on initial boot', () => {
+    expect(MAIN).toMatch(/import \{[^}]*getDirection[^}]*\} from ['"]\.\/i18n['"]/);
+    expect(MAIN).toMatch(/document\.documentElement\.dir = getDirection\(locale\)/);
+  });
+});


### PR DESCRIPTION
## Summary
- \`getDirection(locale)\` helper exported from \`src/i18n\`
- \`setLocale\` + \`initI18n\` now flip \`document.documentElement.dir\` so a future RTL locale auto-flips layout (CSS already uses logical properties everywhere)
- 6 tests: helper coverage + source invariants on the wiring

## Why
Last scaffolding item from #38. RTL translations aren't being shipped yet (out-of-scope per the issue's note), but the runtime + components now cooperate so dropping a translation is a one-line PR.

Plurals deferred (no pluralized strings today, adding ICU machinery would be premature).

## Test plan
- [x] vitest 6/6 pass