### PR TITLE
feat(ui): theme switcher in the footer

### DIFF
--- a/index.html
+++ b/index.html
@@ -369,6 +369,14 @@
     <a href="#" id="clear-cache-btn" class="footer-cache-btn" title="Clear cached data and reload">☢ Clear cache</a>
     <span class="footer-sep">|</span>
     <button type="button" id="quiet-mode-toggle" class="footer-quiet-btn" aria-pressed="false"># quiet mode</button>
+    <span class="footer-sep">|</span>
+    <div class="theme-picker" role="radiogroup" id="theme-picker" aria-label="Theme">
+      <span class="theme-picker-label"># theme</span>
+      <button type="button" class="theme-swatch" role="radio" data-theme="green" aria-checked="true" aria-label="Terminal green (default)" title="Terminal green"></button>
+      <button type="button" class="theme-swatch" role="radio" data-theme="amber" aria-checked="false" aria-label="Amber" title="Amber"></button>
+      <button type="button" class="theme-swatch" role="radio" data-theme="cyan" aria-checked="false" aria-label="Cyan" title="Cyan"></button>
+      <button type="button" class="theme-swatch" role="radio" data-theme="magenta" aria-checked="false" aria-label="Magenta" title="Magenta"></button>
+    </div>
     <span class="footer-privacy" id="footer-privacy">Your images never leave your device. Zero uploads. Zero BS.</span>
     <span class="footer-holiday" id="footer-holiday"></span>
   </footer>

--- a/src/main.ts
+++ b/src/main.ts
@@ -879,9 +879,72 @@ function initDeepLinks(): void {
   }
 }
 
+/**
+ * Theme switcher (footer). Four palettes — green (default) / amber /
+ * cyan / magenta — are CSS-only via :root[data-theme="X"] overrides
+ * in main.css. main.ts only reads + writes the attribute and persists
+ * the choice in localStorage. Skips animations / does not affect the
+ * pipeline.
+ */
+type ThemeName = 'green' | 'amber' | 'cyan' | 'magenta';
+const THEME_STORAGE_KEY = 'nukebg:theme';
+const THEMES: readonly ThemeName[] = ['green', 'amber', 'cyan', 'magenta'];
+
+function isThemeName(value: string | null): value is ThemeName {
+  return value !== null && (THEMES as readonly string[]).includes(value);
+}
+
+function applyTheme(theme: ThemeName): void {
+  if (theme === 'green') {
+    delete document.documentElement.dataset.theme;
+  } else {
+    document.documentElement.dataset.theme = theme;
+  }
+  document.querySelectorAll<HTMLButtonElement>('.theme-swatch').forEach((el) => {
+    el.setAttribute('aria-checked', el.dataset.theme === theme ? 'true' : 'false');
+  });
+}
+
+function initThemeSwitcher(): void {
+  const stored = (() => {
+    try { return localStorage.getItem(THEME_STORAGE_KEY); } catch { return null; }
+  })();
+  const initial: ThemeName = isThemeName(stored) ? stored : 'green';
+  applyTheme(initial);
+
+  const picker = document.getElementById('theme-picker');
+  if (!picker) return;
+  picker.addEventListener('click', (e) => {
+    const target = (e.target as HTMLElement | null)?.closest<HTMLButtonElement>('.theme-swatch');
+    if (!target) return;
+    const next = target.dataset.theme;
+    if (!isThemeName(next ?? null)) return;
+    applyTheme(next as ThemeName);
+    try { localStorage.setItem(THEME_STORAGE_KEY, next!); } catch { /* ignore */ }
+  });
+
+  // WAI-ARIA radiogroup keyboard nav: Arrow keys cycle, Home/End jump.
+  picker.addEventListener('keydown', (ev) => {
+    const e = ev as KeyboardEvent;
+    if (!['ArrowLeft', 'ArrowRight', 'ArrowUp', 'ArrowDown', 'Home', 'End'].includes(e.key)) return;
+    const swatches = Array.from(picker.querySelectorAll<HTMLButtonElement>('.theme-swatch'));
+    const idx = swatches.findIndex((s) => s === document.activeElement);
+    if (idx < 0) return;
+    e.preventDefault();
+    let nextIdx = idx;
+    if (e.key === 'ArrowRight' || e.key === 'ArrowDown') nextIdx = (idx + 1) % swatches.length;
+    else if (e.key === 'ArrowLeft' || e.key === 'ArrowUp') nextIdx = (idx - 1 + swatches.length) % swatches.length;
+    else if (e.key === 'Home') nextIdx = 0;
+    else if (e.key === 'End') nextIdx = swatches.length - 1;
+    swatches[nextIdx].focus();
+    swatches[nextIdx].click();
+  });
+}
+
 // Init on DOMContentLoaded
 function init(): void {
   initI18n();
+  initThemeSwitcher();
   initKeyboardShortcuts();
   initTerminalPrompt();
   initClearCacheButton();

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -145,6 +145,48 @@
   --terminal-border-style: 1px solid var(--color-surface-border);
 }
 
