### PR TITLE
feat(reactor): economics utilities + donors.json schema (#136)

### DIFF
--- a/public/donors.json
+++ b/public/donors.json
@@ -1,0 +1,7 @@
+{
+  "version": 1,
+  "updated_at": "2026-04-26",
+  "supporters": [],
+  "anonymous_count": 0,
+  "anonymous_total_eur": 0
+}

--- a/src/utils/reactor-economics.ts
+++ b/src/utils/reactor-economics.ts
@@ -1,0 +1,151 @@
+/**
+ * Reactor economics — pure computation layer for the funding transparency
+ * page (issue #137) and the post-process CTA rotation (issue #139).
+ *
+ * No DOM, no fetch, no side effects. All values are deliberately
+ * conservative and the methodology is documented inline so the numbers
+ * can be defended publicly without hand-waving.
+ *
+ * Background:
+ *   The project is bootstrapped on an AI coding assistant subscription
+ *   paid out of the maintainer's pocket. When that runs out, code
+ *   shipping pauses. Donations directly extend the development runway,
+ *   and this module turns euros into the time-units that humans
+ *   actually feel.
+ */
+
+/**
+ * Sunk investment to date. Time + cash that has already been spent.
+ * Not recoverable; framed as "gift to the community" on the reactor page.
+ *
+ * Hours estimate methodology: 313 commits across 13 active days, weighted
+ * by typical time-per-commit per category, +25% for research / debugging
+ * / discarded explorations not visible in the commit log. Estimate
+ * accuracy: roughly +/-15h.
+ *
+ * Hourly rate: 20 EUR/h is below the mid-market freelance rate in Spain
+ * (which sits around 22-25 EUR/h for a mid developer in 2026).
+ * Deliberately conservative so the number cannot be accused of inflation.
+ */
+export const SUNK = {
+  estimatedHours: 90,
+  hourlyRateEur: 20,
+  cashEur: 195,
+} as const;
+
+/**
+ * Forward burn — what it costs per month to keep code shipping. The
+ * infrastructure (Cloudflare Pages free tier + cached models) keeps
+ * the live app running for users at zero cost; this number is purely
+ * the cost of continuing to ship updates / fixes / new features.
+ */
+export const MONTHLY_BURN_EUR = 91.25;
+
+/**
+ * Breakdown of the estimated hours by activity. Categories chosen to
+ * answer the realistic question "where did the 90h go?". Percent values
+ * sum to 100 (verified by tests).
+ *
+ * The fix: prefix in this codebase is overloaded — it covers genuine
+ * regressions but also UX polish and build-compat patches. Hours have
+ * been redistributed accordingly so the bug-fix bucket reflects only
+ * real bug regressions.
+ */
+export const TIME_BREAKDOWN = [
+  { key: 'features', hours: 30, percent: 33 },
+  { key: 'design', hours: 16, percent: 18 },
+  { key: 'research', hours: 15, percent: 17 },
+  { key: 'bugfixes', hours: 12, percent: 13 },
+  { key: 'refactor', hours: 10, percent: 11 },
+  { key: 'tooling', hours: 5, percent: 6 },
+  { key: 'tests', hours: 2, percent: 2 },
+] as const;
+
+export interface SupporterEntry {
+  name: string;
+  amount_eur: number;
+  date: string;
+  consent: 'explicit';
+}
+
+export interface DonorsFile {
+  version: number;
+  updated_at: string;
+  supporters: SupporterEntry[];
+  anonymous_count: number;
+  anonymous_total_eur: number;
+}
+
+/**
+ * Total sunk investment in EUR (time at fair-rate + cash spent).
+ */
+export function totalSunkEur(): number {
+  return SUNK.estimatedHours * SUNK.hourlyRateEur + SUNK.cashEur;
+}
+
+/**
+ * Lifetime donations from the donors file: explicit supporters' amounts
+ * plus the anonymous bucket total.
+ */
+export function totalDonationsEur(donors: DonorsFile): number {
+  const explicit = donors.supporters.reduce((acc, s) => acc + s.amount_eur, 0);
+  return explicit + donors.anonymous_total_eur;
+}
+
+/**
+ * How long the current donation balance can fund development at the
+ * current monthly burn rate. Returns months as a float and days as an
+ * integer (days = floor of the leftover after whole months).
+ *
+ * Returns 0/0 if donations are zero — code shipping is currently
+ * funded by the maintainer's pocket, not by donations, and the page
+ * should show that honestly.
+ */
+export function computeRuntime(lifetimeDonationsEur: number): {
+  months: number;
+  days: number;
+} {
+  if (lifetimeDonationsEur <= 0) return { months: 0, days: 0 };
+  const monthsFloat = lifetimeDonationsEur / MONTHLY_BURN_EUR;
+  const wholeMonths = Math.floor(monthsFloat);
+  const leftover = monthsFloat - wholeMonths;
+  const days = Math.floor(leftover * 30);
+  return { months: wholeMonths, days };
+}
+
+/**
+ * Human-readable runtime: "0 months", "3.8 months", "1.0 month", etc.
+ * Uses one decimal so small donations register as a visible delta on
+ * the next render instead of disappearing into rounding.
+ */
+export function formatRuntime(monthsFloat: number): string {
+  if (monthsFloat <= 0) return '0 months';
+  const rounded = Math.round(monthsFloat * 10) / 10;
+  return `${rounded.toFixed(1)} months`;
+}
+
+/**
+ * What an incoming donation of `amountEur` adds to the runtime, framed
+ * as the smallest unit that still feels concrete.
+ *
+ *   < 1 day    -> "+X hours"
+ *   < 30 days  -> "+X days"
+ *   >= 30 days -> "+X months"
+ *
+ * Keeps the conversion legible and tangible at every donation size.
+ */
+export function donationToRuntimeDelta(amountEur: number): string {
+  if (amountEur <= 0) return '+0';
+  const monthsFloat = amountEur / MONTHLY_BURN_EUR;
+  const days = monthsFloat * 30;
+  if (days < 1) {
+    const hours = Math.round(days * 24);
+    return `+${hours} hour${hours === 1 ? '' : 's'}`;
+  }
+  if (days < 30) {
+    const rounded = Math.round(days * 10) / 10;
+    return `+${rounded.toFixed(1)} days`;
+  }
+  const months = Math.round(monthsFloat * 10) / 10;
+  return `+${months.toFixed(1)} months`;
+}

--- a/tests/utils/reactor-economics.test.ts
+++ b/tests/utils/reactor-economics.test.ts
@@ -1,0 +1,158 @@
+import { describe, it, expect } from 'vitest';
+import {
+  SUNK,
+  MONTHLY_BURN_EUR,
+  TIME_BREAKDOWN,
+  totalSunkEur,
+  totalDonationsEur,
+  computeRuntime,
+  formatRuntime,
+  donationToRuntimeDelta,
+  type DonorsFile,
+} from '../../src/utils/reactor-economics';
+
+describe('reactor-economics — constants', () => {
+  it('TIME_BREAKDOWN percents sum to 100', () => {
+    const total = TIME_BREAKDOWN.reduce((acc, b) => acc + b.percent, 0);
+    expect(total).toBe(100);
+  });
+
+  it('TIME_BREAKDOWN hours sum matches SUNK.estimatedHours', () => {
+    const total = TIME_BREAKDOWN.reduce((acc, b) => acc + b.hours, 0);
+    expect(total).toBe(SUNK.estimatedHours);
+  });
+
+  it('SUNK.hourlyRateEur is conservative for Spain (≤ €25/h)', () => {
+    expect(SUNK.hourlyRateEur).toBeLessThanOrEqual(25);
+  });
+
+  it('MONTHLY_BURN_EUR matches the documented breakdown (€90 AI + €1.25 domain)', () => {
+    expect(MONTHLY_BURN_EUR).toBe(91.25);
+  });
+});
+
+describe('reactor-economics — totalSunkEur', () => {
+  it('combines time value and cash spent', () => {
+    expect(totalSunkEur()).toBe(SUNK.estimatedHours * SUNK.hourlyRateEur + SUNK.cashEur);
+  });
+
+  it('matches the documented €1,995 figure with current constants', () => {
+    expect(totalSunkEur()).toBe(1995);
+  });
+});
+
+describe('reactor-economics — totalDonationsEur', () => {
+  const empty: DonorsFile = {
+    version: 1,
+    updated_at: '2026-04-26',
+    supporters: [],
+    anonymous_count: 0,
+    anonymous_total_eur: 0,
+  };
+
+  it('returns 0 for an empty donors file', () => {
+    expect(totalDonationsEur(empty)).toBe(0);
+  });
+
+  it('sums explicit supporter amounts', () => {
+    const file: DonorsFile = {
+      ...empty,
+      supporters: [
+        { name: 'a', amount_eur: 25, date: '2026-04-20', consent: 'explicit' },
+        { name: 'b', amount_eur: 15, date: '2026-04-21', consent: 'explicit' },
+      ],
+    };
+    expect(totalDonationsEur(file)).toBe(40);
+  });
+
+  it('includes the anonymous bucket', () => {
+    const file: DonorsFile = {
+      ...empty,
+      supporters: [{ name: 'a', amount_eur: 10, date: '2026-04-20', consent: 'explicit' }],
+      anonymous_count: 3,
+      anonymous_total_eur: 30,
+    };
+    expect(totalDonationsEur(file)).toBe(40);
+  });
+});
+
+describe('reactor-economics — computeRuntime', () => {
+  it('returns 0/0 for zero donations (no fake runway)', () => {
+    expect(computeRuntime(0)).toEqual({ months: 0, days: 0 });
+  });
+
+  it('returns 0/0 for negative input (defensive)', () => {
+    expect(computeRuntime(-50)).toEqual({ months: 0, days: 0 });
+  });
+
+  it('returns 1 month for exactly one burn unit', () => {
+    expect(computeRuntime(MONTHLY_BURN_EUR)).toEqual({ months: 1, days: 0 });
+  });
+
+  it('returns months + leftover days for partial second month', () => {
+    // 1.5 burn units = 1 month + 15 days
+    const result = computeRuntime(MONTHLY_BURN_EUR * 1.5);
+    expect(result.months).toBe(1);
+    expect(result.days).toBe(15);
+  });
+
+  it('handles small donations as 0 months + some days', () => {
+    // €5 = 5/91.25 ≈ 0.0548 months ≈ 1.6 days
+    const result = computeRuntime(5);
+    expect(result.months).toBe(0);
+    expect(result.days).toBe(1);
+  });
+
+  it('handles a large donation correctly (12 months)', () => {
+    expect(computeRuntime(MONTHLY_BURN_EUR * 12)).toEqual({ months: 12, days: 0 });
+  });
+});
+
+describe('reactor-economics — formatRuntime', () => {
+  it('shows 0 months for zero or negative input', () => {
+    expect(formatRuntime(0)).toBe('0 months');
+    expect(formatRuntime(-5)).toBe('0 months');
+  });
+
+  it('shows one decimal for fractional months', () => {
+    expect(formatRuntime(3.84)).toBe('3.8 months');
+    expect(formatRuntime(0.55)).toBe('0.6 months');
+  });
+
+  it('always uses "months" plural — terminal aesthetic, no special case', () => {
+    expect(formatRuntime(1)).toBe('1.0 months');
+  });
+});
+
+describe('reactor-economics — donationToRuntimeDelta', () => {
+  it('returns +0 for zero or negative donations', () => {
+    expect(donationToRuntimeDelta(0)).toBe('+0');
+    expect(donationToRuntimeDelta(-10)).toBe('+0');
+  });
+
+  it('expresses tiny donations in hours', () => {
+    // €1 = 1/91.25 months ≈ 0.33 days ≈ 8 hours
+    expect(donationToRuntimeDelta(1)).toMatch(/^\+\d+ hours?$/);
+  });
+
+  it('expresses small donations in days (between 1 and 30)', () => {
+    // €5 = ≈ 1.6 days
+    expect(donationToRuntimeDelta(5)).toBe('+1.6 days');
+    // €25 = ≈ 8.2 days
+    expect(donationToRuntimeDelta(25)).toBe('+8.2 days');
+  });
+
+  it('expresses large donations in months (>= 30 days)', () => {
+    // €91.25 = exactly 1 month
+    expect(donationToRuntimeDelta(MONTHLY_BURN_EUR)).toBe('+1.0 months');
+    // €273.75 = 3 months
+    expect(donationToRuntimeDelta(MONTHLY_BURN_EUR * 3)).toBe('+3.0 months');
+  });
+
+  it('singular vs plural hours', () => {
+    // Find an amount that gives exactly 1 hour
+    // 1 hour = 1/24 days = 1/(24*30) months = MONTHLY_BURN_EUR / 720
+    const oneHourEur = MONTHLY_BURN_EUR / 720;
+    expect(donationToRuntimeDelta(oneHourEur)).toBe('+1 hour');
+  });
+});


### PR DESCRIPTION
Closes #136. Foundation for the reactor transparency feature — pure computation layer, no UI yet.

**Adds**
- `public/donors.json` (empty initial schema)
- `src/utils/reactor-economics.ts` (constants + 5 pure functions)
- 23 test cases

**Constants** are deliberately conservative and the methodology is documented inline so the published numbers can be defended publicly.

**Unblocks** #137 (the /reactor page), #138 (footer copy), #139 (post-process CTA).