### PR TITLE
feat(reactor): footer + marquee runtime-aware copy (#138)

### DIFF
--- a/index.html
+++ b/index.html
@@ -364,7 +364,7 @@
     <span class="footer-sep">|</span>
     <a href="https://github.com/yocreoquesi/nukebg" target="_blank" rel="noopener noreferrer">GitHub</a>
     <span class="footer-sep">|</span>
-    <a href="https://ko-fi.com/yocreoquesi" target="_blank" rel="noopener noreferrer" class="kofi-link" id="kofi-link">☕ Support on Ko-fi</a>
+    <a href="https://ko-fi.com/yocreoquesi" target="_blank" rel="noopener noreferrer" class="kofi-link" id="kofi-link" aria-label="Tip the reactor">☕ Tip the reactor →</a>
     <span class="footer-sep">|</span>
     <a href="#" id="clear-cache-btn" class="footer-cache-btn" title="Clear cached data and reload">☢ Clear cache</a>
     <span class="footer-sep">|</span>
@@ -380,6 +380,7 @@
       <button type="button" class="theme-swatch" role="radio" data-theme="yellow" aria-checked="false" aria-label="Yellow" title="Yellow"></button>
     </div>
     <span class="footer-privacy" id="footer-privacy">Your images never leave your device. Zero uploads. Zero BS.</span>
+    <span class="footer-reactor-status" id="footer-reactor-status">Ships only while the budget holds (€91/mo). Currently funded for 0 months.</span>
     <span class="footer-holiday" id="footer-holiday"></span>
   </footer>
 

--- a/src/components/ar-app.ts
+++ b/src/components/ar-app.ts
@@ -959,7 +959,7 @@ export class ArApp extends HTMLElement {
       <!-- Full-bleed marquee outside the main column per design #69.
            Gradient mask fades text in/out at the edges so it never
            clips mid-word the way the old column-scoped marquee did. -->
-      <div class="marquee-bleed" id="precision-marquee-bleed"><span>☢ NUKEBG | DROP. NUKE. DOWNLOAD. | Your images never leave your device | nukebg.app ☢ NUKEBG | DROP. NUKE. DOWNLOAD. | Your images never leave your device | nukebg.app ☢</span></div>
+      <div class="marquee-bleed" id="precision-marquee-bleed"><span>☢ NUKEBG | DROP. NUKE. DOWNLOAD. | Your images never leave your device | <span data-marquee-runtime>development funded for 0 months — tip to extend runway</span> | nukebg.app ☢ NUKEBG | DROP. NUKE. DOWNLOAD. | <span data-marquee-runtime>development funded for 0 months — tip to extend runway</span> | nukebg.app ☢</span></div>
 
       <section class="hero" id="hero">
         <h1>

--- a/src/i18n/index.ts
+++ b/src/i18n/index.ts
@@ -190,7 +190,10 @@ const translations: Translations = {
     'download.share.text': 'Processed with nukebg.app — stays local',
     // Header / Footer (index.html)
     'header.skipLink': 'Skip to main content',
-    'footer.kofi': '\u2615 Support on Ko-fi',
+    'footer.kofi': '\u2615 Tip the reactor \u2192',
+    'footer.kofiAria': 'Tip the reactor \u2014 currently funded for {runtime}',
+    'footer.reactorStatus': 'Ships only while the budget holds ({burn}). Currently funded for {runtime}.',
+    'marquee.funding': 'development funded for {runtime} \u2014 tip to extend runway',
     'footer.privacy': 'Your images never leave your device. Zero uploads. Zero BS.',
 
     // Pipeline error
@@ -413,7 +416,10 @@ const translations: Translations = {
     'download.share.text': 'Procesado con nukebg.app — todo local',
     // Header / Footer (index.html)
     'header.skipLink': 'Saltar al contenido principal',
-    'footer.kofi': '\u2615 Apoyar en Ko-fi',
+    'footer.kofi': '\u2615 Alimentar el reactor \u2192',
+    'footer.kofiAria': 'Alimentar el reactor \u2014 actualmente financiado por {runtime}',
+    'footer.reactorStatus': 'Sigue funcionando mientras el presupuesto aguante ({burn}). Actualmente financiado por {runtime}.',
+    'marquee.funding': 'desarrollo financiado por {runtime} \u2014 ap\u00F3yanos para extender el runway',
     'footer.privacy': 'Tus im\u00E1genes nunca salen de tu dispositivo. Cero subidas. Cero complicaciones.',
 
     // Pipeline error
@@ -636,7 +642,10 @@ const translations: Translations = {
     'download.share.text': 'Traité avec nukebg.app — 100% local',
     // Header / Footer (index.html)
     'header.skipLink': 'Aller au contenu principal',
-    'footer.kofi': '\u2615 Soutenir sur Ko-fi',
+    'footer.kofi': '\u2615 Alimenter le r\u00E9acteur \u2192',
+    'footer.kofiAria': 'Alimenter le r\u00E9acteur \u2014 actuellement financ\u00E9 pour {runtime}',
+    'footer.reactorStatus': 'Continue tant que le budget tient ({burn}). Actuellement financ\u00E9 pour {runtime}.',
+    'marquee.funding': 'd\u00E9veloppement financ\u00E9 pour {runtime} \u2014 soutenez pour prolonger',
     'footer.privacy': 'Tes images ne quittent jamais ton appareil. Z\u00E9ro upload. Z\u00E9ro baratin.',
 
     // Pipeline error
@@ -859,7 +868,10 @@ const translations: Translations = {
     'download.share.text': 'Mit nukebg.app verarbeitet — bleibt lokal',
     // Header / Footer (index.html)
     'header.skipLink': 'Zum Hauptinhalt springen',
-    'footer.kofi': '\u2615 Unterst\u00FCtzen auf Ko-fi',
+    'footer.kofi': '\u2615 Reaktor speisen \u2192',
+    'footer.kofiAria': 'Reaktor speisen \u2014 aktuell finanziert f\u00FCr {runtime}',
+    'footer.reactorStatus': 'L\u00E4uft solange das Budget reicht ({burn}). Aktuell finanziert f\u00FCr {runtime}.',
+    'marquee.funding': 'Entwicklung finanziert f\u00FCr {runtime} \u2014 speisen um zu verl\u00E4ngern',
     'footer.privacy': 'Deine Bilder verlassen nie dein Ger\u00E4t. Null Uploads. Null Bullshit.',
 
     // Pipeline error
@@ -1082,7 +1094,10 @@ const translations: Translations = {
     'download.share.text': 'Processado com nukebg.app — fica local',
     // Header / Footer (index.html)
     'header.skipLink': 'Pular para o conte\u00FAdo principal',
-    'footer.kofi': '\u2615 Apoiar no Ko-fi',
+    'footer.kofi': '\u2615 Alimentar o reator \u2192',
+    'footer.kofiAria': 'Alimentar o reator \u2014 atualmente financiado por {runtime}',
+    'footer.reactorStatus': 'Continua enquanto o or\u00E7amento aguentar ({burn}). Atualmente financiado por {runtime}.',
+    'marquee.funding': 'desenvolvimento financiado por {runtime} \u2014 apoia para estender',
     'footer.privacy': 'Suas imagens nunca saem do seu dispositivo. Zero uploads. Zero enrola\u00E7\u00E3o.',
 
     // Pipeline error
@@ -1305,7 +1320,10 @@ const translations: Translations = {
     'download.share.text': '\u7531 nukebg.app \u5904\u7406—\u672C\u5730\u8FD0\u884C',
     // Header / Footer (index.html)
     'header.skipLink': '\u8DF3\u8F6C\u5230\u4E3B\u8981\u5185\u5BB9',
-    'footer.kofi': '\u2615 \u5728 Ko-fi \u4E0A\u652F\u6301\u6211\u4EEC',
+    'footer.kofi': '\u2615 \u8D44\u52A9\u53CD\u5E94\u5806 \u2192',
+    'footer.kofiAria': '\u8D44\u52A9\u53CD\u5E94\u5806 \u2014 \u76EE\u524D\u8D44\u91D1\u53EF\u7EF4\u6301 {runtime}',
+    'footer.reactorStatus': '\u9884\u7B97\u591F\u7528\u5C31\u7EE7\u7EED\u8FD0\u884C ({burn})\u3002\u76EE\u524D\u8D44\u91D1\u53EF\u7EF4\u6301 {runtime}',
+    'marquee.funding': '\u5F00\u53D1\u8D44\u91D1\u53EF\u7EF4\u6301 {runtime} \u2014 \u8D44\u52A9\u4EE5\u5EF6\u957F',
     'footer.privacy': '\u4F60\u7684\u56FE\u7247\u6C38\u8FDC\u4E0D\u4F1A\u79BB\u5F00\u4F60\u7684\u8BBE\u5907\u3002\u96F6\u4E0A\u4F20\u3002\u4E0D\u6574\u865A\u7684\u3002',
 
     // Pipeline error

--- a/src/main.ts
+++ b/src/main.ts
@@ -6,6 +6,7 @@ import './styles/main.css';
 
 // i18n - importar antes de los componentes para que detecte el locale
 import { getLocale, setLocale, getDirection, t } from './i18n';
+import { applyReactorStatus, formatBurnRate } from './utils/reactor-status-injector';
 
 // Register Web Components
 import './components/ar-dropzone';
@@ -956,6 +957,19 @@ function init(): void {
   initLogoClickCounter();
   initLogoDoubleTap();
   initShakeDetection();
+  initReactorStatus();
+}
+
+function initReactorStatus(): void {
+  const burn = formatBurnRate();
+  void applyReactorStatus({
+    footerStatus: (runtime) =>
+      t('footer.reactorStatus', { burn, runtime }),
+    marqueeFunding: (runtime) =>
+      t('marquee.funding', { burn, runtime }),
+    kofiAriaLabel: (runtime) =>
+      t('footer.kofiAria', { runtime }),
+  });
 }
 
 if (document.readyState === 'loading') {

--- a/src/utils/reactor-status-injector.ts
+++ b/src/utils/reactor-status-injector.ts
@@ -1,0 +1,76 @@
+/**
+ * Reactor status injector — fetches donors.json at boot, computes runtime
+ * via the pure economics module, and updates the few DOM elements that
+ * carry the live numbers (footer status line, marquee segment, Ko-fi
+ * link aria-label).
+ *
+ * Pure separation: no economics math here, no UI math here. Just glue.
+ *
+ * Failure mode: if the fetch fails (offline, CDN hiccup) we leave the
+ * placeholders alone. The placeholders themselves are honest defaults
+ * ("0 months" — same as the no-donations state) so a failed fetch is
+ * indistinguishable from "no donations yet" to the user. No UX surprise.
+ */
+
+import {
+  computeRuntime,
+  formatRuntime,
+  totalDonationsEur,
+  MONTHLY_BURN_EUR,
+  type DonorsFile,
+} from './reactor-economics';
+
+const DONORS_URL = '/donors.json';
+
+interface ReactorStatusStrings {
+  /** Footer status line. Receives `{runtime}` as the runtime label. */
+  footerStatus: (runtime: string) => string;
+  /** Marquee segment. Receives `{runtime}` as the runtime label. */
+  marqueeFunding: (runtime: string) => string;
+  /** aria-label / title for the Ko-fi link. Receives `{runtime}`. */
+  kofiAriaLabel: (runtime: string) => string;
+}
+
+export async function applyReactorStatus(strings: ReactorStatusStrings): Promise<void> {
+  const runtimeLabel = await fetchAndComputeRuntime();
+  applyDom(runtimeLabel, strings);
+}
+
+/**
+ * Pure-ish: does the fetch + math, returns the human runtime label.
+ * Returns "0 months" on any failure path (offline, malformed JSON, etc.)
+ * so callers always have something safe to render.
+ */
+async function fetchAndComputeRuntime(): Promise<string> {
+  try {
+    const res = await fetch(DONORS_URL, { cache: 'no-cache' });
+    if (!res.ok) return formatRuntime(0);
+    const donors = (await res.json()) as DonorsFile;
+    const totalEur = totalDonationsEur(donors);
+    const { months, days } = computeRuntime(totalEur);
+    const monthsFloat = months + days / 30;
+    return formatRuntime(monthsFloat);
+  } catch {
+    return formatRuntime(0);
+  }
+}
+
+function applyDom(runtimeLabel: string, strings: ReactorStatusStrings): void {
+  const footer = document.getElementById('footer-reactor-status');
+  if (footer) footer.textContent = strings.footerStatus(runtimeLabel);
+
+  // Marquee text — the marquee is a long string with our segment marked
+  // by a sentinel placeholder (to avoid having to re-render the whole
+  // animated span). Replace the placeholder with the live segment.
+  document.querySelectorAll<HTMLSpanElement>('[data-marquee-runtime]').forEach((el) => {
+    el.textContent = strings.marqueeFunding(runtimeLabel);
+  });
+
+  const kofi = document.getElementById('kofi-link');
+  if (kofi) kofi.setAttribute('aria-label', strings.kofiAriaLabel(runtimeLabel));
+}
+
+/** Exported for tests — the burn rate in human-readable form. */
+export function formatBurnRate(): string {
+  return `€${MONTHLY_BURN_EUR.toFixed(2).replace(/\.00$/, '')}/mo`;
+}


### PR DESCRIPTION
Closes #138.

Replaces the static 'Support on Ko-fi' footer link with runtime-aware copy and adds a marquee segment that announces current funding. Vendor-neutral wording (no 'Claude Code' / 'Copilot' brand mentions in user-visible text). Both surfaces are updated at boot from donors.json via the pure economics module from #136.

**Footer**
- 'Tip the reactor →' (was 'Support on Ko-fi')
- New status line: 'Ships only while the budget holds (€91/mo). Currently funded for 0 months.'

**Marquee**
- New segment: 'development funded for 0 months — tip to extend runway'

**Plumbing**
- `src/utils/reactor-status-injector.ts` — fetches donors.json, computes runtime, injects DOM. Falls back silently to '0 months' on any failure path
- All four i18n keys translated in 6 locales

**Tests**: 649 passing (up from 626 — the new economics module from #136 added 23 tests in the previous PR)