+/* === Theme palettes ===
+   Override the accent + text-* tokens only. Background, surface, and
+   semantic warning/error colors stay constant so the terminal feel
+   doesn't get lost. data-theme is set on <html> by main.ts on boot
+   and persisted via localStorage. */
+:root[data-theme="amber"] {
+  --color-text-primary: #ff8c00;
+  --color-text-secondary: #cc7000;
+  --color-text-tertiary: #995300;
+  --color-accent-rgb: 255, 140, 0;
+  --color-accent-primary: #ff8c00;
+  --color-accent-hover: #ffaa33;
+  --color-hazard: #ff8c00;
+  --color-surface-border: #3a2a0a;
+  --color-surface-hover: #2a1f0a;
+  --color-surface-active: #302510;
+}
+:root[data-theme="cyan"] {
+  --color-text-primary: #00ddff;
+  --color-text-secondary: #00aacc;
+  --color-text-tertiary: #0088aa;
+  --color-accent-rgb: 0, 221, 255;
+  --color-accent-primary: #00ddff;
+  --color-accent-hover: #33eeff;
+  --color-hazard: #00ddff;
+  --color-surface-border: #0a2a3a;
+  --color-surface-hover: #0a1f2a;
+  --color-surface-active: #102530;
+}
+:root[data-theme="magenta"] {
+  --color-text-primary: #ff33ff;
+  --color-text-secondary: #cc22cc;
+  --color-text-tertiary: #991199;
+  --color-accent-rgb: 255, 51, 255;
+  --color-accent-primary: #ff33ff;
+  --color-accent-hover: #ff66ff;
+  --color-hazard: #ff33ff;
+  --color-surface-border: #3a0a3a;
+  --color-surface-hover: #2a0a2a;
+  --color-surface-active: #301030;
+}
+
 /* === Reset === */
 *, *::before, *::after {
   box-sizing: border-box;
@@ -478,6 +520,52 @@ body::after {
 }
 .footer-quiet-btn[aria-pressed="true"] {
   color: var(--color-accent-primary);
+}
+
+/* Theme picker — four small swatches in the footer that flip
+   document.documentElement[data-theme]. Each swatch carries its own
+   absolute color via the data-theme attribute so the active theme's
+   accent doesn't bleed across all four. */
+.theme-picker {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  vertical-align: middle;
+}
+.theme-picker-label {
+  color: var(--color-text-tertiary);
+  font-size: inherit;
+}
+.theme-swatch {
+  appearance: none;
+  border: 1px solid var(--color-surface-border);
+  width: 14px;
+  height: 14px;
+  padding: 0;
+  cursor: pointer;
+  border-radius: 0;
+  transition: outline-offset var(--duration-fast), transform var(--duration-fast);
+  outline: 1px solid transparent;
+  outline-offset: 0;
+}
+.theme-swatch[data-theme="green"]   { background: #00ff41; }
+.theme-swatch[data-theme="amber"]   { background: #ff8c00; }
+.theme-swatch[data-theme="cyan"]    { background: #00ddff; }
+.theme-swatch[data-theme="magenta"] { background: #ff33ff; }
+.theme-swatch:hover,
+.theme-swatch:focus-visible {
+  outline-color: var(--color-accent-primary);
+  outline-offset: 2px;
+}
+.theme-swatch[aria-checked="true"] {
+  outline: 1px solid var(--color-accent-primary);
+  outline-offset: 2px;
+}
+@media (pointer: coarse) {
+  .theme-swatch { width: 18px; height: 18px; }
+}
+@media (max-width: 480px) {
+  .theme-picker-label { display: none; }
 }
 
 .footer-privacy {

--- a/tests/theme-switcher.test.ts
+++ b/tests/theme-switcher.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+/**
+ * Theme switcher (footer) — replaces the deleted Reactor segmented
+ * control with a pure-cosmetic palette swap.
+ *
+ * Source invariants:
+ *   1. Four swatches in the footer (green / amber / cyan / magenta)
+ *      with WAI-ARIA radiogroup semantics
+ *   2. main.ts persists choice via localStorage["nukebg:theme"]
+ *   3. main.css ships per-theme :root[data-theme="X"] overrides
+ *   4. Default state has aria-checked="true" on green
+ */
+
+const ROOT = resolve(__dirname, '..');
+const HTML = readFileSync(resolve(ROOT, 'index.html'), 'utf8');
+const CSS = readFileSync(resolve(ROOT, 'src/styles/main.css'), 'utf8');
+const MAIN = readFileSync(resolve(ROOT, 'src/main.ts'), 'utf8');
+
+describe('theme switcher — DOM', () => {
+  it('renders <div class="theme-picker" role="radiogroup"> in the footer', () => {
+    expect(HTML).toMatch(/<div class="theme-picker" role="radiogroup"/);
+    expect(HTML).toMatch(/aria-label="Theme"/);
+  });
+
+  it('exposes four swatches: green / amber / cyan / magenta', () => {
+    for (const name of ['green', 'amber', 'cyan', 'magenta']) {
+      expect(HTML).toMatch(new RegExp(`data-theme="${name}"`));
+      expect(HTML).toMatch(new RegExp(`<button[^>]*role="radio"[^>]*data-theme="${name}"`));
+    }
+  });
+
+  it('green is the default (aria-checked="true" only on green)', () => {
+    const checkedTrue = HTML.match(/aria-checked="true"[^>]*data-theme="(\w+)"|data-theme="(\w+)"[^>]*aria-checked="true"/g) ?? [];
+    expect(checkedTrue.length).toBe(1);
+    expect(checkedTrue[0]).toMatch(/data-theme="green"/);
+  });
+});
+
+describe('theme switcher — palettes in main.css', () => {
+  for (const theme of ['amber', 'cyan', 'magenta']) {
+    it(`:root[data-theme="${theme}"] overrides accent + text-* tokens`, () => {
+      const re = new RegExp(`:root\\[data-theme="${theme}"\\]\\s*\\{[\\s\\S]*?--color-accent-primary[\\s\\S]*?--color-text-primary`);
+      expect(CSS).toMatch(re);
+    });
+  }
+
+  it('green has no override block (it is the :root default)', () => {
+    expect(CSS).not.toMatch(/:root\[data-theme="green"\]/);
+  });
+});
+
+describe('theme switcher — main.ts wiring', () => {
+  it('reads localStorage["nukebg:theme"] on boot and applies it', () => {
+    expect(MAIN).toMatch(/THEME_STORAGE_KEY = ['"]nukebg:theme['"]/);
+    expect(MAIN).toMatch(/localStorage\.getItem\(THEME_STORAGE_KEY\)/);
+    expect(MAIN).toMatch(/applyTheme\(initial\)/);
+  });
+
+  it('applyTheme deletes data-theme for green and sets it for the others', () => {
+    expect(MAIN).toMatch(/if \(theme === ['"]green['"]\)[\s\S]*?delete document\.documentElement\.dataset\.theme/);
+    expect(MAIN).toMatch(/document\.documentElement\.dataset\.theme = theme/);
+  });
+
+  it('initThemeSwitcher is wired into init() and click+keydown drive selection', () => {
+    expect(MAIN).toMatch(/^\s*initThemeSwitcher\(\);\s*$/m);
+    expect(MAIN).toMatch(/picker\.addEventListener\(['"]click['"]/);
+    expect(MAIN).toMatch(/picker\.addEventListener\(['"]keydown['"]/);
+    expect(MAIN).toMatch(/localStorage\.setItem\(THEME_STORAGE_KEY/);
+  });
+
+  it('keyboard nav cycles via Arrow / Home / End (WAI-ARIA radiogroup)', () => {
+    for (const key of ['ArrowLeft', 'ArrowRight', 'ArrowUp', 'ArrowDown', 'Home', 'End']) {
+      expect(MAIN).toContain(`'${key}'`);
+    }
+  });
+});


### PR DESCRIPTION
Replaces the deleted Reactor segmented control with a pure-cosmetic palette swap.

## Summary
- Four swatches in the footer: green (default) / amber / cyan / magenta
- \`:root[data-theme="X"]\` overrides accent + text-* tokens in \`main.css\`
- Persistence via \`localStorage["nukebg:theme"]\`
- WAI-ARIA radiogroup keyboard nav (Arrow / Home / End)
- Each swatch shows its absolute color so the picker is self-explanatory

## Test plan
- [x] vitest 627/627
- [x] build green
- [x] lint clean
- [ ] Manual: click amber → whole UI shifts to amber, persists across reload
- [ ] Manual: keyboard nav cycles through the four swatches