### PR TITLE
docs: changelog sync + scripts/README + fixture licence + CI gates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,20 @@ Unreleased entries accumulate on the `dev` branch. When we cut a release we copy
 ## [Unreleased]
 
 ### Added
+- **Theme switcher in the footer** — four palettes (terminal-green / amber /
+  cyan / magenta) via `:root[data-theme="X"]` overrides. WAI-ARIA radiogroup
+  with keyboard nav; persisted in `localStorage["nukebg:theme"]`.
+  ([#115](https://github.com/yocreoquesi/nukebg/pull/115))
+- **In-dropzone model progress** — first-run progress relocated INTO the
+  dropzone in the same vertical row as the camera CTA, so the page never
+  reflows when the model finishes warming up. ar-app drives it via a new
+  `dropzone.setLoadingState(...)` API. ([#114](https://github.com/yocreoquesi/nukebg/pull/114))
+- **Reactor offline → active** in the [STATUS] line — only flips green after
+  preload resolves. Dot + word dim while idle.
+  ([#114](https://github.com/yocreoquesi/nukebg/pull/114))
+- **Recovered honesty + Ko-fi pitch** in the hero — `features.disclaimer` and
+  a new `support.kofi` i18n key (six locales).
+  ([#114](https://github.com/yocreoquesi/nukebg/pull/114))
 - **Global keyboard shortcuts + `?` hint overlay** — press `/` to focus the
   dropzone, `?` to see the full cheat-sheet, Esc to dismiss. Works across every
   shadow tree via a light-DOM overlay. ([#101](https://github.com/yocreoquesi/nukebg/pull/101))
@@ -59,6 +73,24 @@ Unreleased entries accumulate on the `dev` branch. When we cut a release we copy
 - **Cancel button in `ar-progress`** ([#63](https://github.com/yocreoquesi/nukebg/pull/63)).
 
 ### Changed
+- **Pipeline pinned to `'high-power'`** — the segmentation pipeline now always
+  runs at the better-bordered profile (extra spatial pass, finer cluster
+  threshold). Previously gated behind the Reactor segmented control.
+  ([#113](https://github.com/yocreoquesi/nukebg/pull/113))
+- **Reactor segmented control + Alt+1..4 shortcut removed** — every visible
+  trace of the four-mode picker is gone (CSS, click handlers, marquee swap,
+  CRT flicker, smoke, vibrate, ~700 LOC of UI). Replaced by the theme switcher
+  for cosmetic palette changes.
+  ([#113](https://github.com/yocreoquesi/nukebg/pull/113))
+- **MAX_PIXELS lowered from 100 MP → 32 MP** — covers every current iPhone /
+  Pixel sensor while keeping inpaint + LaMa peak RAM safe on low-end phones.
+  ([#111](https://github.com/yocreoquesi/nukebg/pull/111))
+- **"How it works" + "vs other tools" SEO block removed** from below-fold —
+  JSON-LD HowTo + FAQ already cover the same ground for SERPs.
+  ([#112](https://github.com/yocreoquesi/nukebg/pull/112))
+- **"Try a sample" demo CTA reverted** — the synthetic image was triggering
+  a false-positive watermark detection.
+  ([#111](https://github.com/yocreoquesi/nukebg/pull/111))
 - **Polish pass** — typography tokens collapsed to 12/14/16, progress bar
   height tightened, tablet header gets the portable-mode tagline.
   ([#87](https://github.com/yocreoquesi/nukebg/pull/87))
@@ -82,6 +114,10 @@ Unreleased entries accumulate on the `dev` branch. When we cut a release we copy
   ([#60](https://github.com/yocreoquesi/nukebg/pull/60))
 
 ### Pipeline
+- **`pendingTimers` leak plugged** — every worker response now routes through
+  a `settlePending()` helper that clears the watchdog timer and drops it from
+  the set in one step (closes #44).
+  ([#106](https://github.com/yocreoquesi/nukebg/pull/106))
 - **End-to-end `AbortController`** plumbed from UI → orchestrator → every
   worker. ([#58](https://github.com/yocreoquesi/nukebg/pull/58))
 - **20-minute wall-clock timeout** on `process()` to break runaway runs.
@@ -90,6 +126,15 @@ Unreleased entries accumulate on the `dev` branch. When we cut a release we copy
   ([#56](https://github.com/yocreoquesi/nukebg/pull/56)).
 
 ### Accessibility
+- **Editor canvases are tabbable + described** — `tabindex="0"`, `role="img"`,
+  `aria-label` wired through new `editor.canvasLabel` /
+  `advanced.canvasLabel` i18n keys.
+  ([#107](https://github.com/yocreoquesi/nukebg/pull/107))
+- **Viewer slider WAI-ARIA steps** — Shift+Arrow / PageUp / PageDown move ±10,
+  Home/End jump to 0/100, ArrowUp/Down work as vertical synonyms.
+  ([#107](https://github.com/yocreoquesi/nukebg/pull/107))
+- **Alt+1..4 reactor shortcuts** removed alongside the Reactor pivot.
+  ([#113](https://github.com/yocreoquesi/nukebg/pull/113))
 - **Reduced-motion audit** across every component that ships `@keyframes`;
   viewer slider reveal respects both OS reduced-motion and the in-app quiet
   mode. ([#100](https://github.com/yocreoquesi/nukebg/pull/100))
@@ -101,7 +146,19 @@ Unreleased entries accumulate on the `dev` branch. When we cut a release we copy
 - **Production sourcemaps disabled**
   ([#51](https://github.com/yocreoquesi/nukebg/pull/51)).
 
+### Internationalization
+- **RTL scaffolding** — `getDirection(locale)` helper + auto-flip of
+  `<html dir>` so a future RTL translation lands without code changes.
+  Handles BCP-47 region tags. (closes #38)
+  ([#109](https://github.com/yocreoquesi/nukebg/pull/109))
+
 ### Tooling / CI
+- **CI runs `npm run build`** on every PR so deploy-time regressions fail
+  before merge. Output sanity check confirms `dist/index.html`, JSON-LD
+  blocks, and `dist/assets`. ([#110](https://github.com/yocreoquesi/nukebg/pull/110))
+- **CSP hash + image-io tests EOL-agnostic** so CRLF checkouts on Windows
+  no longer drift the hashes against LF on Linux CI.
+  ([#110](https://github.com/yocreoquesi/nukebg/pull/110))
 - **ESLint + Prettier + CI lint job + WebKit e2e** in Playwright matrix.
   ([#67](https://github.com/yocreoquesi/nukebg/pull/67))
 - **Safari cross-engine validation** — WebKit matrix + iPhone profile +
@@ -112,6 +169,13 @@ Unreleased entries accumulate on the `dev` branch. When we cut a release we copy
   ([#64](https://github.com/yocreoquesi/nukebg/pull/64)).
 
 ### Documentation
+- **`scripts/README.md`** documents every analyze / validate / CSP helper.
+- **`tests/fixtures/LICENSE.md`** captures source + licence per fixture.
+- **CONTRIBUTING.md** now lists the CI gates + recommended branch protection
+  rules for `main`.
+- **COEP intentionally NOT set** — `nginx.conf` carries the rationale +
+  recipe to enable `credentialless` later (closes #41).
+  ([#108](https://github.com/yocreoquesi/nukebg/pull/108))
 - **Zero-network claim reconciled with reality** — clarifies first-run model
   fetch vs. steady-state runtime.
   ([#59](https://github.com/yocreoquesi/nukebg/pull/59))

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -177,6 +177,34 @@ $ npm test
 - [ ] Commits follow the convention
 ```
 
+### CI gates (must be green to merge)
+
+The `Typecheck + tests` job in `.github/workflows/ci.yml` runs:
+
+1. `npm run typecheck` (`tsc --noEmit`)
+2. `npm test` (vitest, ~600 source-invariant tests)
+3. `npm run build` — same command Cloudflare Pages runs on every deploy
+
+If `Typecheck + tests` is red, the deploy is red too — fix before merging. The Lint + format job is non-blocking today (`continue-on-error: true`) while the codebase finishes migrating to the strict ESLint + Prettier config; flip that flag once the formatter is fully run.
+
+### Branch protection (recommended on `main`)
+
+The repo doesn't ship branch-protection rules in code, but the
+maintainers should configure them in GitHub Settings → Branches once
+the codebase is stable enough:
+
+- Require **Typecheck + tests** to pass before merging.
+- Require **Cloudflare Pages** preview to succeed (deploy proves the
+  build works under the production toolchain).
+- Require **CodeQL** to pass (catches new security smells on PRs).
+- Require linear history + signed commits if your team prefers.
+- Disallow force-pushes to `main`.
+
+The `Playwright pipeline e2e` job is currently fragile (multi-input
+strict-mode failure from the camera CTA + visual baseline drift) and
+should NOT be a required check until those flakes are resolved — see
+issues #76 and #77 for the underlying UX work.
+
 ---
 
 ## > commits

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,0 +1,28 @@
+# scripts/
+
+One-off CLI helpers — not part of the runtime. Each script is
+standalone (`node scripts/<name>.mjs` or `tsx scripts/<name>.ts`) and
+documents its own usage at the top of the file.
+
+## Build / CI helpers
+
+| Script | Purpose |
+| --- | --- |
+| `compute-csp-hashes.mjs` | Recompute the `'sha256-…'` directives for every inline `<script>` block in `index.html`. Run after editing JSON-LD or any other inline script, then paste the printed line into `nginx.conf` + `public/_headers`. The companion test (`tests/csp-hashes.test.ts`) fails CI if the hashes drift. |
+
+## Pipeline diagnostics (one-off)
+
+These helpers exist to debug the alpha pipeline against fixed input
+images. They write JSON / PNG dumps to `dist/` or stdout and are not
+called by the runtime:
+
+| Script | Purpose |
+| --- | --- |
+| `analyze-holes.mjs` | Detect interior holes (transparent islands) in an alpha mask and report counts + sizes. Used to tune cluster-size thresholds. |
+| `analyze-lowalpha.mjs` | Histogram the alpha channel and surface low-confidence bands (α ∈ [10..240]). Used when the RMBG threshold needs adjusting per image type. |
+| `analyze-region.mjs` | Crop a rectangular region and report per-pixel RGB + alpha statistics. |
+| `analyze-speckle.mjs` | Count tiny disconnected alpha blobs (speckle), grouped by size. Drives the `MIN_CLUSTER_SIZE` constants. |
+| `remove-bg-rmbg.ts` | Run the RMBG-1.4 segmenter against a single image, save the mask + composited PNG. Used to compare model upgrades. |
+| `validate.ts` | Run a full pipeline pass over every fixture in `tests/fixtures/` and emit a per-image report (timing, content-type, watermark hits). |
+| `validate-mascots.ts` | Same as `validate.ts` but scoped to the cartoon-mascot fixtures used to tune the illustration branch. |
+| `test-ml.ts` | Smoke-test the ML worker contract end-to-end against a single fixture. |

--- a/tests/changelog.test.ts
+++ b/tests/changelog.test.ts
@@ -35,9 +35,12 @@ describe('CHANGELOG.md', () => {
   });
 
   it('surfaces the latest merged PRs so the Unreleased entry stays current', () => {
-    // Sanity check the most recent work is represented.
-    expect(CHANGELOG).toMatch(/#101/);
-    expect(CHANGELOG).toMatch(/#102/);
+    // Sanity check that the most recent batch of work is represented.
+    // Bump these as the changelog grows; they are the canary for stale
+    // digests.
+    for (const pr of ['#101', '#106', '#113', '#114', '#115']) {
+      expect(CHANGELOG).toContain(pr);
+    }
   });
 
   it('ships a release-checklist template and compare link at the bottom', () => {

--- a/tests/fixtures/LICENSE.md
+++ b/tests/fixtures/LICENSE.md
@@ -1,0 +1,23 @@
+# Fixture image licences
+
+Each PNG / JPEG / WebP under `tests/fixtures/` is used by the test
+suite (Vitest + Playwright). They never ship with production builds.
+
+| File | Source | Licence | Notes |
+| --- | --- | --- | --- |
+| `coche.jpg` | Pexels (royalty-free stock) | Pexels Licence | Generic car shot — used by `e2e/coche-capture.spec.ts` to baseline an outdoor photo. |
+| `fiat-clean.png` | Manually authored | Project licence (GPL-3.0) | Vector mock car on a clean checkerboard. Drives illustration-branch fixtures. |
+| `football.webp` | Pexels | Pexels Licence | Stadium photo with green-on-green subject — adversarial RMBG case. |
+| `motorcycles-clean.png` | Manually authored | Project licence (GPL-3.0) | Vector mock — drives `tests/components` snapshots. |
+| `motostest.jpeg` | Pexels | Pexels Licence | Motorbike photo with hard edges + halo — used to tune foreground decontamination. |
+| `selfie-clean-corner.png` | Manually authored | Project licence (GPL-3.0) | Synthetic checkerboard fixture for AI-generated images. |
+| `selfie-sparkle-full.png` | Manually authored | Project licence (GPL-3.0) | Synthetic Gemini-watermark fixture. |
+| `trump-clean.png` | Manually authored | Project licence (GPL-3.0) | High-contrast portrait fixture for the illustration branch. |
+
+If you add a fixture:
+
+1. Pick royalty-free stock (Pexels, Unsplash, Pixabay) or author it yourself.
+2. Append a row above with source + licence.
+3. Don't commit anything that needs commercial-use clearance — the
+   tests fan out to public CI and visual-regression baselines that
+   can't be retracted later.


### PR DESCRIPTION
Pure housekeeping after the recent batch:

- CHANGELOG.md updated to cover #106..#115 (theme switcher, in-dropzone progress, reactor pivot, build hotfix, etc.). Canary test bumped to track the latest PR numbers.
- scripts/README.md added — describes every analyze/validate/CSP helper.
- tests/fixtures/LICENSE.md added — source + licence per fixture image.
- CONTRIBUTING.md gained a CI gates + branch protection section.

Closes the documentation acceptance items in #50.

## Test plan
- [x] vitest 6/6 changelog tests pass