### PR TITLE
fix(mobile): download CTAs stack at ≤640px + remove Share button (#150)

### DIFF
--- a/src/components/ar-download.ts
+++ b/src/components/ar-download.ts
@@ -32,8 +32,6 @@ export class ArDownload extends HTMLElement {
     if (copyBtn && !copyBtn.classList.contains('copied')) copyBtn.innerHTML = `${t('download.copy')}<br><small>PNG</small>`;
     const anotherBtn = root.querySelector('#another-btn');
     if (anotherBtn) anotherBtn.textContent = t('download.another');
-    const shareBtn = root.querySelector('#share-btn');
-    if (shareBtn) shareBtn.innerHTML = `${t('download.share')}<br><small>PNG</small>`;
     this.updateCtaLabels();
   }
 
@@ -66,7 +64,6 @@ export class ArDownload extends HTMLElement {
     // Prepare WebP blob lazily — it's the secondary CTA; encode in the
     // background so its size metadata renders as soon as ready.
     this.updateCtaAnchors('png-only');
-    this.syncShareButton();
     void this.prepareWebp(imageData);
 
     this.show();
@@ -100,23 +97,6 @@ export class ArDownload extends HTMLElement {
   private show(): void {
     const bar = this.shadowRoot!.querySelector('#bar');
     if (bar) bar.classList.add('visible');
-  }
-
-  /**
-   * Show the Web Share button if (a) the PNG blob is ready and
-   * (b) the browser reports support for sharing files. Safari
-   * (desktop + iOS), Chromium on Android, and Edge qualify; desktop
-   * Chromium + Firefox return false and the button stays hidden.
-   */
-  private syncShareButton(): void {
-    const btn = this.shadowRoot?.querySelector('#share-btn') as HTMLButtonElement | null;
-    if (!btn || !this.pngBlob) return;
-    try {
-      const probe = new File([this.pngBlob], this.pngFilename, { type: 'image/png' });
-      btn.hidden = !(navigator.canShare && navigator.canShare({ files: [probe] }));
-    } catch {
-      btn.hidden = true;
-    }
   }
 
   private render(): void {
@@ -233,8 +213,12 @@ export class ArDownload extends HTMLElement {
           .btn-primary { animation: none !important; }
         }
 
-        /* === Mobile (max-width: 480px) === */
-        @media (max-width: 480px) {
+        /* === Phone (max-width: 640px) ===
+           #150 — bumped from 480px to 640px because the dl-cta min-width
+           of 220px + horizontal padding pushes the row past the viewport
+           on real phones rendering at 360-420 CSS px. Stack vertically
+           the moment we lose room for two columns. */
+        @media (max-width: 640px) {
           .download-bar {
             flex-direction: column;
             gap: 8px;
@@ -248,19 +232,14 @@ export class ArDownload extends HTMLElement {
           .dl-cta {
             min-width: 0;
             width: 100%;
+            box-sizing: border-box;
           }
           .dl-side {
             justify-content: center;
             flex-wrap: wrap;
-          }
-          .btn-secondary {
             width: 100%;
-            text-align: center;
-            min-height: 44px;
-            display: flex;
-            align-items: center;
-            justify-content: center;
           }
+          .btn-secondary,
           .btn-copy {
             width: 100%;
             text-align: center;
@@ -268,6 +247,7 @@ export class ArDownload extends HTMLElement {
             display: flex;
             align-items: center;
             justify-content: center;
+            box-sizing: border-box;
           }
         }
 
@@ -320,7 +300,6 @@ export class ArDownload extends HTMLElement {
         </div>
         <div class="dl-side">
           <button class="btn-copy" id="copy-btn" title="Copy to clipboard" aria-live="polite">${t('download.copy')}<br><small>PNG</small></button>
-          <button class="btn-secondary" id="share-btn" hidden aria-live="polite">${t('download.share')}<br><small>PNG</small></button>
           <button class="btn-secondary" id="another-btn">${t('download.another')}</button>
         </div>
       </div>
@@ -330,33 +309,8 @@ export class ArDownload extends HTMLElement {
       this.dispatchEvent(new CustomEvent('ar:process-another', { bubbles: true, composed: true }));
     });
 
-    // Web Share API (#74). Only exposed on engines that can actually
-    // share files — `navigator.canShare({ files })` returns false on
-    // desktop Chromium + older Safari, so we keep the button hidden
-    // and let the Copy + Download paths handle those cases.
-    const shareBtn = this.shadowRoot!.querySelector('#share-btn') as HTMLButtonElement | null;
-    shareBtn?.addEventListener('click', async () => {
-      if (!this.pngBlob) return;
-      const file = new File([this.pngBlob], this.pngFilename, { type: 'image/png' });
-      try {
-        // canShare re-check at click time (user may have disabled
-        // sharing between page load and click).
-        if (!navigator.canShare || !navigator.canShare({ files: [file] })) {
-          shareBtn.hidden = true;
-          return;
-        }
-        await navigator.share({
-          files: [file],
-          title: t('download.share.title'),
-          text: t('download.share.text'),
-          url: 'https://nukebg.app',
-        });
-      } catch (err) {
-        // AbortError = user dismissed the share sheet; not an error.
-        if ((err as DOMException)?.name === 'AbortError') return;
-        console.warn('[ar-download] share failed:', err);
-      }
-    });
+    // Web Share API (#74) removed in #150 — the user wanted it gone
+    // from the result section. Copy + Download cover the export paths.
     // Track which format the user clicked so external callers (editor /
     // clipboard) know the latest intent via this.selectedFormat.
     this.shadowRoot!.querySelector('#dl-png')!.addEventListener('click', () => {
@@ -454,8 +408,6 @@ export class ArDownload extends HTMLElement {
     const webp = root.querySelector('#dl-webp') as HTMLAnchorElement | null;
     if (png) { png.hidden = true; png.removeAttribute('href'); }
     if (webp) { webp.hidden = true; webp.removeAttribute('href'); }
-    const shareBtn = root.querySelector('#share-btn') as HTMLButtonElement | null;
-    if (shareBtn) shareBtn.hidden = true;
   }
 }
 

--- a/src/i18n/index.ts
+++ b/src/i18n/index.ts
@@ -188,9 +188,6 @@ const translations: Translations = {
     'footer.quietMode': 'quiet mode',
     'footer.playfulMode': 'playful mode',
     'firstRun.ready': '# ready — cached locally, offline-capable',
-    'download.share': 'Share',
-    'download.share.title': 'Nuked background',
-    'download.share.text': 'Processed with nukebg.app — stays local',
     // Header / Footer (index.html)
     'header.skipLink': 'Skip to main content',
     'footer.kofi': '\u2615 Support on Ko-fi',
@@ -456,9 +453,6 @@ const translations: Translations = {
     'footer.quietMode': 'modo silencio',
     'footer.playfulMode': 'modo playful',
     'firstRun.ready': '# listo — cacheado localmente, listo offline',
-    'download.share': 'Compartir',
-    'download.share.title': 'Fondo nukeado',
-    'download.share.text': 'Procesado con nukebg.app — todo local',
     // Header / Footer (index.html)
     'header.skipLink': 'Saltar al contenido principal',
     'footer.kofi': '\u2615 Apoyar en Ko-fi',
@@ -724,9 +718,6 @@ const translations: Translations = {
     'footer.quietMode': 'mode silencieux',
     'footer.playfulMode': 'mode expressif',
     'firstRun.ready': '# prêt — caché localement, prêt hors ligne',
-    'download.share': 'Partager',
-    'download.share.title': 'Arrière-plan nuké',
-    'download.share.text': 'Traité avec nukebg.app — 100% local',
     // Header / Footer (index.html)
     'header.skipLink': 'Aller au contenu principal',
     'footer.kofi': '\u2615 Soutenir sur Ko-fi',
@@ -992,9 +983,6 @@ const translations: Translations = {
     'footer.quietMode': 'ruhemodus',
     'footer.playfulMode': 'lebhaft',
     'firstRun.ready': '# bereit — lokal zwischengespeichert, offline-fähig',
-    'download.share': 'Teilen',
-    'download.share.title': 'Hintergrund genuked',
-    'download.share.text': 'Mit nukebg.app verarbeitet — bleibt lokal',
     // Header / Footer (index.html)
     'header.skipLink': 'Zum Hauptinhalt springen',
     'footer.kofi': '\u2615 Unterst\u00FCtzen auf Ko-fi',
@@ -1260,9 +1248,6 @@ const translations: Translations = {
     'footer.quietMode': 'modo silencioso',
     'footer.playfulMode': 'modo brincalhão',
     'firstRun.ready': '# pronto — em cache local, pronto offline',
-    'download.share': 'Compartilhar',
-    'download.share.title': 'Fundo nukeado',
-    'download.share.text': 'Processado com nukebg.app — fica local',
     // Header / Footer (index.html)
     'header.skipLink': 'Pular para o conte\u00FAdo principal',
     'footer.kofi': '\u2615 Apoiar no Ko-fi',
@@ -1528,9 +1513,6 @@ const translations: Translations = {
     'footer.quietMode': '\u5B89\u9759\u6A21\u5F0F',
     'footer.playfulMode': '\u6D3B\u6CFC\u6A21\u5F0F',
     'firstRun.ready': '# \u5C31\u7EEA — \u672C\u5730\u7F13\u5B58\uFF0C\u53EF\u79BB\u7EBF\u4F7F\u7528',
-    'download.share': '\u5206\u4EAB',
-    'download.share.title': '\u5DF2\u53BB\u9664\u7684\u80CC\u666F',
-    'download.share.text': '\u7531 nukebg.app \u5904\u7406—\u672C\u5730\u8FD0\u884C',
     // Header / Footer (index.html)
     'header.skipLink': '\u8DF3\u8F6C\u5230\u4E3B\u8981\u5185\u5BB9',
     'footer.kofi': '\u2615 \u5728 Ko-fi \u4E0A\u652F\u6301\u6211\u4EEC',


### PR DESCRIPTION
Closes #150.

## 1. Download buttons stack earlier on mobile

Bumped the column-stack breakpoint from `≤480px` to `≤640px` because real phones render at 360-420 CSS px and the 220px-min-width download CTAs overflowed even there. Also added `box-sizing: border-box` so padding doesn't extend past 100% width.

## 2. Share button removed from result section

User wanted it gone. Removed:
- Markup, click handler, syncShareButton method, reset hooks
- 18 i18n keys (`download.share*` × 6 locales)

The unrelated **header** share button (`header-share-btn` in index.html) stays — different code path, different purpose.

Tests: 685 passing.