### PR TITLE
fix(mobile): triple polish — duplicated $, camera CTA, footer privacy (#146, #149)

### DIFF
--- a/e2e/coche-capture.spec.ts
+++ b/e2e/coche-capture.spec.ts
@@ -19,7 +19,7 @@ test('capture coche output + mirror console/network', async ({ page }, testInfo)
   await page.goto('/');
   await page.waitForLoadState('networkidle');
 
-  const fileInput = page.locator('ar-dropzone').locator('input[type="file"]:not(.dz-camera-input)');
+  const fileInput = page.locator('ar-dropzone').locator('input[type="file"]');
   await fileInput.setInputFiles(FIXTURE);
 
   const downloadBtn = page.locator('ar-download').locator('#dl-png');

--- a/e2e/football-capture.spec.ts
+++ b/e2e/football-capture.spec.ts
@@ -19,7 +19,7 @@ test('capture football output + mirror console/network', async ({ page }, testIn
   await page.goto('/');
   await page.waitForLoadState('networkidle');
 
-  const fileInput = page.locator('ar-dropzone').locator('input[type="file"]:not(.dz-camera-input)');
+  const fileInput = page.locator('ar-dropzone').locator('input[type="file"]');
   await fileInput.setInputFiles(FIXTURE);
 
   const downloadBtn = page.locator('ar-download').locator('#dl-png');

--- a/e2e/motostest-capture.spec.ts
+++ b/e2e/motostest-capture.spec.ts
@@ -18,7 +18,7 @@ test('capture motostest output for halo comparison', async ({ page, baseURL }, t
   await page.goto('/');
   await page.waitForLoadState('networkidle');
 
-  const fileInput = page.locator('ar-dropzone').locator('input[type="file"]:not(.dz-camera-input)');
+  const fileInput = page.locator('ar-dropzone').locator('input[type="file"]');
   await fileInput.setInputFiles(FIXTURE);
 
   const downloadBtn = page.locator('ar-download').locator('#dl-png');

--- a/e2e/pipeline.spec.ts
+++ b/e2e/pipeline.spec.ts
@@ -41,10 +41,8 @@ test.describe('pipeline end-to-end', () => {
     await page.goto('/');
     await page.waitForLoadState('networkidle');
 
-    // ar-dropzone exposes two hidden <input type="file"> elements (regular +
-    // mobile camera CTA). Disambiguate with :not(.dz-camera-input) — same
-    // selector the component itself uses internally.
-    const fileInput = page.locator('ar-dropzone').locator('input[type="file"]:not(.dz-camera-input)');
+    // ar-dropzone exposes a single hidden <input type="file"> in shadow DOM.
+    const fileInput = page.locator('ar-dropzone').locator('input[type="file"]');
     await fileInput.setInputFiles(FIXTURE);
 
     // ar-download makes its #dl-png href a blob: URL only after the pipeline

--- a/src/components/ar-app.ts
+++ b/src/components/ar-app.ts
@@ -964,7 +964,7 @@ export class ArApp extends HTMLElement {
       <section class="hero" id="hero">
         <h1>
           <span class="hero-title-long"><span class="accent">${t('hero.title.accent')}</span> ${t('hero.title.rest')}</span>
-          <span class="hero-title-short"><span class="accent">$ </span>${t('hero.title.short')}</span>
+          <span class="hero-title-short"><span class="accent">${t('hero.title.short')}</span></span>
         </h1>
         <p class="subline">
           <span class="subline-long">${t('hero.subtitle').replace(/\n/g, ' ')}</span>
@@ -1084,7 +1084,7 @@ export class ArApp extends HTMLElement {
     const h1 = root.querySelector('h1');
     if (h1) h1.innerHTML =
       `<span class="hero-title-long"><span class="accent">${t('hero.title.accent')}</span> ${t('hero.title.rest')}</span>` +
-      `<span class="hero-title-short"><span class="accent">$ </span>${t('hero.title.short')}</span>`;
+      `<span class="hero-title-short"><span class="accent">${t('hero.title.short')}</span></span>`;
     const subline = root.querySelector('.subline');
     if (subline) subline.innerHTML =
       `<span class="subline-long">${t('hero.subtitle').replace(/\n/g, ' ')}</span>` +

--- a/src/components/ar-dropzone.ts
+++ b/src/components/ar-dropzone.ts
@@ -4,7 +4,6 @@ import { getBatchLimit } from '../types/batch';
 
 export class ArDropzone extends HTMLElement {
   private fileInput!: HTMLInputElement;
-  private cameraInput!: HTMLInputElement;
   private dropArea!: HTMLDivElement;
   private boundLocaleHandler: (() => void) | null = null;
   private boundPasteHandler: ((e: ClipboardEvent) => void) | null = null;
@@ -123,34 +122,6 @@ export class ArDropzone extends HTMLElement {
           content: '[*] ';
           color: var(--color-accent-primary, #00ff41);
         }
-        /* Camera CTA — mobile-only (#73). Triggers a second file input
-           with capture="environment" so iOS / Android opens the camera
-           directly instead of the photo library. */
-        .dz-camera-cta {
-          display: none;
-          margin-top: 10px;
-          padding: 10px 14px;
-          font-family: 'JetBrains Mono', monospace;
-          font-size: 13px;
-          letter-spacing: 0.05em;
-          background: transparent;
-          color: var(--color-accent-primary, #00ff41);
-          border: 1px solid var(--color-accent-primary, #00ff41);
-          border-radius: 0;
-          cursor: pointer;
-          min-height: 44px;
-          transition: background 0.15s ease, box-shadow 0.15s ease;
-        }
-        .dz-camera-cta:hover,
-        .dz-camera-cta:focus-visible {
-          background: rgba(var(--color-accent-rgb, 0, 255, 65), 0.08);
-          box-shadow: 0 0 8px rgba(var(--color-accent-rgb, 0, 255, 65), 0.2);
-          outline: none;
-        }
-        @media (pointer: coarse), (max-width: 480px) {
-          .dz-camera-cta { display: inline-flex; align-items: center; justify-content: center; }
-        }
-        .dz-camera-input { display: none; }
 
         /* Loading slot — model warmup progress lives inside the
            dropzone so the page doesn't reflow when fetch resolves.
@@ -199,9 +170,7 @@ export class ArDropzone extends HTMLElement {
           color: var(--color-text-tertiary, #00b34a);
         }
         /* When the loading slot is visible, the camera CTA hides so
-           the row swaps cleanly; when loading ends, the camera CTA
-           returns. */
-        .dropzone.is-loading .dz-camera-cta { display: none !important; }
+           the row swaps cleanly. */
         .dropzone:hover {
           box-shadow:
             0 0 18px rgba(var(--color-accent-rgb, 0, 255, 65), 0.14),
@@ -304,13 +273,14 @@ export class ArDropzone extends HTMLElement {
           <span id="dz-formats">${t('dropzone.formats')}</span>
           <span class="hint-multi" id="dz-multi">${t('dropzone.multi')}</span>
         </div>
-        <button type="button" class="dz-camera-cta" id="dz-camera-cta">
-          &#8227; ${t('dropzone.takePhoto')}
-        </button>
-        <!-- Loading slot — sits in the same vertical space as the
-             camera CTA so the dropzone doesn't reflow when the model
-             finishes warming up. ar-app drives visibility + progress
-             via setLoadingState(). -->
+        <!-- #146: dedicated 'tomar foto' camera CTA removed.
+             Tapping the dropzone box already opens the OS file picker,
+             which on mobile exposes the camera as one of the source
+             options. The extra button was duplicating that affordance
+             and making the mobile UX inconsistent with desktop. -->
+        <!-- Loading slot — sits where the old camera CTA was so the
+             dropzone doesn't reflow when the model finishes warming up.
+             ar-app drives visibility + progress via setLoadingState(). -->
         <div class="dz-loading" id="dz-loading" role="status" aria-live="polite" hidden>
           <div class="dz-loading-head">
             <span class="dz-loading-prompt">$</span>
@@ -323,12 +293,10 @@ export class ArDropzone extends HTMLElement {
         </div>
       </div>
       <input type="file" accept="image/png,image/jpeg,image/webp" multiple />
-      <input type="file" accept="image/*" capture="environment" class="dz-camera-input" />
     `;
 
     this.dropArea = this.shadowRoot!.querySelector('.dropzone')!;
-    this.fileInput = this.shadowRoot!.querySelector('input[type="file"]:not(.dz-camera-input)')!;
-    this.cameraInput = this.shadowRoot!.querySelector('input.dz-camera-input')!;
+    this.fileInput = this.shadowRoot!.querySelector('input[type="file"]')!;
   }
 
   private updateTexts(): void {
@@ -345,8 +313,6 @@ export class ArDropzone extends HTMLElement {
     if (dragover) dragover.textContent = t('dropzone.dragover');
     const dropzone = root.querySelector('.dropzone');
     if (dropzone) dropzone.setAttribute('aria-label', t('dropzone.ariaLabel'));
-    const camera = root.querySelector('#dz-camera-cta');
-    if (camera) camera.innerHTML = `&#8227; ${t('dropzone.takePhoto')}`;
   }
 
   private setupEvents(): void {
@@ -356,19 +322,16 @@ export class ArDropzone extends HTMLElement {
     };
     document.addEventListener('nukebg:locale-changed', this.boundLocaleHandler);
 
-    // Click to open file picker — but ignore clicks that bubbled from
-    // the inline camera CTA (it manages its own file input).
-    this.dropArea.addEventListener('click', (e) => {
-      const target = e.target as HTMLElement | null;
-      if (target?.closest('#dz-camera-cta')) return;
+    // Click to open file picker. The OS picker exposes the camera as
+    // one of the source options on mobile, so a dedicated camera CTA
+    // is unnecessary (#146).
+    this.dropArea.addEventListener('click', () => {
       this.fileInput.click();
     });
 
     // Keyboard support
     this.dropArea.addEventListener('keydown', (e) => {
       if (e.key === 'Enter' || e.key === ' ') {
-        const target = e.target as HTMLElement | null;
-        if (target?.closest('#dz-camera-cta')) return;
         e.preventDefault();
         this.fileInput.click();
       }
@@ -378,20 +341,6 @@ export class ArDropzone extends HTMLElement {
     this.fileInput.addEventListener('change', () => {
       if (this.fileInput.files && this.fileInput.files.length > 0) {
         this.handleFiles(this.fileInput.files);
-      }
-    });
-
-    // Camera CTA (#73). Opens a second file input with
-    // capture="environment" so iOS / Android treat it as a camera
-    // intent instead of the photo library picker.
-    const cameraBtn = this.shadowRoot!.querySelector('#dz-camera-cta') as HTMLButtonElement | null;
-    cameraBtn?.addEventListener('click', (e) => {
-      e.stopPropagation();
-      this.cameraInput.click();
-    });
-    this.cameraInput.addEventListener('change', () => {
-      if (this.cameraInput.files && this.cameraInput.files.length > 0) {
-        this.handleFiles(this.cameraInput.files);
       }
     });
 

--- a/src/i18n/index.ts
+++ b/src/i18n/index.ts
@@ -14,7 +14,7 @@ const translations: Translations = {
     'hero.subtitle': 'Drop any image. Get a clean transparent PNG.\nNo upload. No account. No BS.',
     'hero.title.short': 'NUKE BG',
     'hero.subtitle.short': 'Drop image · transparent PNG · stays local.',
-    'dropzone.takePhoto': 'take photo',    'hero.modelStatus': 'Ready to nuke',
+    'hero.modelStatus': 'Ready to nuke',
 
     // Dropzone
     'dropzone.title': 'Drop your image here',
@@ -282,7 +282,7 @@ const translations: Translations = {
     'hero.subtitle': 'Arrastra una imagen. Obt\u00E9n un PNG transparente.\nSin subidas. Sin cuenta. Sin complicaciones.',
     'hero.title.short': 'NUKE FONDOS',
     'hero.subtitle.short': 'Imagen · PNG transparente · nunca sale.',
-    'dropzone.takePhoto': 'tomar foto',    'hero.modelStatus': 'Listo para nukear',
+    'hero.modelStatus': 'Listo para nukear',
 
     // Dropzone
     'dropzone.title': 'Arrastra tu imagen aqu\u00ED',
@@ -550,7 +550,7 @@ const translations: Translations = {
     'hero.subtitle': "Balance ton image. R\u00E9cup\u00E8re un PNG transparent.\nZ\u00E9ro upload. Z\u00E9ro compte. Z\u00E9ro baratin.",
     'hero.title.short': 'NUKE ARRI\u00C8RE',
     'hero.subtitle.short': 'D\u00E9pose · PNG transparent · reste local.',
-    'dropzone.takePhoto': 'prendre photo',    'hero.modelStatus': 'Pr\u00EAt \u00E0 atomiser',
+    'hero.modelStatus': 'Pr\u00EAt \u00E0 atomiser',
 
     // Dropzone
     'dropzone.title': 'D\u00E9pose ton image ici',
@@ -818,7 +818,7 @@ const translations: Translations = {
     'hero.subtitle': 'Bild reinwerfen. Transparentes PNG kriegen.\nKein Upload. Kein Konto. Kein Bullshit.',
     'hero.title.short': 'NUKE BG',
     'hero.subtitle.short': 'Bild · transparentes PNG · bleibt lokal.',
-    'dropzone.takePhoto': 'foto machen',    'hero.modelStatus': 'Bereit zum Nuken',
+    'hero.modelStatus': 'Bereit zum Nuken',
 
     // Dropzone
     'dropzone.title': 'Bild hier ablegen',
@@ -1086,7 +1086,7 @@ const translations: Translations = {
     'hero.subtitle': 'Joga a imagem. Pega o PNG transparente.\nSem upload. Sem conta. Sem frescura.',
     'hero.title.short': 'NUKE FUNDO',
     'hero.subtitle.short': 'Imagem · PNG transparente · fica local.',
-    'dropzone.takePhoto': 'tirar foto',    'hero.modelStatus': 'Pronto pra nukear',
+    'hero.modelStatus': 'Pronto pra nukear',
 
     // Dropzone
     'dropzone.title': 'Solta a imagem aqui',
@@ -1354,7 +1354,7 @@ const translations: Translations = {
     'hero.subtitle': '\u4E22\u5F20\u56FE\u7247\u8FDB\u6765\u3002\u62FF\u8D70\u900F\u660E PNG\u3002\n\u96F6\u4E0A\u4F20\u3002\u96F6\u6CE8\u518C\u3002\u96F6\u5E9F\u8BDD\u3002',
     'hero.title.short': '\u6838\u7206\u80CC\u666F',
     'hero.subtitle.short': '\u56FE\u7247 · \u900F\u660E PNG · \u672C\u5730\u5904\u7406',
-    'dropzone.takePhoto': '\u62CD\u7167',    'hero.modelStatus': '\u51C6\u5907\u6838\u7206',
+    'hero.modelStatus': '\u51C6\u5907\u6838\u7206',
 
     // Dropzone
     'dropzone.title': '\u628A\u56FE\u7247\u4E22\u8FD9\u91CC',

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -818,6 +818,11 @@ body::after {
     margin: 0 var(--space-1);
   }
   .footer-privacy {
+    /* #149 — already shown in marquee + hero subtitle on mobile;
+       repeating it in the footer is just clutter on a narrow viewport */
+    display: none;
+  }
+  .footer-reactor-status {
     font-size: var(--text-xs);
   }
   .kbd-toast {

--- a/tests/components/ar-first-run.test.ts
+++ b/tests/components/ar-first-run.test.ts
@@ -30,10 +30,6 @@ describe('first-run explainer (#78)', () => {
     expect(DZ).toMatch(/label\.textContent = t\(['"]firstRun\.ready['"]\)/);
   });
 
-  it('camera CTA hides while the loading slot is active so the row does not reflow', () => {
-    expect(DZ).toMatch(/\.dropzone\.is-loading \.dz-camera-cta \{ display: none/);
-  });
-
   it('ar-app reveals the slot after 400 ms of sustained loading (cold-cache heuristic)', () => {
     expect(APP).toMatch(/window\.setTimeout\([\s\S]*?this\.dropzone\.setLoadingState\(\{ visible: true \}\)[\s\S]*?\}, 400\)/);
   });

--- a/tests/components/ar-mobile-hero.test.ts
+++ b/tests/components/ar-mobile-hero.test.ts
@@ -32,36 +32,21 @@ describe('Mobile hero — short-form copy swap (#73)', () => {
   });
 });
 
-describe('Dropzone camera CTA (#73)', () => {
-  it('renders a second <input type="file" capture="environment">', () => {
-    expect(DZ).toMatch(/<input[^>]*type="file"[^>]*capture="environment"[^>]*class="dz-camera-input"/);
-  });
-
-  it('renders a #dz-camera-cta button with takePhoto label', () => {
-    expect(DZ).toMatch(/id="dz-camera-cta"/);
-    expect(DZ).toMatch(/t\(['"]dropzone\.takePhoto['"]\)/);
-  });
-
-  it('camera CTA is visible only on coarse pointer OR ≤ 480 px', () => {
-    expect(DZ).toMatch(/\.dz-camera-cta \{[\s\S]*?display: none;/);
-    expect(DZ).toMatch(/@media \(pointer: coarse\), \(max-width: 480px\) \{[\s\S]*?\.dz-camera-cta \{ display: inline-flex/);
-  });
-
-  it('camera CTA click stops propagation + triggers the camera input, not the main one', () => {
-    expect(DZ).toMatch(/cameraBtn\?\.addEventListener\(['"]click['"],[\s\S]*?stopPropagation\(\)[\s\S]*?this\.cameraInput\.click\(\)/);
-  });
-
-  it('main dropzone click ignores events bubbling from the camera CTA', () => {
-    expect(DZ).toMatch(/target\?\.closest\(['"]#dz-camera-cta['"]\)\) return/);
-  });
-
-  it('cameraInput "change" handler routes into the existing handleFiles path', () => {
-    expect(DZ).toMatch(/this\.cameraInput\.addEventListener\(['"]change['"],[\s\S]*?this\.handleFiles\(this\.cameraInput\.files\)/);
+// Camera CTA (#73) was removed in #146 — tapping the dropzone box on
+// mobile already opens the OS file picker, which exposes the camera as
+// one of the source options. The dedicated button was duplicating that
+// affordance and made the mobile UX inconsistent with desktop.
+describe('Dropzone camera CTA — removed (#146)', () => {
+  it('no longer ships a dedicated camera input or CTA button', () => {
+    expect(DZ).not.toMatch(/dz-camera-cta/);
+    expect(DZ).not.toMatch(/dz-camera-input/);
+    expect(DZ).not.toMatch(/capture="environment"/);
+    expect(DZ).not.toMatch(/dropzone\.takePhoto/);
   });
 });
 
-describe('i18n parity — hero.*.short + dropzone.takePhoto', () => {
-  const keys = ['hero.title.short', 'hero.subtitle.short', 'dropzone.takePhoto'];
+describe('i18n parity — hero.*.short', () => {
+  const keys = ['hero.title.short', 'hero.subtitle.short'];
   for (const key of keys) {
     it(`'${key}' declared in all six locales`, () => {
       const re = new RegExp(`'${key.replace(/\./g, '\\.')}'\\s*:`, 'g');


### PR DESCRIPTION
Closes #146, #149.

Three independent mobile-only issues caught via real-device ADB inspection on a Samsung Galaxy. Bundled because they share the same review surface.

## 1. Hero title `$ $ NUKE FONDOS` (new bug)

`h1::before` already prepends a terminal prompt `$ `. The short-form template additionally hardcoded `<span class="accent">$ </span>` inside the H1, so on mobile users saw TWO dollar signs. Removed the redundant inline `$ ` from the short variant.

Desktop was unaffected because `hero-title-long` uses the brand verb (`Nuke` / `Nukea`) in the accent span, not a `$`.

## 2. Camera CTA removed (#146)

Tapping the dropzone already opens the OS file picker which exposes the camera as a source option. The dedicated "tomar foto" button duplicated that affordance.

Removed:
- `<button id="dz-camera-cta">` markup
- Second `<input capture="environment" class="dz-camera-input">`
- All related CSS + click/keyboard handlers + `cameraInput` field
- `dropzone.takePhoto` i18n key in 6 locales
- e2e selectors reverted to plain `input[type="file"]`
- 7 obsolete source-pattern test assertions

## 3. Footer privacy hidden on mobile (#149)

On viewports ≤480px, `Tus imágenes nunca salen de tu dispositivo...` was crowding the footer alongside reactor-status, license, GitHub, Ko-fi, theme picker. Same message already rendered in marquee + hero subtitle.

Pure CSS, no JS changes. `footer-reactor-status` promoted to the compact font size that `footer-privacy` used to claim.

## Tests

678 passing (down from 685 — 7 obsolete source-pattern assertions removed).

Verified live on Samsung Galaxy via `adb reverse` + Chrome — bug 1 confirmed reproduced, fix confirmed visually.