### PR TITLE
chore(license): MobileSAM + LaMa in compliance table + contributor licensing terms

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -285,6 +285,45 @@ More test coverage is always welcome. Especially CV algorithm tests with edge-ca
 
 ---
 
+## > licensing_of_contributions
+
+NukeBG is published under [GPL-3.0-only](LICENSE). To keep the door open for
+future relicensing decisions (dual-licensing, swapping to a more permissive OSI
+license, or repackaging parts of the codebase under a different model), every
+contribution accepted into this repo is governed by the following terms.
+
+By submitting a pull request to this repository, you (the contributor) certify
+that:
+
+1. **Origin** — The contribution was created in whole by you, or you have the
+   right to submit it under the licensing terms below. If your contribution
+   includes third-party code, you have made that clear in the PR description
+   along with the third-party license.
+2. **Project license grant** — Your contribution is licensed under
+   [GPL-3.0-only](LICENSE) for inclusion in the project.
+3. **Relicense grant** — You additionally grant the project owner
+   ([@yocreoquesi](https://github.com/yocreoquesi)) a perpetual, worldwide,
+   non-exclusive, royalty-free, irrevocable right to relicense your
+   contribution under any [OSI-approved license](https://opensource.org/licenses)
+   in the future, at the project owner's discretion. This keeps the project's
+   relicensing options open without requiring contributor sign-off for every
+   change.
+4. **Patent grant** — You grant the same perpetual patent license to anyone
+   using the project as the GPL-3.0 already provides for the GPL portion.
+
+You are not assigning copyright — you keep ownership of your work. You are
+granting the project the rights it needs to ship and evolve.
+
+This sits in lieu of a separate signed CLA. By opening a PR you acknowledge
+these terms; the maintainer will check this is understood on first-time
+contributions before merging.
+
+If any of the above is a problem for your contribution (e.g. corporate IP that
+can't be licensed this way), open an issue first to discuss before submitting
+the PR. We can usually find a path.
+
+---
+
 ```
 $ echo "Thanks for helping nuke garbage backgrounds."
 Thanks for helping nuke garbage backgrounds.

--- a/README.md
+++ b/README.md
@@ -185,7 +185,9 @@ artifacts whose licenses carry independent obligations:
 
 | Component | License | Notes |
 |-----------|---------|-------|
-| RMBG-1.4 ML model (BRIA AI) | [bria-rmbg-1.4 license](https://huggingface.co/briaai/RMBG-1.4) | **Non-commercial use only**. Commercial deployments — paid products, paid APIs, paid SaaS — require a commercial agreement with BRIA AI, or swapping to a different model. The GPL-3.0 license of NukeBG's code does not override this. |
+| RMBG-1.4 ML model (BRIA AI) | [bria-rmbg-1.4 license](https://huggingface.co/briaai/RMBG-1.4) — CC-BY-NC-4.0 | **Non-commercial use only**. Commercial deployments — paid products, paid APIs, paid SaaS, ad-supported products — require a commercial agreement with BRIA AI, or swapping to a different model. The GPL-3.0 license of NukeBG's code does not override this. Donations to cover hosting / maintenance are fine. |
+| MobileSAM ML models (Acly/MobileSAM) | [MIT](https://huggingface.co/Acly/MobileSAM) | Used by the advanced editor for interactive click-to-segment. Commercial use OK. Encoder + decoder fetched from Hugging Face at runtime; not bundled. |
+| LaMa inpainting ML model (opencv/inpainting_lama) | [Apache-2.0](https://huggingface.co/opencv/inpainting_lama) | Used by the watermark-removal pipeline for content-aware reconstruction. Commercial use OK. Single FP32 ONNX (~95 MB) fetched from Hugging Face at runtime; not bundled. |
 | JetBrains Mono font | [SIL Open Font License 1.1](public/fonts/OFL.txt) | Bundled self-hosted. Attribution preserved in `public/fonts/OFL.txt`. |
 | Transformers.js, ONNX Runtime Web | Apache-2.0 / MIT | Compatible. |
 

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "version": "2.8.0",
   "type": "module",
   "description": "NukeBG: Nuke AI backgrounds, checkerboard patterns, and watermarks. 100% client-side. Zero uploads. Zero BS.",
-  "license": "GPL-3.0",
+  "license": "GPL-3.0-only",
   "scripts": {
     "dev": "vite",
     "build": "tsc && vite build",


### PR DESCRIPTION
## Summary

Three small license-hygiene fixes from the audit conversation.

### README license_compliance table
- Add **MobileSAM** (Acly/MobileSAM, MIT) — used by the advanced editor for click-to-segment
- Add **LaMa** (opencv/inpainting_lama, Apache-2.0) — used by the watermark inpainting pipeline
- Tighten the RMBG-1.4 row: spell out CC-BY-NC-4.0 explicitly, name the carve-out for "donations covering hosting" vs revenue-generating commercial use, list ad-supported as not OK

### CONTRIBUTING.md — \`licensing_of_contributions\`
New section. Acts as a lightweight CLA-equivalent: contributors grant the project owner the right to relicense their contribution under any OSI-approved license at the maintainer's discretion.

This keeps future moves possible (dual-license, MIT swap, repackage parts under a different model) without having to chase down every past contributor for sign-off. Standard practice for projects that want to keep their licensing options open without imposing a heavyweight signed CLA process.

### package.json license SPDX
\`GPL-3.0\` → \`GPL-3.0-only\` (canonical SPDX identifier; the short form is deprecated and trips license-checker tooling into reporting the package as UNLICENSED).

## Test plan

- [ ] README renders cleanly on GitHub
- [ ] CONTRIBUTING renders cleanly on GitHub
- [ ] \`npx license-checker-rseidelsohn --production --summary\` no longer flags nukebg as UNLICENSED
- [ ] All existing tests pass (no functional code touched)