### PR TITLE
chore: prettier sweep + flip CI to blocking (#134)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,6 +1,6 @@
 ---
-name: "Bug report"
-about: "Something broke. Tell us what happened."
+name: 'Bug report'
+about: 'Something broke. Tell us what happened.'
 title: '[BUG] '
 labels: bug
 assignees: ''

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,6 +1,6 @@
 ---
-name: "Feature request"
-about: "Got an idea? Drop it here."
+name: 'Feature request'
+about: 'Got an idea? Drop it here.'
 title: '[FEATURE] '
 labels: enhancement
 assignees: ''

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,9 +12,10 @@ jobs:
   lint:
     name: Lint + format
     runs-on: ubuntu-latest
-    # Non-blocking while the codebase migrates to the new formatter/linter
-    # — flips to false once the one-shot `npm run format` PR lands.
-    continue-on-error: true
+    # #134 — flipped to blocking after the one-shot prettier sweep landed.
+    # Re-enable continue-on-error temporarily if a future formatter bump
+    # surfaces a wave of legitimate diffs that need their own sweep PR.
+    continue-on-error: false
     steps:
       - uses: actions/checkout@v4
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Unreleased entries accumulate on the `dev` branch. When we cut a release we copy
 ## [2.8.0] — 2026-04-25
 
 ### Added
+
 - **Theme picker grew to six palettes** — original four (terminal-green / amber
   / cyan / magenta) plus **red** (`#ff3344`) and **yellow** (`#ffee00`). Each
   swatch now glows its own colour on hover/focus while the active-state ring
@@ -44,7 +45,7 @@ Unreleased entries accumulate on the `dev` branch. When we cut a release we copy
   shadow tree via a light-DOM overlay. ([#101](https://github.com/yocreoquesi/nukebg/pull/101))
 - **PWA app shortcuts + deep-link handler** — installed app exposes "New image"
   and "Keyboard shortcuts" on long-press; `launch_handler.client_mode:
-  focus-existing` reuses the open tab; `?help=1` / `?action=new` query params
+focus-existing` reuses the open tab; `?help=1` / `?action=new` query params
   re-dispatch the matching keyboard shortcut.
   ([#102](https://github.com/yocreoquesi/nukebg/pull/102))
 - **Quiet mode toggle** — `data-playful` attribute gates CRT flicker, smoke,
@@ -87,6 +88,7 @@ Unreleased entries accumulate on the `dev` branch. When we cut a release we copy
 - **Cancel button in `ar-progress`** ([#63](https://github.com/yocreoquesi/nukebg/pull/63)).
 
 ### Changed
+
 - **Manual editor edits survive Apply** — both basic and advanced editors now
   pass `skipTopologyCleanup: true` to `refineEdges`. Previously the
   `keepLargestComponent` pass discarded any user edit (lasso crop, restore)
@@ -152,6 +154,7 @@ Unreleased entries accumulate on the `dev` branch. When we cut a release we copy
   ([#64](https://github.com/yocreoquesi/nukebg/pull/64))
 
 ### Security
+
 - **CSP: `script-src 'unsafe-inline'` removed** — strict inline-hash allowlist
   only. ([#57](https://github.com/yocreoquesi/nukebg/pull/57))
 - **DNS prefetch disabled + HF preconnects dropped** to preserve the
@@ -164,6 +167,7 @@ Unreleased entries accumulate on the `dev` branch. When we cut a release we copy
   ([#60](https://github.com/yocreoquesi/nukebg/pull/60))
 
 ### Pipeline
+
 - **`pendingTimers` leak plugged** — every worker response now routes through
   a `settlePending()` helper that clears the watchdog timer and drops it from
   the set in one step (closes #44).
@@ -176,6 +180,7 @@ Unreleased entries accumulate on the `dev` branch. When we cut a release we copy
   ([#56](https://github.com/yocreoquesi/nukebg/pull/56)).
 
 ### Accessibility
+
 - **Editor canvases are tabbable + described** — `tabindex="0"`, `role="img"`,
   `aria-label` wired through new `editor.canvasLabel` /
   `advanced.canvasLabel` i18n keys.
@@ -191,18 +196,21 @@ Unreleased entries accumulate on the `dev` branch. When we cut a release we copy
 - **Escape closes the shortcuts popover** ([#62](https://github.com/yocreoquesi/nukebg/pull/62)).
 
 ### Infrastructure
+
 - **Runtime hardening** — tokens, size limits, caps, engine pins, HEALTHCHECK.
   ([#66](https://github.com/yocreoquesi/nukebg/pull/66))
 - **Production sourcemaps disabled**
   ([#51](https://github.com/yocreoquesi/nukebg/pull/51)).
 
 ### Internationalization
+
 - **RTL scaffolding** — `getDirection(locale)` helper + auto-flip of
   `<html dir>` so a future RTL translation lands without code changes.
   Handles BCP-47 region tags. (closes #38)
   ([#109](https://github.com/yocreoquesi/nukebg/pull/109))
 
 ### Tooling / CI
+
 - **`exploration/` promoted to `src/refine/`** — what was lab-tagged code has
   been imported by the production advanced editor since v2.4. Folder renamed,
   ESLint + Prettier carve-out removed, files reformatted to repo style. Test
@@ -230,6 +238,7 @@ Unreleased entries accumulate on the `dev` branch. When we cut a release we copy
   ([#64](https://github.com/yocreoquesi/nukebg/pull/64)).
 
 ### Documentation
+
 - **`scripts/README.md`** documents every analyze / validate / CSP helper.
 - **`tests/fixtures/LICENSE.md`** captures source + licence per fixture.
 - **CONTRIBUTING.md** now lists the CI gates + recommended branch protection
@@ -254,15 +263,25 @@ section, keep only the relevant subsections, and empty `[Unreleased]`:
 ## [0.0.0] — 1970-01-01
 
 ### Added
+
 ### Changed
+
 ### Deprecated
+
 ### Removed
+
 ### Fixed
+
 ### Security
+
 ### Pipeline
+
 ### Accessibility
+
 ### Infrastructure
+
 ### Tooling / CI
+
 ### Documentation
 ```
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -48,13 +48,13 @@ $ npm run build
 
 ### Available scripts
 
-| Command | What it does |
-|---------|-------------|
-| `npm run dev` | Vite dev server with HMR |
-| `npm run build` | TypeScript compile + Vite production build |
-| `npm run preview` | Preview the production build locally |
-| `npm test` | Run tests once (Vitest) |
-| `npm run test:watch` | Run tests in watch mode |
+| Command              | What it does                               |
+| -------------------- | ------------------------------------------ |
+| `npm run dev`        | Vite dev server with HMR                   |
+| `npm run build`      | TypeScript compile + Vite production build |
+| `npm run preview`    | Preview the production build locally       |
+| `npm test`           | Run tests once (Vitest)                    |
+| `npm run test:watch` | Run tests in watch mode                    |
 
 ---
 
@@ -213,16 +213,16 @@ Format: `type: short description`
 
 ### Types
 
-| Type | When to use |
-|------|------------|
-| `feat` | New functionality |
-| `fix` | Bug fix |
-| `docs` | Documentation changes |
-| `test` | Adding or fixing tests |
+| Type       | When to use                      |
+| ---------- | -------------------------------- |
+| `feat`     | New functionality                |
+| `fix`      | Bug fix                          |
+| `docs`     | Documentation changes            |
+| `test`     | Adding or fixing tests           |
 | `refactor` | Refactor without behavior change |
-| `infra` | Build, CI/CD, deployment |
-| `security` | Security-related changes |
-| `design` | UI/UX changes |
+| `infra`    | Build, CI/CD, deployment         |
+| `security` | Security-related changes         |
+| `design`   | UI/UX changes                    |
 
 ### Examples
 

--- a/README.md
+++ b/README.md
@@ -130,19 +130,19 @@ The ML model is lazy-loaded on first use, then cached by the Service Worker for 
 
 ## > tech_stack
 
-| Layer | Technology |
-|-------|-----------|
-| Language | Vanilla TypeScript (no framework) |
-| UI | Web Components (`<ar-dropzone>`, `<ar-viewer>`, `<ar-progress>`) |
-| Build | Vite 6 |
-| Testing | Vitest |
-| ML Runtime | Transformers.js (ONNX Runtime Web) |
-| ML Models | RMBG-1.4 INT8 (~45MB) |
-| GPU | WASM (WebGPU reserved for future) |
-| Processing | Canvas API + OffscreenCanvas in Web Workers |
-| Caching | Service Worker + Cache API |
-| Styling | Custom CSS (JetBrains Mono, zero dependencies) |
-| i18n | Lightweight custom system (EN/ES/FR/DE/PT/ZH) |
+| Layer      | Technology                                                       |
+| ---------- | ---------------------------------------------------------------- |
+| Language   | Vanilla TypeScript (no framework)                                |
+| UI         | Web Components (`<ar-dropzone>`, `<ar-viewer>`, `<ar-progress>`) |
+| Build      | Vite 6                                                           |
+| Testing    | Vitest                                                           |
+| ML Runtime | Transformers.js (ONNX Runtime Web)                               |
+| ML Models  | RMBG-1.4 INT8 (~45MB)                                            |
+| GPU        | WASM (WebGPU reserved for future)                                |
+| Processing | Canvas API + OffscreenCanvas in Web Workers                      |
+| Caching    | Service Worker + Cache API                                       |
+| Styling    | Custom CSS (JetBrains Mono, zero dependencies)                   |
+| i18n       | Lightweight custom system (EN/ES/FR/DE/PT/ZH)                    |
 
 ## > privacy
 
@@ -167,29 +167,29 @@ you should see after the first warmup are the initial page load.
 
 ## > comparison
 
-| Feature | NukeBG | remove.bg | backgroundless.io | Photoshop |
-|---------|--------|-----------|-------------------|-----------|
-| ML background removal (RMBG-1.4) | Yes | Yes (proprietary) | Yes | Yes |
-| Auto content-type detection | Yes | No | No | No |
-| Checkerboard detection | Yes | No | No | Manual |
-| Watermark removal (Gemini + DALL-E) | Yes | No | No | Manual |
-| Client-side (private) | Yes | No | Yes | N/A |
-| Free and unlimited | Yes | No (credits) | Yes | No ($22/mo) |
-| Open source | Yes (GPL-3.0) | No | No | No |
-| Works offline | Yes | No | No | Yes |
+| Feature                             | NukeBG        | remove.bg         | backgroundless.io | Photoshop   |
+| ----------------------------------- | ------------- | ----------------- | ----------------- | ----------- |
+| ML background removal (RMBG-1.4)    | Yes           | Yes (proprietary) | Yes               | Yes         |
+| Auto content-type detection         | Yes           | No                | No                | No          |
+| Checkerboard detection              | Yes           | No                | No                | Manual      |
+| Watermark removal (Gemini + DALL-E) | Yes           | No                | No                | Manual      |
+| Client-side (private)               | Yes           | No                | Yes               | N/A         |
+| Free and unlimited                  | Yes           | No (credits)      | Yes               | No ($22/mo) |
+| Open source                         | Yes (GPL-3.0) | No                | No                | No          |
+| Works offline                       | Yes           | No                | No                | Yes         |
 
 ## > license_compliance
 
 NukeBG itself is GPL-3.0 (see [LICENSE](LICENSE)), but it ships with third-party
 artifacts whose licenses carry independent obligations:
 
-| Component | License | Notes |
-|-----------|---------|-------|
-| RMBG-1.4 ML model (BRIA AI) | [bria-rmbg-1.4 license](https://huggingface.co/briaai/RMBG-1.4) — CC-BY-NC-4.0 | **Non-commercial use only**. Commercial deployments — paid products, paid APIs, paid SaaS, ad-supported products — require a commercial agreement with BRIA AI, or swapping to a different model. The GPL-3.0 license of NukeBG's code does not override this. Donations to cover hosting / maintenance are fine. |
-| MobileSAM ML models (Acly/MobileSAM) | [MIT](https://huggingface.co/Acly/MobileSAM) | Used by the advanced editor for interactive click-to-segment. Commercial use OK. Encoder + decoder fetched from Hugging Face at runtime; not bundled. |
-| LaMa inpainting ML model (opencv/inpainting_lama) | [Apache-2.0](https://huggingface.co/opencv/inpainting_lama) | Used by the watermark-removal pipeline for content-aware reconstruction. Commercial use OK. Single FP32 ONNX (~95 MB) fetched from Hugging Face at runtime; not bundled. |
-| JetBrains Mono font | [SIL Open Font License 1.1](public/fonts/OFL.txt) | Bundled self-hosted. Attribution preserved in `public/fonts/OFL.txt`. |
-| Transformers.js, ONNX Runtime Web | Apache-2.0 / MIT | Compatible. |
+| Component                                         | License                                                                        | Notes                                                                                                                                                                                                                                                                                                             |
+| ------------------------------------------------- | ------------------------------------------------------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| RMBG-1.4 ML model (BRIA AI)                       | [bria-rmbg-1.4 license](https://huggingface.co/briaai/RMBG-1.4) — CC-BY-NC-4.0 | **Non-commercial use only**. Commercial deployments — paid products, paid APIs, paid SaaS, ad-supported products — require a commercial agreement with BRIA AI, or swapping to a different model. The GPL-3.0 license of NukeBG's code does not override this. Donations to cover hosting / maintenance are fine. |
+| MobileSAM ML models (Acly/MobileSAM)              | [MIT](https://huggingface.co/Acly/MobileSAM)                                   | Used by the advanced editor for interactive click-to-segment. Commercial use OK. Encoder + decoder fetched from Hugging Face at runtime; not bundled.                                                                                                                                                             |
+| LaMa inpainting ML model (opencv/inpainting_lama) | [Apache-2.0](https://huggingface.co/opencv/inpainting_lama)                    | Used by the watermark-removal pipeline for content-aware reconstruction. Commercial use OK. Single FP32 ONNX (~95 MB) fetched from Hugging Face at runtime; not bundled.                                                                                                                                          |
+| JetBrains Mono font                               | [SIL Open Font License 1.1](public/fonts/OFL.txt)                              | Bundled self-hosted. Attribution preserved in `public/fonts/OFL.txt`.                                                                                                                                                                                                                                             |
+| Transformers.js, ONNX Runtime Web                 | Apache-2.0 / MIT                                                               | Compatible.                                                                                                                                                                                                                                                                                                       |
 
 If you fork NukeBG and host it commercially, you are responsible for complying
 with the RMBG-1.4 model license. The project does not bundle the model weights —
@@ -218,4 +218,4 @@ If NukeBG saves you time, consider keeping the reactor running:
 
 **Built for creators who are done dealing with garbage backgrounds. Open source forever.**
 
-*Built with the assistance of AI agents ([Claude](https://www.anthropic.com/claude) by Anthropic).*
+_Built with the assistance of AI agents ([Claude](https://www.anthropic.com/claude) by Anthropic)._

--- a/docs/donors.md
+++ b/docs/donors.md
@@ -98,7 +98,7 @@ When the response arrives, edit the JSON.
   "name": "<as approved by the donor>",
   "amount_eur": 25,
   "date": "2026-04-30",
-  "consent": "explicit"
+  "consent": "explicit",
 }
 ```
 
@@ -146,7 +146,7 @@ The reactor page footer surfaces the removal contact email so
 supporters never have to dig:
 
 > "If you appear here and want to be removed, email <contact> —
->  done within 7 days, no questions."
+> done within 7 days, no questions."
 
 ## What NOT to do
 
@@ -172,14 +172,14 @@ in `src/utils/reactor-economics.ts` via the `DonorsFile` interface):
 ```typescript
 interface DonorsFile {
   version: 1;
-  updated_at: string;        // YYYY-MM-DD
+  updated_at: string; // YYYY-MM-DD
   supporters: Array<{
-    name: string;            // as approved by the donor
-    amount_eur: number;      // EUR, integer or one decimal
-    date: string;            // YYYY-MM-DD donation date
-    consent: 'explicit';     // only value accepted right now
+    name: string; // as approved by the donor
+    amount_eur: number; // EUR, integer or one decimal
+    date: string; // YYYY-MM-DD donation date
+    consent: 'explicit'; // only value accepted right now
   }>;
-  anonymous_count: number;   // bucket size
+  anonymous_count: number; // bucket size
   anonymous_total_eur: number;
 }
 ```

--- a/docs/safari-testing.md
+++ b/docs/safari-testing.md
@@ -9,10 +9,10 @@ Playwright ships its own WebKit build (same engine Apple uses on macOS
 and iOS). On every PR, CI runs the `e2e-safari` matrix with two
 projects:
 
-| Project  | Playwright preset      | Why                                    |
-|----------|------------------------|----------------------------------------|
-| `webkit` | `Desktop Safari`       | Catches desktop Safari rendering bugs. |
-| `iphone` | `iPhone 15 Pro`        | Touch + viewport + iOS-ish behaviour.  |
+| Project  | Playwright preset | Why                                    |
+| -------- | ----------------- | -------------------------------------- |
+| `webkit` | `Desktop Safari`  | Catches desktop Safari rendering bugs. |
+| `iphone` | `iPhone 15 Pro`   | Touch + viewport + iOS-ish behaviour.  |
 
 The job is `continue-on-error: true` today because:
 
@@ -64,18 +64,18 @@ drain in an afternoon otherwise.
 
 ## What each tier catches
 
-| Class of bug                                        | Tier 1 | Tier 2 | Tier 3 |
-|-----------------------------------------------------|--------|--------|--------|
-| CSS / layout rendering                              | ✅     | ✅     | ✅     |
-| Font hinting / kerning                              | ≈      | ✅     | ✅     |
-| WebKit-specific JS engine quirks                    | ✅     | ✅     | ✅     |
-| Touch gesture timing (synthetic vs native)          | ≈      | ≈      | ✅     |
-| ITP / Intelligent Tracking Prevention / storage     | ❌     | ≈      | ✅     |
-| `navigator.share` behaviour                         | ❌     | ❌     | ✅     |
-| `capture="environment"` on `<input type="file">`    | ❌     | ❌     | ✅     |
-| PWA "Add to Home Screen"                            | ❌     | ❌     | ✅     |
-| SharedArrayBuffer + COOP / COEP                     | ≈      | ✅     | ✅     |
-| iOS Safari warmup hang at 96 % (real ML)            | ❌     | ≈      | ✅     |
+| Class of bug                                     | Tier 1 | Tier 2 | Tier 3 |
+| ------------------------------------------------ | ------ | ------ | ------ |
+| CSS / layout rendering                           | ✅     | ✅     | ✅     |
+| Font hinting / kerning                           | ≈      | ✅     | ✅     |
+| WebKit-specific JS engine quirks                 | ✅     | ✅     | ✅     |
+| Touch gesture timing (synthetic vs native)       | ≈      | ≈      | ✅     |
+| ITP / Intelligent Tracking Prevention / storage  | ❌     | ≈      | ✅     |
+| `navigator.share` behaviour                      | ❌     | ❌     | ✅     |
+| `capture="environment"` on `<input type="file">` | ❌     | ❌     | ✅     |
+| PWA "Add to Home Screen"                         | ❌     | ❌     | ✅     |
+| SharedArrayBuffer + COOP / COEP                  | ≈      | ✅     | ✅     |
+| iOS Safari warmup hang at 96 % (real ML)         | ❌     | ≈      | ✅     |
 
 Legend: ✅ reliable · ≈ partial · ❌ not testable.
 

--- a/docs/v2.4.0-technical-design.md
+++ b/docs/v2.4.0-technical-design.md
@@ -24,8 +24,8 @@
 
 ### Issue #18: Workspace Slider Fixed Width (S)
 
-| File | Action | What Changes |
-|------|--------|-------------|
+| File                       | Action | What Changes                                                                                                                                                                                                                                                                                                           |
+| -------------------------- | ------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `src/components/ar-app.ts` | Modify | Replace `.ws-controls` flex layout with CSS Grid: `grid-template-columns: 1fr auto 1fr`. Left column = slider (right-aligned), center = reprocess button (fixed), right column = empty or future actions. This prevents layout shift when buttons appear/disappear. Remove `min-width: 180px` from `.ws-action-fixed`. |
 
 **CSS change detail** (inside `ar-app.ts` shadow DOM styles):
@@ -76,61 +76,61 @@ Mobile breakpoints: at `max-width: 480px`, collapse grid to `grid-template-colum
 
 ### Issue #3: WebP Export (M)
 
-| File | Action | What Changes |
-|------|--------|-------------|
-| `src/utils/image-io.ts` | Modify | Add `exportWebp()` function. Modify `generateOutputFilename()` to accept optional `format` param (`'png' \| 'webp'`), defaulting to `'png'`. |
-| `src/components/ar-download.ts` | Modify | Add format toggle state (`'png' \| 'webp'`), toggle buttons in download bar, re-export on format change. |
-| `src/i18n/index.ts` | Modify | Add new keys: `download.formatPng`, `download.formatWebp`, `download.btnWebp` for all 6 languages. |
+| File                            | Action | What Changes                                                                                                                                 |
+| ------------------------------- | ------ | -------------------------------------------------------------------------------------------------------------------------------------------- |
+| `src/utils/image-io.ts`         | Modify | Add `exportWebp()` function. Modify `generateOutputFilename()` to accept optional `format` param (`'png' \| 'webp'`), defaulting to `'png'`. |
+| `src/components/ar-download.ts` | Modify | Add format toggle state (`'png' \| 'webp'`), toggle buttons in download bar, re-export on format change.                                     |
+| `src/i18n/index.ts`             | Modify | Add new keys: `download.formatPng`, `download.formatWebp`, `download.btnWebp` for all 6 languages.                                           |
 
 ---
 
 ### Issue #7: PWA Installable (M)
 
-| File | Action | What Changes |
-|------|--------|-------------|
-| `public/manifest.webmanifest` | Modify | Add `id`, `scope`, `categories`, `orientation`, add 192px, 512px, and maskable icon entries. |
-| `public/service-worker.js` | Rewrite | Full stale-while-revalidate caching strategy for app shell. Explicit exclusion of huggingface.co URLs. |
-| `src/sw-register.ts` | Rewrite | Add update detection, `beforeinstallprompt` capture, expose install trigger, new-version notification. |
-| `src/components/ar-app.ts` | Modify | Add install button (terminal-themed) in hero section, listen for install-ready event. |
-| `src/i18n/index.ts` | Modify | Add keys: `pwa.install`, `pwa.installed`, `pwa.updateAvailable`, `pwa.updateReady` for all 6 languages. |
-| `public/icon-192.png` | Create | 192x192 PNG icon (can be generated from existing favicon.svg). |
-| `public/icon-512.png` | Create | 512x512 PNG icon. |
-| `public/icon-maskable-512.png` | Create | 512x512 maskable icon (10% safe zone padding). |
+| File                           | Action  | What Changes                                                                                            |
+| ------------------------------ | ------- | ------------------------------------------------------------------------------------------------------- |
+| `public/manifest.webmanifest`  | Modify  | Add `id`, `scope`, `categories`, `orientation`, add 192px, 512px, and maskable icon entries.            |
+| `public/service-worker.js`     | Rewrite | Full stale-while-revalidate caching strategy for app shell. Explicit exclusion of huggingface.co URLs.  |
+| `src/sw-register.ts`           | Rewrite | Add update detection, `beforeinstallprompt` capture, expose install trigger, new-version notification.  |
+| `src/components/ar-app.ts`     | Modify  | Add install button (terminal-themed) in hero section, listen for install-ready event.                   |
+| `src/i18n/index.ts`            | Modify  | Add keys: `pwa.install`, `pwa.installed`, `pwa.updateAvailable`, `pwa.updateReady` for all 6 languages. |
+| `public/icon-192.png`          | Create  | 192x192 PNG icon (can be generated from existing favicon.svg).                                          |
+| `public/icon-512.png`          | Create  | 512x512 PNG icon.                                                                                       |
+| `public/icon-maskable-512.png` | Create  | 512x512 maskable icon (10% safe zone padding).                                                          |
 
 ---
 
 ### Issue #6: Languages FR, DE, PT, ZH (L)
 
-| File | Action | What Changes |
-|------|--------|-------------|
-| `src/i18n/index.ts` | Modify | Add `fr`, `de`, `pt`, `zh` translation objects (all 60+ keys each). Localized tone per spec. |
-| `src/utils/image-io.ts` | Modify | Add per-locale nuclear filename prefixes: `NUKE_PREFIXES_FR`, `NUKE_PREFIXES_DE`, `NUKE_PREFIXES_PT`, `NUKE_PREFIXES_ZH`. Modify `generateOutputFilename()` to accept locale param. |
-| `index.html` | Modify | Add hreflang tags for `fr`, `de`, `pt`, `zh`. |
-| `src/components/ar-app.ts` | Modify | Language selector UI — render a `<select>` or button group showing all 6 locale options with native names. Wire to `setLocale()`. |
+| File                       | Action | What Changes                                                                                                                                                                        |
+| -------------------------- | ------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `src/i18n/index.ts`        | Modify | Add `fr`, `de`, `pt`, `zh` translation objects (all 60+ keys each). Localized tone per spec.                                                                                        |
+| `src/utils/image-io.ts`    | Modify | Add per-locale nuclear filename prefixes: `NUKE_PREFIXES_FR`, `NUKE_PREFIXES_DE`, `NUKE_PREFIXES_PT`, `NUKE_PREFIXES_ZH`. Modify `generateOutputFilename()` to accept locale param. |
+| `index.html`               | Modify | Add hreflang tags for `fr`, `de`, `pt`, `zh`.                                                                                                                                       |
+| `src/components/ar-app.ts` | Modify | Language selector UI — render a `<select>` or button group showing all 6 locale options with native names. Wire to `setLocale()`.                                                   |
 
 ---
 
 ### Issue #9: More Watermarks (L)
 
-| File | Action | What Changes |
-|------|--------|-------------|
-| `src/workers/cv/watermark-diagonal.ts` | Create | Diagonal repeating text watermark detector (Shutterstock, Getty, etc.). |
-| `src/workers/cv/watermark-corner.ts` | Create | Generalized corner logo detector (Firefly, Canva, etc.). |
-| `src/pipeline/constants.ts` | Modify | Add `DIAGONAL_WATERMARK_PARAMS` and `CORNER_WATERMARK_PARAMS` constant objects. |
-| `src/workers/cv.worker.ts` | Modify | Import and wire the two new detector functions into the switch statement. |
-| `src/types/worker-messages.ts` | Modify | Add `CvWatermarkDetectDiagonalRequest`, `CvWatermarkDetectCornerRequest` to the union, and corresponding response variants. |
-| `src/pipeline/orchestrator.ts` | Modify | Run all 4 watermark detectors in parallel (Gemini, DALL-E, diagonal, corner). Update `combineMasks` to merge N masks. |
+| File                                   | Action | What Changes                                                                                                                |
+| -------------------------------------- | ------ | --------------------------------------------------------------------------------------------------------------------------- |
+| `src/workers/cv/watermark-diagonal.ts` | Create | Diagonal repeating text watermark detector (Shutterstock, Getty, etc.).                                                     |
+| `src/workers/cv/watermark-corner.ts`   | Create | Generalized corner logo detector (Firefly, Canva, etc.).                                                                    |
+| `src/pipeline/constants.ts`            | Modify | Add `DIAGONAL_WATERMARK_PARAMS` and `CORNER_WATERMARK_PARAMS` constant objects.                                             |
+| `src/workers/cv.worker.ts`             | Modify | Import and wire the two new detector functions into the switch statement.                                                   |
+| `src/types/worker-messages.ts`         | Modify | Add `CvWatermarkDetectDiagonalRequest`, `CvWatermarkDetectCornerRequest` to the union, and corresponding response variants. |
+| `src/pipeline/orchestrator.ts`         | Modify | Run all 4 watermark detectors in parallel (Gemini, DALL-E, diagonal, corner). Update `combineMasks` to merge N masks.       |
 
 ---
 
 ### Cross-cutting: Version Bump
 
-| File | Action | What Changes |
-|------|--------|-------------|
-| `package.json` | Modify | `"version": "2.4.0"` |
-| `src/main.ts` | Modify | Console logo version string |
-| `src/utils/image-io.ts` | Modify | PNG metadata `Software: NukeBG v2.4.0` |
-| `index.html` | Modify | JSON-LD `softwareVersion`, footer version |
+| File                    | Action | What Changes                              |
+| ----------------------- | ------ | ----------------------------------------- |
+| `package.json`          | Modify | `"version": "2.4.0"`                      |
+| `src/main.ts`           | Modify | Console logo version string               |
+| `src/utils/image-io.ts` | Modify | PNG metadata `Software: NukeBG v2.4.0`    |
+| `index.html`            | Modify | JSON-LD `softwareVersion`, footer version |
 
 ---
 
@@ -254,8 +254,8 @@ export const DIAGONAL_WATERMARK_PARAMS = {
 ### Performance Considerations
 
 - **Downsample by 2x** before Sobel: watermark text features are large enough to survive halving. This cuts pixel count by 4x.
-- Sobel is O(W*H) — fast for typical image sizes.
-- Autocorrelation is O(strips * maxPeriod) — manageable.
+- Sobel is O(W\*H) — fast for typical image sizes.
+- Autocorrelation is O(strips \* maxPeriod) — manageable.
 - Total expected runtime: <100ms for a 2048x2048 image.
 
 ### Function Signature
@@ -265,7 +265,7 @@ export function watermarkDetectDiagonal(
   pixels: Uint8ClampedArray,
   width: number,
   height: number,
-): WatermarkResult
+): WatermarkResult;
 ```
 
 Note: unlike the Gemini detector, this does NOT need background colors as input — it operates purely on gradient information.
@@ -277,6 +277,7 @@ Note: unlike the Gemini detector, this does NOT need background colors as input 
 ### Problem Statement
 
 AI tools (Adobe Firefly, Canva, etc.) and some stock sites place small logos or badges in image corners. Unlike the Gemini sparkle detector (which only checks bottom-right and uses deviation from bg colors), we need a generalized detector that:
+
 - Scans all 4 corners
 - Does NOT depend on knowing the background color
 - Handles both opaque logos and semi-transparent overlays
@@ -284,13 +285,13 @@ AI tools (Adobe Firefly, Canva, etc.) and some stock sites place small logos or 
 
 ### How It Differs from Gemini Sparkle Detector
 
-| Aspect | Gemini (`watermark-detect.ts`) | Corner (`watermark-corner.ts`) |
-|--------|-------------------------------|-------------------------------|
-| Corners scanned | Bottom-right only | All 4 |
-| Depends on bg colors | Yes (colorA, colorB) | No |
-| Detection method | Pixel deviation from bg | Cluster analysis of local anomalies |
-| Target | Single sparkle glyph | Rectangular logo/badge of varying size |
-| Size range | ~10-30px radius | 20-120px per side |
+| Aspect               | Gemini (`watermark-detect.ts`) | Corner (`watermark-corner.ts`)         |
+| -------------------- | ------------------------------ | -------------------------------------- |
+| Corners scanned      | Bottom-right only              | All 4                                  |
+| Depends on bg colors | Yes (colorA, colorB)           | No                                     |
+| Detection method     | Pixel deviation from bg        | Cluster analysis of local anomalies    |
+| Target               | Single sparkle glyph           | Rectangular logo/badge of varying size |
+| Size range           | ~10-30px radius                | 20-120px per side                      |
 
 ### Algorithm Overview
 
@@ -413,7 +414,7 @@ export function watermarkDetectCorner(
   pixels: Uint8ClampedArray,
   width: number,
   height: number,
-): WatermarkResult
+): WatermarkResult;
 ```
 
 No color inputs needed — the algorithm estimates local background per corner.
@@ -430,25 +431,25 @@ Cache name: nukebg-shell-v{N}    (N = integer, bumped on deploy)
 
 **What gets cached (app shell):**
 
-| Asset | Strategy | Reason |
-|-------|----------|--------|
-| `/` (index.html) | Stale-while-revalidate | Always serve cached page, fetch update in background |
-| `/assets/*.js` | Cache-first | Vite hashes filenames; immutable |
-| `/assets/*.css` | Cache-first | Same — content-hashed |
-| `/fonts/*.woff2` | Cache-first | Static, never changes |
-| `/favicon*.png`, `/favicon.svg` | Cache-first | Static |
-| `/apple-touch-icon.png` | Cache-first | Static |
-| `/og-image.png` | Cache-first | Static |
-| `/manifest.webmanifest` | Stale-while-revalidate | May change on version bump |
-| `/icon-*.png` | Cache-first | Static PWA icons |
+| Asset                           | Strategy               | Reason                                               |
+| ------------------------------- | ---------------------- | ---------------------------------------------------- |
+| `/` (index.html)                | Stale-while-revalidate | Always serve cached page, fetch update in background |
+| `/assets/*.js`                  | Cache-first            | Vite hashes filenames; immutable                     |
+| `/assets/*.css`                 | Cache-first            | Same — content-hashed                                |
+| `/fonts/*.woff2`                | Cache-first            | Static, never changes                                |
+| `/favicon*.png`, `/favicon.svg` | Cache-first            | Static                                               |
+| `/apple-touch-icon.png`         | Cache-first            | Static                                               |
+| `/og-image.png`                 | Cache-first            | Static                                               |
+| `/manifest.webmanifest`         | Stale-while-revalidate | May change on version bump                           |
+| `/icon-*.png`                   | Cache-first            | Static PWA icons                                     |
 
 **What is NEVER cached:**
 
-| URL Pattern | Reason |
-|-------------|--------|
-| `*huggingface.co*` | 45MB RMBG model — let browser HTTP cache handle it |
-| `*cdn.jsdelivr.net*` | Transformers.js CDN — same reason |
-| `*analytics*`, `*tracking*` | Should not exist but defensive exclusion |
+| URL Pattern                 | Reason                                             |
+| --------------------------- | -------------------------------------------------- |
+| `*huggingface.co*`          | 45MB RMBG model — let browser HTTP cache handle it |
+| `*cdn.jsdelivr.net*`        | Transformers.js CDN — same reason                  |
+| `*analytics*`, `*tracking*` | Should not exist but defensive exclusion           |
 
 ### Service Worker Pseudocode
 
@@ -469,27 +470,30 @@ const NEVER_CACHE_PATTERNS = [
 ];
 
 function shouldCache(url) {
-  return NEVER_CACHE_PATTERNS.every(pattern => !pattern.test(url));
+  return NEVER_CACHE_PATTERNS.every((pattern) => !pattern.test(url));
 }
 
 // Install: pre-cache critical shell
 self.addEventListener('install', (event) => {
   event.waitUntil(
-    caches.open(CACHE_NAME)
-      .then(cache => cache.addAll(SHELL_URLS))
-      .then(() => self.skipWaiting())
+    caches
+      .open(CACHE_NAME)
+      .then((cache) => cache.addAll(SHELL_URLS))
+      .then(() => self.skipWaiting()),
   );
 });
 
 // Activate: clean old caches
 self.addEventListener('activate', (event) => {
   event.waitUntil(
-    caches.keys().then(keys =>
-      Promise.all(keys
-        .filter(k => k !== CACHE_NAME)
-        .map(k => caches.delete(k))
+    caches
+      .keys()
+      .then((keys) =>
+        Promise.all(
+          keys.filter((k) => k !== CACHE_NAME).map((k) => caches.delete(k)),
+        ),
       )
-    ).then(() => self.clients.claim())
+      .then(() => self.clients.claim()),
   );
 });
 
@@ -508,31 +512,33 @@ self.addEventListener('fetch', (event) => {
   // Navigation requests (HTML): stale-while-revalidate
   if (event.request.mode === 'navigate') {
     event.respondWith(
-      caches.open(CACHE_NAME).then(cache =>
-        cache.match('/').then(cached => {
-          const fetchPromise = fetch(event.request).then(response => {
+      caches.open(CACHE_NAME).then((cache) =>
+        cache.match('/').then((cached) => {
+          const fetchPromise = fetch(event.request).then((response) => {
             if (response.ok) cache.put('/', response.clone());
             return response;
           });
           return cached || fetchPromise;
-        })
-      )
+        }),
+      ),
     );
     return;
   }
 
   // Static assets: cache-first, fallback to network
   event.respondWith(
-    caches.match(event.request).then(cached => {
+    caches.match(event.request).then((cached) => {
       if (cached) return cached;
-      return fetch(event.request).then(response => {
+      return fetch(event.request).then((response) => {
         if (response.ok && shouldCache(url.href)) {
           const clone = response.clone();
-          caches.open(CACHE_NAME).then(cache => cache.put(event.request, clone));
+          caches
+            .open(CACHE_NAME)
+            .then((cache) => cache.put(event.request, clone));
         }
         return response;
       });
-    })
+    }),
   );
 });
 
@@ -599,7 +605,10 @@ if ('serviceWorker' in navigator) {
         if (!newWorker) return;
 
         newWorker.addEventListener('statechange', () => {
-          if (newWorker.state === 'installed' && navigator.serviceWorker.controller) {
+          if (
+            newWorker.state === 'installed' &&
+            navigator.serviceWorker.controller
+          ) {
             // New version available — notify UI
             document.dispatchEvent(new CustomEvent('nukebg:update-available'));
           }
@@ -724,9 +733,13 @@ Styled as a segmented control (terminal aesthetic):
   font-size: 11px;
   text-transform: uppercase;
   cursor: pointer;
-  transition: background 0.2s, color 0.2s;
+  transition:
+    background 0.2s,
+    color 0.2s;
 }
-.fmt-btn:last-child { border-right: none; }
+.fmt-btn:last-child {
+  border-right: none;
+}
 .fmt-btn.active {
   background: var(--color-accent-primary, #00ff41);
   color: #000;
@@ -790,7 +803,10 @@ async setResult(
 ### exportWebp() in image-io.ts
 
 ```typescript
-export async function exportWebp(imageData: ImageData, quality = 0.9): Promise<Blob> {
+export async function exportWebp(
+  imageData: ImageData,
+  quality = 0.9,
+): Promise<Blob> {
   if (typeof OffscreenCanvas !== 'undefined') {
     const canvas = new OffscreenCanvas(imageData.width, imageData.height);
     const ctx = canvas.getContext('2d')!;
@@ -882,8 +898,8 @@ export type CvWorkerRequest =
   | CvSimpleFloodFillRequest
   | CvWatermarkDetectRequest
   | CvWatermarkDetectDalleRequest
-  | CvWatermarkDetectDiagonalRequest   // NEW
-  | CvWatermarkDetectCornerRequest     // NEW
+  | CvWatermarkDetectDiagonalRequest // NEW
+  | CvWatermarkDetectCornerRequest // NEW
   | CvShadowCleanupRequest
   | CvAlphaRefineRequest
   | CvClassifyImageRequest
@@ -896,8 +912,8 @@ Update `CvWorkerResponse` union:
 export type CvWorkerResponse =
   | { id: string; type: 'detect-bg-colors'; result: BgColorResult }
   // ... existing entries ...
-  | { id: string; type: 'watermark-detect-diagonal'; result: WatermarkResult }  // NEW
-  | { id: string; type: 'watermark-detect-corner'; result: WatermarkResult }    // NEW
+  | { id: string; type: 'watermark-detect-diagonal'; result: WatermarkResult } // NEW
+  | { id: string; type: 'watermark-detect-corner'; result: WatermarkResult } // NEW
   | { id: string; type: 'error'; error: string };
 ```
 
@@ -941,33 +957,33 @@ No new test file. This is CSS-only. Verify visually.
 
 **New file: `tests/utils/image-io.test.ts`**
 
-| Test | What it validates |
-|------|-------------------|
-| `exportWebp returns a blob with type image/webp` | Basic WebP export works |
-| `exportWebp respects quality parameter` | Lower quality = smaller blob |
-| `exportWebp handles 1x1 image` | Edge case |
-| `generateOutputFilename returns .webp extension for webp format` | Filename generation |
-| `generateOutputFilename returns .png extension by default` | Backward compat |
-| `generateOutputFilename uses locale-specific prefixes` | Per-locale prefix pools |
+| Test                                                             | What it validates            |
+| ---------------------------------------------------------------- | ---------------------------- |
+| `exportWebp returns a blob with type image/webp`                 | Basic WebP export works      |
+| `exportWebp respects quality parameter`                          | Lower quality = smaller blob |
+| `exportWebp handles 1x1 image`                                   | Edge case                    |
+| `generateOutputFilename returns .webp extension for webp format` | Filename generation          |
+| `generateOutputFilename returns .png extension by default`       | Backward compat              |
+| `generateOutputFilename uses locale-specific prefixes`           | Per-locale prefix pools      |
 
 **Modify: `tests/components/ar-download.test.ts`** (if exists, else create)
 
-| Test | What it validates |
-|------|-------------------|
-| `format toggle switches between PNG and WebP` | UI state management |
-| `switching format re-exports the blob` | Re-export triggers correctly |
-| `copy button always uses PNG regardless of selected format` | Clipboard compat |
+| Test                                                        | What it validates            |
+| ----------------------------------------------------------- | ---------------------------- |
+| `format toggle switches between PNG and WebP`               | UI state management          |
+| `switching format re-exports the blob`                      | Re-export triggers correctly |
+| `copy button always uses PNG regardless of selected format` | Clipboard compat             |
 
 ### Issue #7: PWA (M)
 
 **New file: `tests/pwa/sw-register.test.ts`**
 
-| Test | What it validates |
-|------|-------------------|
-| `canInstall returns false initially` | Default state |
-| `installApp returns false when no prompt captured` | Guard |
-| `beforeinstallprompt event makes canInstall return true` | Event capture |
-| `installApp calls prompt and returns result` | Install flow |
+| Test                                                     | What it validates |
+| -------------------------------------------------------- | ----------------- |
+| `canInstall returns false initially`                     | Default state     |
+| `installApp returns false when no prompt captured`       | Guard             |
+| `beforeinstallprompt event makes canInstall return true` | Event capture     |
+| `installApp calls prompt and returns result`             | Install flow      |
 
 Note: Service worker itself is hard to unit test (runs in SW scope). Rely on manual testing + Lighthouse PWA audit for SW validation.
 
@@ -975,28 +991,28 @@ Note: Service worker itself is hard to unit test (runs in SW scope). Rely on man
 
 **New file: `tests/i18n/translations.test.ts`**
 
-| Test | What it validates |
-|------|-------------------|
-| `all locales have the same keys as English` | No missing translations |
-| `no locale has empty string values` | All keys translated |
-| `t() falls back to English for missing keys` | Fallback works |
-| `setLocale dispatches nukebg:locale-changed event` | Event fired |
-| `locale-specific filename prefixes exist for all locales` | Prefix pools not empty |
+| Test                                                      | What it validates       |
+| --------------------------------------------------------- | ----------------------- |
+| `all locales have the same keys as English`               | No missing translations |
+| `no locale has empty string values`                       | All keys translated     |
+| `t() falls back to English for missing keys`              | Fallback works          |
+| `setLocale dispatches nukebg:locale-changed event`        | Event fired             |
+| `locale-specific filename prefixes exist for all locales` | Prefix pools not empty  |
 
 ### Issue #9: Watermark Detectors (L)
 
 **New file: `tests/cv/watermark-diagonal.test.ts`**
 
-| Test | What it validates |
-|------|-------------------|
-| `returns false for clean solid image` | No false positive on blank |
-| `returns false for image with horizontal stripes only` | Rejects non-diagonal patterns |
-| `detects synthetic diagonal repeating text pattern` | Core detection (paint diagonal lines at 45 degrees, tiled) |
-| `returns false for single diagonal stripe (no periodicity)` | Requires repetition |
-| `returns false for diagonal content with low coverage (localized stripes)` | Coverage filter works |
-| `mask covers detected watermark pixels` | Mask generation |
-| `handles small image without crash` | Edge case (image < MIN_PERIOD) |
-| `handles image with subject + diagonal watermark overlay` | Does not over-mask |
+| Test                                                                       | What it validates                                          |
+| -------------------------------------------------------------------------- | ---------------------------------------------------------- |
+| `returns false for clean solid image`                                      | No false positive on blank                                 |
+| `returns false for image with horizontal stripes only`                     | Rejects non-diagonal patterns                              |
+| `detects synthetic diagonal repeating text pattern`                        | Core detection (paint diagonal lines at 45 degrees, tiled) |
+| `returns false for single diagonal stripe (no periodicity)`                | Requires repetition                                        |
+| `returns false for diagonal content with low coverage (localized stripes)` | Coverage filter works                                      |
+| `mask covers detected watermark pixels`                                    | Mask generation                                            |
+| `handles small image without crash`                                        | Edge case (image < MIN_PERIOD)                             |
+| `handles image with subject + diagonal watermark overlay`                  | Does not over-mask                                         |
 
 **Helper needed for diagonal tests**: Add to `tests/helpers.ts`:
 
@@ -1018,16 +1034,16 @@ export function paintDiagonalLines(
 
 **New file: `tests/cv/watermark-corner.test.ts`**
 
-| Test | What it validates |
-|------|-------------------|
-| `returns false for clean solid image` | No false positive |
-| `detects logo in bottom-right corner` | BR detection |
-| `detects logo in top-left corner` | TL detection |
-| `detects logos in multiple corners simultaneously` | Multi-corner |
+| Test                                                                   | What it validates     |
+| ---------------------------------------------------------------------- | --------------------- |
+| `returns false for clean solid image`                                  | No false positive     |
+| `detects logo in bottom-right corner`                                  | BR detection          |
+| `detects logo in top-left corner`                                      | TL detection          |
+| `detects logos in multiple corners simultaneously`                     | Multi-corner          |
 | `returns false when corner deviation is too large (subject, not logo)` | Size heuristic filter |
-| `returns false when anomaly touches inner edge (extending subject)` | Inner edge filter |
-| `mask covers detected logo with padding` | Mask bounds |
-| `handles small image without crash` | Edge case |
+| `returns false when anomaly touches inner edge (extending subject)`    | Inner edge filter     |
+| `mask covers detected logo with padding`                               | Mask bounds           |
+| `handles small image without crash`                                    | Edge case             |
 
 **Helper needed for corner tests**: Add to `tests/helpers.ts`:
 
@@ -1048,29 +1064,29 @@ export function paintCornerLogo(
 
 **Modify: `tests/pipeline/orchestrator.test.ts`**
 
-| Test | What it validates |
-|------|-------------------|
+| Test                                                      | What it validates                         |
+| --------------------------------------------------------- | ----------------------------------------- |
 | `orchestrator runs all 4 watermark detectors in parallel` | Parallel dispatch verified (mock workers) |
-| `combined mask merges results from multiple detectors` | N-way OR works |
+| `combined mask merges results from multiple detectors`    | N-way OR works                            |
 
 ### Test Helper Summary
 
-| Helper | File | Purpose |
-|--------|------|---------|
+| Helper                 | File               | Purpose                           |
+| ---------------------- | ------------------ | --------------------------------- |
 | `paintDiagonalLines()` | `tests/helpers.ts` | Generate diagonal stripe patterns |
-| `paintCornerLogo()` | `tests/helpers.ts` | Generate corner logos |
+| `paintCornerLogo()`    | `tests/helpers.ts` | Generate corner logos             |
 
 ### Expected Test Count Impact
 
-| Area | New Tests |
-|------|-----------|
-| watermark-diagonal | ~8 |
-| watermark-corner | ~8 |
-| image-io (WebP + filenames) | ~6 |
-| i18n translations | ~5 |
-| sw-register | ~4 |
-| orchestrator updates | ~2 |
-| **Total new** | **~33** |
+| Area                        | New Tests |
+| --------------------------- | --------- |
+| watermark-diagonal          | ~8        |
+| watermark-corner            | ~8        |
+| image-io (WebP + filenames) | ~6        |
+| i18n translations           | ~5        |
+| sw-register                 | ~4        |
+| orchestrator updates        | ~2        |
+| **Total new**               | **~33**   |
 
 Post-v2.4.0 expected total: ~194 tests.
 
@@ -1078,28 +1094,28 @@ Post-v2.4.0 expected total: ~194 tests.
 
 ## 8. Risk Register
 
-| # | Risk | Probability | Impact | Mitigation |
-|---|------|-------------|--------|------------|
-| R1 | **Diagonal detector false positives on real diagonal content** (striped shirts, blinds, architectural lines) | Medium | High (unwanted inpainting destroys image) | Three-filter defense: coverage check (>60% of strips), regularity check (consistent spacing), CV range check. Conservative thresholds — better to miss a watermark than damage content. Add `contentType === 'ICON'` skip (icons never have stock watermarks). |
-| R2 | **Corner detector flags subject matter as logo** (e.g., person's head near corner) | Medium | High | Inner-edge filter: if the connected component touches the inward-facing edges of the scan region, it is part of the main image subject, not a corner logo. Max area cap prevents large subjects from being flagged. |
-| R3 | **WebP export not supported in Safari <16.4** | Low | Medium | `canvas.convertToBlob({type: 'image/webp'})` returns an empty blob or throws on unsupported browsers. Detect by checking `blob.size === 0` and fall back to PNG with a toast notification. |
-| R4 | **Service worker caches stale app shell after deploy** | Medium | Medium | Stale-while-revalidate means users always get the cached version first, but the fresh version is fetched in background. On next navigation, they get the update. The `nukebg:update-available` event lets us show a "New version available, refresh" banner. Cache name includes version number for clean purges. |
-| R5 | **SW accidentally caches HuggingFace model** | Low | Critical (45MB in Cache API = quota issues) | URL pattern exclusion is the first defense. Additionally, only same-origin requests are cached. HuggingFace URLs are cross-origin, so they are excluded by the `url.origin !== self.location.origin` check. Double protection. |
-| R6 | **i18n translations drift** (new keys added in EN but forgotten in other locales) | High | Low | Test `tests/i18n/translations.test.ts` explicitly asserts all locales have the same key set as English. CI will catch missing keys. |
-| R7 | **Format toggle re-export is slow for large images** | Low | Medium | WebP encoding is done by the browser engine (C++ canvas implementation), not JS. For a 4096x4096 image, `convertToBlob` for WebP takes ~200-500ms, which is acceptable. Show a brief loading indicator on the download button during re-export if needed. |
-| R8 | **beforeinstallprompt event never fires** (Chrome-only, not in Firefox/Safari) | High | Low | The install button is progressive enhancement — it only appears when the event fires. No install button shown = no broken UX. Safari users can still "Add to Home Screen" manually. |
-| R9 | **Diagonal watermark Sobel + autocorrelation is slow on large images** | Medium | Medium | Downsample by 2x before processing. At 2048x2048 input, we process at 1024x1024 = 1M pixels. Sobel is simple per-pixel math. Autocorrelation operates on ~1400 strip bins with lags up to 400. Total estimate: <100ms. If it exceeds 200ms, increase DOWNSAMPLE to 3 or 4. |
-| R10 | **Multiple watermark detectors find overlapping regions, causing over-inpainting** | Low | Medium | The existing `combineMasks` uses OR, so overlapping regions are simply merged. This is correct behavior — the inpainter only sees a binary mask. The Telea FMM inpainter handles large masks gracefully. |
+| #   | Risk                                                                                                         | Probability | Impact                                      | Mitigation                                                                                                                                                                                                                                                                                                        |
+| --- | ------------------------------------------------------------------------------------------------------------ | ----------- | ------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| R1  | **Diagonal detector false positives on real diagonal content** (striped shirts, blinds, architectural lines) | Medium      | High (unwanted inpainting destroys image)   | Three-filter defense: coverage check (>60% of strips), regularity check (consistent spacing), CV range check. Conservative thresholds — better to miss a watermark than damage content. Add `contentType === 'ICON'` skip (icons never have stock watermarks).                                                    |
+| R2  | **Corner detector flags subject matter as logo** (e.g., person's head near corner)                           | Medium      | High                                        | Inner-edge filter: if the connected component touches the inward-facing edges of the scan region, it is part of the main image subject, not a corner logo. Max area cap prevents large subjects from being flagged.                                                                                               |
+| R3  | **WebP export not supported in Safari <16.4**                                                                | Low         | Medium                                      | `canvas.convertToBlob({type: 'image/webp'})` returns an empty blob or throws on unsupported browsers. Detect by checking `blob.size === 0` and fall back to PNG with a toast notification.                                                                                                                        |
+| R4  | **Service worker caches stale app shell after deploy**                                                       | Medium      | Medium                                      | Stale-while-revalidate means users always get the cached version first, but the fresh version is fetched in background. On next navigation, they get the update. The `nukebg:update-available` event lets us show a "New version available, refresh" banner. Cache name includes version number for clean purges. |
+| R5  | **SW accidentally caches HuggingFace model**                                                                 | Low         | Critical (45MB in Cache API = quota issues) | URL pattern exclusion is the first defense. Additionally, only same-origin requests are cached. HuggingFace URLs are cross-origin, so they are excluded by the `url.origin !== self.location.origin` check. Double protection.                                                                                    |
+| R6  | **i18n translations drift** (new keys added in EN but forgotten in other locales)                            | High        | Low                                         | Test `tests/i18n/translations.test.ts` explicitly asserts all locales have the same key set as English. CI will catch missing keys.                                                                                                                                                                               |
+| R7  | **Format toggle re-export is slow for large images**                                                         | Low         | Medium                                      | WebP encoding is done by the browser engine (C++ canvas implementation), not JS. For a 4096x4096 image, `convertToBlob` for WebP takes ~200-500ms, which is acceptable. Show a brief loading indicator on the download button during re-export if needed.                                                         |
+| R8  | **beforeinstallprompt event never fires** (Chrome-only, not in Firefox/Safari)                               | High        | Low                                         | The install button is progressive enhancement — it only appears when the event fires. No install button shown = no broken UX. Safari users can still "Add to Home Screen" manually.                                                                                                                               |
+| R9  | **Diagonal watermark Sobel + autocorrelation is slow on large images**                                       | Medium      | Medium                                      | Downsample by 2x before processing. At 2048x2048 input, we process at 1024x1024 = 1M pixels. Sobel is simple per-pixel math. Autocorrelation operates on ~1400 strip bins with lags up to 400. Total estimate: <100ms. If it exceeds 200ms, increase DOWNSAMPLE to 3 or 4.                                        |
+| R10 | **Multiple watermark detectors find overlapping regions, causing over-inpainting**                           | Low         | Medium                                      | The existing `combineMasks` uses OR, so overlapping regions are simply merged. This is correct behavior — the inpainter only sees a binary mask. The Telea FMM inpainter handles large masks gracefully.                                                                                                          |
 
 ### Decision Classification
 
-| Decision | Type | Reasoning |
-|----------|------|-----------|
-| WebP as secondary format (PNG stays default) | Two-way door | Easy to change default later or add more formats |
-| Stale-while-revalidate SW strategy | Two-way door | SW can be replaced/updated trivially |
-| Sobel + autocorrelation for diagonal detection | Two-way door | Algorithm is a pure function, can swap implementation without touching interfaces |
-| Corner detector using local bg estimation (no color input) | One-way door (mild) | Sets the API contract. But since `WatermarkResult` is unchanged, the downstream impact is zero. |
-| Excluding model from SW cache | One-way door | If we later want to cache the model, we would need to redesign quota management. Correct decision for now — 45MB in Cache API is risky for user quota. |
+| Decision                                                   | Type                | Reasoning                                                                                                                                              |
+| ---------------------------------------------------------- | ------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| WebP as secondary format (PNG stays default)               | Two-way door        | Easy to change default later or add more formats                                                                                                       |
+| Stale-while-revalidate SW strategy                         | Two-way door        | SW can be replaced/updated trivially                                                                                                                   |
+| Sobel + autocorrelation for diagonal detection             | Two-way door        | Algorithm is a pure function, can swap implementation without touching interfaces                                                                      |
+| Corner detector using local bg estimation (no color input) | One-way door (mild) | Sets the API contract. But since `WatermarkResult` is unchanged, the downstream impact is zero.                                                        |
+| Excluding model from SW cache                              | One-way door        | If we later want to cache the model, we would need to redesign quota management. Correct decision for now — 45MB in Cache API is risky for user quota. |
 
 ---
 
@@ -1120,20 +1136,25 @@ Updated to 4-way parallel:
 const [wmGemini, wmDalle, wmDiagonal, wmCorner] = await Promise.all([
   this.cvCall<WatermarkResult>('watermark-detect', {
     pixels: new Uint8ClampedArray(imageData.data),
-    width, height,
-    colorA: bgInfo.colorA, colorB: bgInfo.colorB,
+    width,
+    height,
+    colorA: bgInfo.colorA,
+    colorB: bgInfo.colorB,
   }),
   this.cvCall<WatermarkResult>('watermark-detect-dalle', {
     pixels: new Uint8ClampedArray(imageData.data),
-    width, height,
+    width,
+    height,
   }),
   this.cvCall<WatermarkResult>('watermark-detect-diagonal', {
     pixels: new Uint8ClampedArray(imageData.data),
-    width, height,
+    width,
+    height,
   }),
   this.cvCall<WatermarkResult>('watermark-detect-corner', {
     pixels: new Uint8ClampedArray(imageData.data),
-    width, height,
+    width,
+    height,
   }),
 ]);
 ```
@@ -1165,8 +1186,11 @@ private static combineMasks(
 Call site:
 
 ```typescript
-const anyWatermark = wmGemini.detected || wmDalle.detected
-  || wmDiagonal.detected || wmCorner.detected;
+const anyWatermark =
+  wmGemini.detected ||
+  wmDalle.detected ||
+  wmDiagonal.detected ||
+  wmCorner.detected;
 const combinedMask = PipelineOrchestrator.combineMasks(
   [wmGemini.mask, wmDalle.mask, wmDiagonal.mask, wmCorner.mask],
   width * height,
@@ -1174,6 +1198,7 @@ const combinedMask = PipelineOrchestrator.combineMasks(
 ```
 
 Note: since all 4 calls go through the same CV worker (single thread), they are queued — not truly parallel at the worker level. However, the `Promise.all` pattern is correct because:
+
 1. The orchestrator sends all 4 messages without waiting.
 2. The CV worker processes them sequentially but returns results as they complete.
 3. The main thread only blocks on the slowest one.
@@ -1198,14 +1223,14 @@ pwa.updateReady          — "Click to update" (action)
 
 ### Translation tone per language (examples for key `pwa.install`):
 
-| Lang | `pwa.install` | `download.btnWebp` |
-|------|--------------|-------------------|
-| en | `> Install NukeBG` | `Download Clean WebP` |
-| es | `> Instalar NukeBG` | `Descargar WebP limpio` |
-| fr | `> Installer NukeBG` | `Telecharger WebP propre` |
-| de | `> NukeBG installieren` | `Sauberes WebP laden` |
-| pt | `> Instalar NukeBG` | `Baixar WebP limpo` |
-| zh | `> ?????? NukeBG` | `?????????WebP` |
+| Lang | `pwa.install`           | `download.btnWebp`        |
+| ---- | ----------------------- | ------------------------- |
+| en   | `> Install NukeBG`      | `Download Clean WebP`     |
+| es   | `> Instalar NukeBG`     | `Descargar WebP limpio`   |
+| fr   | `> Installer NukeBG`    | `Telecharger WebP propre` |
+| de   | `> NukeBG installieren` | `Sauberes WebP laden`     |
+| pt   | `> Instalar NukeBG`     | `Baixar WebP limpo`       |
+| zh   | `> ?????? NukeBG`       | `?????????WebP`           |
 
 ### Localized Filename Prefix Pools
 

--- a/e2e/pipeline.spec.ts
+++ b/e2e/pipeline.spec.ts
@@ -54,7 +54,10 @@ test.describe('pipeline end-to-end', () => {
 
     // Warmup must have fired — this catches regressions where the ML worker
     // boot path silently breaks (e.g. onnxruntime init errors swallowed).
-    expect(warmupLogs.length, `expected at least one warmup log, got ${warmupLogs.length}`).toBeGreaterThan(0);
+    expect(
+      warmupLogs.length,
+      `expected at least one warmup log, got ${warmupLogs.length}`,
+    ).toBeGreaterThan(0);
     expect(warmupLogs.some((line) => line.includes(' ok '))).toBe(true);
 
     // No uncaught page errors during the full run.

--- a/index.html
+++ b/index.html
@@ -1,395 +1,581 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en" dir="ltr">
-<head>
-  <meta charset="UTF-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=5.0, user-scalable=yes" />
+  <head>
+    <meta charset="UTF-8" />
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1.0, maximum-scale=5.0, user-scalable=yes"
+    />
 
-  <!-- Primary Meta Tags -->
-  <title>NukeBG | Background Remover That Never Uploads Your Images</title>
-  <meta name="description" content="Remove backgrounds from any image for free. 100% in your browser, your images never leave your device. No account, no watermarks on output, no limits." />
-  <meta name="keywords" content="remove background free, background remover online, transparent png, client-side background removal, remove checkerboard AI, remove gemini watermark, checkerboard background removal, ai image cleanup, private background removal, background eraser online, remove background without photoshop, free transparent background, remove background from screenshot, nukebg" />
-  <meta name="robots" content="index, follow" />
-  <meta name="author" content="NukeBG" />
-  <meta name="application-name" content="NukeBG" />
-  <meta name="theme-color" content="#000000" />
-  <meta name="color-scheme" content="dark" />
-  <link rel="canonical" href="https://nukebg.app/" />
-  <link rel="alternate" hreflang="en" href="https://nukebg.app/" />
-  <link rel="alternate" hreflang="x-default" href="https://nukebg.app/" />
+    <!-- Primary Meta Tags -->
+    <title>NukeBG | Background Remover That Never Uploads Your Images</title>
+    <meta
+      name="description"
+      content="Remove backgrounds from any image for free. 100% in your browser, your images never leave your device. No account, no watermarks on output, no limits."
+    />
+    <meta
+      name="keywords"
+      content="remove background free, background remover online, transparent png, client-side background removal, remove checkerboard AI, remove gemini watermark, checkerboard background removal, ai image cleanup, private background removal, background eraser online, remove background without photoshop, free transparent background, remove background from screenshot, nukebg"
+    />
+    <meta name="robots" content="index, follow" />
+    <meta name="author" content="NukeBG" />
+    <meta name="application-name" content="NukeBG" />
+    <meta name="theme-color" content="#000000" />
+    <meta name="color-scheme" content="dark" />
+    <link rel="canonical" href="https://nukebg.app/" />
+    <link rel="alternate" hreflang="en" href="https://nukebg.app/" />
+    <link rel="alternate" hreflang="x-default" href="https://nukebg.app/" />
 
-  <!-- Open Graph -->
-  <meta property="og:type" content="website" />
-  <meta property="og:url" content="https://nukebg.app/" />
-  <meta property="og:title" content="NukeBG | Remove Backgrounds Without Uploading a Single Pixel" />
-  <meta property="og:description" content="Remove backgrounds 100% in your browser. Your images never touch a server. Free, open source, no account needed." />
-  <meta property="og:image" content="https://nukebg.app/og-image.png" />
-  <meta property="og:image:width" content="1200" />
-  <meta property="og:image:height" content="630" />
-  <meta property="og:image:alt" content="NukeBG: before and after nuking checkerboard background from an AI-generated image" />
-  <meta property="og:image:type" content="image/png" />
-  <meta property="og:site_name" content="NukeBG" />
-  <meta property="og:locale" content="en_US" />
-  <meta property="og:locale:alternate" content="es_ES" />
-  <meta property="og:locale:alternate" content="fr_FR" />
-  <meta property="og:locale:alternate" content="de_DE" />
-  <meta property="og:locale:alternate" content="pt_BR" />
-  <meta property="og:locale:alternate" content="zh_CN" />
+    <!-- Open Graph -->
+    <meta property="og:type" content="website" />
+    <meta property="og:url" content="https://nukebg.app/" />
+    <meta
+      property="og:title"
+      content="NukeBG | Remove Backgrounds Without Uploading a Single Pixel"
+    />
+    <meta
+      property="og:description"
+      content="Remove backgrounds 100% in your browser. Your images never touch a server. Free, open source, no account needed."
+    />
+    <meta property="og:image" content="https://nukebg.app/og-image.png" />
+    <meta property="og:image:width" content="1200" />
+    <meta property="og:image:height" content="630" />
+    <meta
+      property="og:image:alt"
+      content="NukeBG: before and after nuking checkerboard background from an AI-generated image"
+    />
+    <meta property="og:image:type" content="image/png" />
+    <meta property="og:site_name" content="NukeBG" />
+    <meta property="og:locale" content="en_US" />
+    <meta property="og:locale:alternate" content="es_ES" />
+    <meta property="og:locale:alternate" content="fr_FR" />
+    <meta property="og:locale:alternate" content="de_DE" />
+    <meta property="og:locale:alternate" content="pt_BR" />
+    <meta property="og:locale:alternate" content="zh_CN" />
 
-  <!-- Twitter Card -->
-  <meta name="twitter:card" content="summary_large_image" />
-  <meta name="twitter:title" content="NukeBG | Remove Backgrounds Without Uploading a Single Pixel" />
-  <meta name="twitter:description" content="Drop. Nuke. Download. Backgrounds gone, images never uploaded. Free. Open source. No account." />
-  <meta name="twitter:image" content="https://nukebg.app/og-image.png" />
-  <meta name="twitter:image:alt" content="NukeBG: before and after nuking checkerboard background from an AI-generated image" />
+    <!-- Twitter Card -->
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta
+      name="twitter:title"
+      content="NukeBG | Remove Backgrounds Without Uploading a Single Pixel"
+    />
+    <meta
+      name="twitter:description"
+      content="Drop. Nuke. Download. Backgrounds gone, images never uploaded. Free. Open source. No account."
+    />
+    <meta name="twitter:image" content="https://nukebg.app/og-image.png" />
+    <meta
+      name="twitter:image:alt"
+      content="NukeBG: before and after nuking checkerboard background from an AI-generated image"
+    />
 
-  <!-- Favicon & Icons -->
-  <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32.png" />
-  <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16.png" />
-  <link rel="apple-touch-icon" href="/apple-touch-icon.png" />
-  <link rel="manifest" href="/manifest.webmanifest" />
-  <link rel="preload" href="/fonts/JetBrainsMono-Regular.woff2" as="font" type="font/woff2" crossorigin />
-  <link rel="preload" href="/fonts/JetBrainsMono-Bold.woff2" as="font" type="font/woff2" crossorigin />
+    <!-- Favicon & Icons -->
+    <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32.png" />
+    <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16.png" />
+    <link rel="apple-touch-icon" href="/apple-touch-icon.png" />
+    <link rel="manifest" href="/manifest.webmanifest" />
+    <link
+      rel="preload"
+      href="/fonts/JetBrainsMono-Regular.woff2"
+      as="font"
+      type="font/woff2"
+      crossorigin
+    />
+    <link
+      rel="preload"
+      href="/fonts/JetBrainsMono-Bold.woff2"
+      as="font"
+      type="font/woff2"
+      crossorigin
+    />
 
-  <!-- Fonts: self-hosted, zero external requests -->
-  <style>
-    @font-face { font-family: 'JetBrains Mono'; font-style: normal; font-weight: 400; font-display: swap; src: url('/fonts/JetBrainsMono-Regular.woff2') format('woff2'); }
-    @font-face { font-family: 'JetBrains Mono'; font-style: normal; font-weight: 500; font-display: swap; src: url('/fonts/JetBrainsMono-Medium.woff2') format('woff2'); }
-    @font-face { font-family: 'JetBrains Mono'; font-style: normal; font-weight: 600; font-display: swap; src: url('/fonts/JetBrainsMono-SemiBold.woff2') format('woff2'); }
-    @font-face { font-family: 'JetBrains Mono'; font-style: normal; font-weight: 700; font-display: swap; src: url('/fonts/JetBrainsMono-Bold.woff2') format('woff2'); }
-  </style>
+    <!-- Fonts: self-hosted, zero external requests -->
+    <style>
+      @font-face {
+        font-family: 'JetBrains Mono';
+        font-style: normal;
+        font-weight: 400;
+        font-display: swap;
+        src: url('/fonts/JetBrainsMono-Regular.woff2') format('woff2');
+      }
+      @font-face {
+        font-family: 'JetBrains Mono';
+        font-style: normal;
+        font-weight: 500;
+        font-display: swap;
+        src: url('/fonts/JetBrainsMono-Medium.woff2') format('woff2');
+      }
+      @font-face {
+        font-family: 'JetBrains Mono';
+        font-style: normal;
+        font-weight: 600;
+        font-display: swap;
+        src: url('/fonts/JetBrainsMono-SemiBold.woff2') format('woff2');
+      }
+      @font-face {
+        font-family: 'JetBrains Mono';
+        font-style: normal;
+        font-weight: 700;
+        font-display: swap;
+        src: url('/fonts/JetBrainsMono-Bold.woff2') format('woff2');
+      }
+    </style>
 
-  <!-- JSON-LD Structured Data: WebApplication -->
-  <script type="application/ld+json">
-  {
-    "@context": "https://schema.org",
-    "@type": "WebApplication",
-    "name": "NukeBG",
-    "alternateName": "Nuke Background",
-    "description": "Free client-side background remover. Nuke backgrounds from any image: photos, illustrations, AI-generated art. Also handles painted checkerboard patterns and Gemini watermarks from AI-generated images. 100% private, images never leave your browser.",
-    "url": "https://nukebg.app/",
-    "applicationCategory": "DesignApplication",
-    "applicationSubCategory": "Image Editing",
-    "operatingSystem": "Any (Web Browser)",
-    "browserRequirements": "Chrome 90+, Firefox 90+, Safari 17+, Edge 90+",
-    "offers": {
-      "@type": "Offer",
-      "price": "0",
-      "priceCurrency": "USD",
-      "description": "Free and open source"
-    },
-    "featureList": [
-      "AI checkerboard pattern detection and removal",
-      "Gemini sparkle watermark removal",
-      "ML-powered background removal (RMBG-1.4)",
-      "100% client-side processing (images never uploaded)",
-      "Works offline after first visit",
-      "WebAssembly-powered processing",
-      "Before/after comparison view",
-      "PNG export with true alpha transparency"
-    ],
-    "screenshot": "https://nukebg.app/og-image.png",
-    "softwareVersion": "2.8.0",
-    "license": "https://www.gnu.org/licenses/gpl-3.0.html",
-    "isAccessibleForFree": true,
-    "creator": {
-      "@type": "Organization",
-      "name": "NukeBG",
-      "url": "https://github.com/yocreoquesi/nukebg"
-    },
-    "potentialAction": {
-      "@type": "UseAction",
-      "target": "https://nukebg.app/",
-      "name": "Nuke Background"
-    }
-  }
-  </script>
-
-  <!-- JSON-LD Structured Data: FAQPage -->
-  <script type="application/ld+json">
-  {
-    "@context": "https://schema.org",
-    "@type": "FAQPage",
-    "mainEntity": [
+    <!-- JSON-LD Structured Data: WebApplication -->
+    <script type="application/ld+json">
       {
-        "@type": "Question",
-        "name": "How do I remove the checkerboard background from AI-generated images?",
-        "acceptedAnswer": {
-          "@type": "Answer",
-          "text": "Drop your image into NukeBG. It automatically detects painted checkerboard patterns from AI generators and replaces them with real transparency. Gemini watermark detection included. No upload needed. Processing happens in your browser."
-        }
-      },
-      {
-        "@type": "Question",
-        "name": "Can I remove the Gemini sparkle watermark for free?",
-        "acceptedAnswer": {
-          "@type": "Answer",
-          "text": "Yes. NukeBG detects and removes Gemini's sparkle watermark automatically. It uses color deviation analysis to find the watermark and inpaints the area cleanly. Completely free, no sign-up required."
-        }
-      },
-      {
-        "@type": "Question",
-        "name": "Are my images uploaded to a server?",
-        "acceptedAnswer": {
-          "@type": "Answer",
-          "text": "No. NukeBG processes everything in your browser using WebAssembly. Your images never leave your device. The code is open source (GPL) so you can verify this yourself."
-        }
-      },
-      {
-        "@type": "Question",
-        "name": "Does it work offline?",
-        "acceptedAnswer": {
-          "@type": "Answer",
-          "text": "Yes. After your first visit, NukeBG caches all assets including the ML model via Service Worker. You can process images completely offline."
-        }
-      },
-      {
-        "@type": "Question",
-        "name": "What AI generators does NukeBG support?",
-        "acceptedAnswer": {
-          "@type": "Answer",
-          "text": "NukeBG removes backgrounds from any image, including photos, illustrations, and AI-generated art. It includes specific detection for Gemini watermarks and painted checkerboard patterns."
-        }
-      },
-      {
-        "@type": "Question",
-        "name": "How to remove background from image for free?",
-        "acceptedAnswer": {
-          "@type": "Answer",
-          "text": "Open NukeBG in your browser, drop or paste any image, and download the result as a transparent PNG. It is 100% free with no account, no watermark on output, and no usage limits. The tool runs entirely client-side so there is nothing to pay for."
-        }
-      },
-      {
-        "@type": "Question",
-        "name": "How to get transparent background without Photoshop?",
-        "acceptedAnswer": {
-          "@type": "Answer",
-          "text": "NukeBG gives you a transparent PNG background without Photoshop or any installed software. It uses an ML model (RMBG-1.4) running directly in your browser to separate the subject from the background. Just drop your image and download the result."
-        }
-      },
-      {
-        "@type": "Question",
-        "name": "Is NukeBG safe to use with private photos?",
-        "acceptedAnswer": {
-          "@type": "Answer",
-          "text": "Yes. NukeBG is 100% client-side. Your images are processed locally in your browser and never uploaded anywhere. There are no analytics, no cookies, and no tracking. The source code is open under GPL-3.0 so anyone can audit it."
-        }
-      },
-      {
-        "@type": "Question",
-        "name": "How to remove painted checkerboard from AI image?",
-        "acceptedAnswer": {
-          "@type": "Answer",
-          "text": "AI generators sometimes paint a fake checkerboard pattern instead of producing real transparency. NukeBG detects these painted checkerboard grids using classical computer vision, then replaces them with actual alpha transparency. Drop the image in and it handles it automatically."
-        }
-      },
-      {
-        "@type": "Question",
-        "name": "Can I use NukeBG offline?",
-        "acceptedAnswer": {
-          "@type": "Answer",
-          "text": "Yes. NukeBG uses a Service Worker to cache all assets including the ML model after your first visit. Once cached, you can remove backgrounds completely offline with no internet connection required."
-        }
-      },
-      {
-        "@type": "Question",
-        "name": "What image formats does NukeBG support?",
-        "acceptedAnswer": {
-          "@type": "Answer",
-          "text": "NukeBG accepts PNG, JPEG, and WebP images up to 4096x4096 pixels. The output is always a PNG with true alpha transparency, which is the standard format for transparent backgrounds."
-        }
-      },
-      {
-        "@type": "Question",
-        "name": "How to remove background from a screenshot?",
-        "acceptedAnswer": {
-          "@type": "Answer",
-          "text": "Drop or paste your screenshot directly into NukeBG. It works with screenshots from any device, including desktop, phone, and tablet. The ML model isolates the subject and produces a transparent PNG you can use anywhere."
-        }
-      },
-      {
-        "@type": "Question",
-        "name": "Does NukeBG work on mobile?",
-        "acceptedAnswer": {
-          "@type": "Answer",
-          "text": "Yes. NukeBG works in any modern mobile browser including Chrome, Safari, and Firefox. The interface is responsive and you can upload images from your camera roll or files app. Processing may be slower on older phones since the ML model runs on-device."
-        }
-      },
-      {
-        "@type": "Question",
-        "name": "Why does the model take time to load the first time?",
-        "acceptedAnswer": {
-          "@type": "Answer",
-          "text": "The ML model (RMBG-1.4) is approximately 45 MB and needs to download on your first visit. After that, it is cached by the Service Worker so subsequent visits load instantly, even offline. The initial download is a one-time cost."
-        }
-      },
-      {
-        "@type": "Question",
-        "name": "Is NukeBG really free? What is the catch?",
-        "acceptedAnswer": {
-          "@type": "Answer",
-          "text": "NukeBG is genuinely free and open source under GPL-3.0. There is no catch: no premium tier, no watermarks on output, no account required. It runs entirely in your browser so there are no server costs to recoup. You can support the project on Ko-fi if you want to."
-        }
-      },
-      {
-        "@type": "Question",
-        "name": "Can I use the resulting images commercially?",
-        "acceptedAnswer": {
-          "@type": "Answer",
-          "text": "The tool itself is GPL-3.0, but the images you process are yours. NukeBG does not add watermarks or impose restrictions on your output. You can use the resulting transparent PNGs for any purpose, whether personal, commercial, or otherwise."
+        "@context": "https://schema.org",
+        "@type": "WebApplication",
+        "name": "NukeBG",
+        "alternateName": "Nuke Background",
+        "description": "Free client-side background remover. Nuke backgrounds from any image: photos, illustrations, AI-generated art. Also handles painted checkerboard patterns and Gemini watermarks from AI-generated images. 100% private, images never leave your browser.",
+        "url": "https://nukebg.app/",
+        "applicationCategory": "DesignApplication",
+        "applicationSubCategory": "Image Editing",
+        "operatingSystem": "Any (Web Browser)",
+        "browserRequirements": "Chrome 90+, Firefox 90+, Safari 17+, Edge 90+",
+        "offers": {
+          "@type": "Offer",
+          "price": "0",
+          "priceCurrency": "USD",
+          "description": "Free and open source"
+        },
+        "featureList": [
+          "AI checkerboard pattern detection and removal",
+          "Gemini sparkle watermark removal",
+          "ML-powered background removal (RMBG-1.4)",
+          "100% client-side processing (images never uploaded)",
+          "Works offline after first visit",
+          "WebAssembly-powered processing",
+          "Before/after comparison view",
+          "PNG export with true alpha transparency"
+        ],
+        "screenshot": "https://nukebg.app/og-image.png",
+        "softwareVersion": "2.8.0",
+        "license": "https://www.gnu.org/licenses/gpl-3.0.html",
+        "isAccessibleForFree": true,
+        "creator": {
+          "@type": "Organization",
+          "name": "NukeBG",
+          "url": "https://github.com/yocreoquesi/nukebg"
+        },
+        "potentialAction": {
+          "@type": "UseAction",
+          "target": "https://nukebg.app/",
+          "name": "Nuke Background"
         }
       }
-    ]
-  }
-  </script>
+    </script>
 
-  <!-- JSON-LD Structured Data: HowTo -->
-  <script type="application/ld+json">
-  {
-    "@context": "https://schema.org",
-    "@type": "HowTo",
-    "name": "How to Remove Background from Any Image for Free",
-    "description": "Remove the background from any image and get a transparent PNG in under 30 seconds using NukeBG. No upload, no account, no Photoshop needed. Works with photos, screenshots, and AI-generated images.",
-    "totalTime": "PT30S",
-    "tool": {
-      "@type": "HowToTool",
-      "name": "NukeBG: Free Online Background Remover"
-    },
-    "supply": [],
-    "step": [
+    <!-- JSON-LD Structured Data: FAQPage -->
+    <script type="application/ld+json">
       {
-        "@type": "HowToStep",
-        "position": 1,
-        "name": "Open NukeBG",
-        "text": "Go to nukebg.app in any modern browser. No account or installation required. The tool loads instantly after the first visit."
-      },
-      {
-        "@type": "HowToStep",
-        "position": 2,
-        "name": "Drop or paste your image",
-        "text": "Drag and drop your image onto the page, paste from clipboard, or use the file picker. NukeBG accepts PNG, JPEG, WebP, and other common formats."
-      },
-      {
-        "@type": "HowToStep",
-        "position": 3,
-        "name": "Wait for processing",
-        "text": "NukeBG runs an ML model (RMBG-1.4) directly in your browser to detect and remove the background. It also checks for painted checkerboard patterns and Gemini watermarks. Processing takes a few seconds depending on your device."
-      },
-      {
-        "@type": "HowToStep",
-        "position": 4,
-        "name": "Download the transparent PNG",
-        "text": "Preview the result using the before/after comparison view. When satisfied, download the image as a PNG with true alpha transparency. Your image was never uploaded. Everything happened on your device."
+        "@context": "https://schema.org",
+        "@type": "FAQPage",
+        "mainEntity": [
+          {
+            "@type": "Question",
+            "name": "How do I remove the checkerboard background from AI-generated images?",
+            "acceptedAnswer": {
+              "@type": "Answer",
+              "text": "Drop your image into NukeBG. It automatically detects painted checkerboard patterns from AI generators and replaces them with real transparency. Gemini watermark detection included. No upload needed. Processing happens in your browser."
+            }
+          },
+          {
+            "@type": "Question",
+            "name": "Can I remove the Gemini sparkle watermark for free?",
+            "acceptedAnswer": {
+              "@type": "Answer",
+              "text": "Yes. NukeBG detects and removes Gemini's sparkle watermark automatically. It uses color deviation analysis to find the watermark and inpaints the area cleanly. Completely free, no sign-up required."
+            }
+          },
+          {
+            "@type": "Question",
+            "name": "Are my images uploaded to a server?",
+            "acceptedAnswer": {
+              "@type": "Answer",
+              "text": "No. NukeBG processes everything in your browser using WebAssembly. Your images never leave your device. The code is open source (GPL) so you can verify this yourself."
+            }
+          },
+          {
+            "@type": "Question",
+            "name": "Does it work offline?",
+            "acceptedAnswer": {
+              "@type": "Answer",
+              "text": "Yes. After your first visit, NukeBG caches all assets including the ML model via Service Worker. You can process images completely offline."
+            }
+          },
+          {
+            "@type": "Question",
+            "name": "What AI generators does NukeBG support?",
+            "acceptedAnswer": {
+              "@type": "Answer",
+              "text": "NukeBG removes backgrounds from any image, including photos, illustrations, and AI-generated art. It includes specific detection for Gemini watermarks and painted checkerboard patterns."
+            }
+          },
+          {
+            "@type": "Question",
+            "name": "How to remove background from image for free?",
+            "acceptedAnswer": {
+              "@type": "Answer",
+              "text": "Open NukeBG in your browser, drop or paste any image, and download the result as a transparent PNG. It is 100% free with no account, no watermark on output, and no usage limits. The tool runs entirely client-side so there is nothing to pay for."
+            }
+          },
+          {
+            "@type": "Question",
+            "name": "How to get transparent background without Photoshop?",
+            "acceptedAnswer": {
+              "@type": "Answer",
+              "text": "NukeBG gives you a transparent PNG background without Photoshop or any installed software. It uses an ML model (RMBG-1.4) running directly in your browser to separate the subject from the background. Just drop your image and download the result."
+            }
+          },
+          {
+            "@type": "Question",
+            "name": "Is NukeBG safe to use with private photos?",
+            "acceptedAnswer": {
+              "@type": "Answer",
+              "text": "Yes. NukeBG is 100% client-side. Your images are processed locally in your browser and never uploaded anywhere. There are no analytics, no cookies, and no tracking. The source code is open under GPL-3.0 so anyone can audit it."
+            }
+          },
+          {
+            "@type": "Question",
+            "name": "How to remove painted checkerboard from AI image?",
+            "acceptedAnswer": {
+              "@type": "Answer",
+              "text": "AI generators sometimes paint a fake checkerboard pattern instead of producing real transparency. NukeBG detects these painted checkerboard grids using classical computer vision, then replaces them with actual alpha transparency. Drop the image in and it handles it automatically."
+            }
+          },
+          {
+            "@type": "Question",
+            "name": "Can I use NukeBG offline?",
+            "acceptedAnswer": {
+              "@type": "Answer",
+              "text": "Yes. NukeBG uses a Service Worker to cache all assets including the ML model after your first visit. Once cached, you can remove backgrounds completely offline with no internet connection required."
+            }
+          },
+          {
+            "@type": "Question",
+            "name": "What image formats does NukeBG support?",
+            "acceptedAnswer": {
+              "@type": "Answer",
+              "text": "NukeBG accepts PNG, JPEG, and WebP images up to 4096x4096 pixels. The output is always a PNG with true alpha transparency, which is the standard format for transparent backgrounds."
+            }
+          },
+          {
+            "@type": "Question",
+            "name": "How to remove background from a screenshot?",
+            "acceptedAnswer": {
+              "@type": "Answer",
+              "text": "Drop or paste your screenshot directly into NukeBG. It works with screenshots from any device, including desktop, phone, and tablet. The ML model isolates the subject and produces a transparent PNG you can use anywhere."
+            }
+          },
+          {
+            "@type": "Question",
+            "name": "Does NukeBG work on mobile?",
+            "acceptedAnswer": {
+              "@type": "Answer",
+              "text": "Yes. NukeBG works in any modern mobile browser including Chrome, Safari, and Firefox. The interface is responsive and you can upload images from your camera roll or files app. Processing may be slower on older phones since the ML model runs on-device."
+            }
+          },
+          {
+            "@type": "Question",
+            "name": "Why does the model take time to load the first time?",
+            "acceptedAnswer": {
+              "@type": "Answer",
+              "text": "The ML model (RMBG-1.4) is approximately 45 MB and needs to download on your first visit. After that, it is cached by the Service Worker so subsequent visits load instantly, even offline. The initial download is a one-time cost."
+            }
+          },
+          {
+            "@type": "Question",
+            "name": "Is NukeBG really free? What is the catch?",
+            "acceptedAnswer": {
+              "@type": "Answer",
+              "text": "NukeBG is genuinely free and open source under GPL-3.0. There is no catch: no premium tier, no watermarks on output, no account required. It runs entirely in your browser so there are no server costs to recoup. You can support the project on Ko-fi if you want to."
+            }
+          },
+          {
+            "@type": "Question",
+            "name": "Can I use the resulting images commercially?",
+            "acceptedAnswer": {
+              "@type": "Answer",
+              "text": "The tool itself is GPL-3.0, but the images you process are yours. NukeBG does not add watermarks or impose restrictions on your output. You can use the resulting transparent PNGs for any purpose, whether personal, commercial, or otherwise."
+            }
+          }
+        ]
       }
-    ]
-  }
-  </script>
-</head>
-<body>
-  <a href="#main" class="skip-link" id="skip-link">Skip to main content</a>
+    </script>
 
-  <header class="header hazard-border" role="banner">
-    <div class="header-inner">
-      <div class="header-left">
-        <a href="/" class="logo" id="logo" aria-label="NukeBG - Home"><span class="logo-accent">Nuke</span>BG</a>
-        <div class="terminal-prompt" id="terminal-prompt">
-          <span class="terminal-prompt-prefix">nukebg@local:~$</span><span class="terminal-cursor" id="terminal-cursor"></span><input type="text" class="terminal-input" id="terminal-input" maxlength="12" placeholder="" autocomplete="off" spellcheck="false" aria-label="Terminal prompt">
+    <!-- JSON-LD Structured Data: HowTo -->
+    <script type="application/ld+json">
+      {
+        "@context": "https://schema.org",
+        "@type": "HowTo",
+        "name": "How to Remove Background from Any Image for Free",
+        "description": "Remove the background from any image and get a transparent PNG in under 30 seconds using NukeBG. No upload, no account, no Photoshop needed. Works with photos, screenshots, and AI-generated images.",
+        "totalTime": "PT30S",
+        "tool": {
+          "@type": "HowToTool",
+          "name": "NukeBG: Free Online Background Remover"
+        },
+        "supply": [],
+        "step": [
+          {
+            "@type": "HowToStep",
+            "position": 1,
+            "name": "Open NukeBG",
+            "text": "Go to nukebg.app in any modern browser. No account or installation required. The tool loads instantly after the first visit."
+          },
+          {
+            "@type": "HowToStep",
+            "position": 2,
+            "name": "Drop or paste your image",
+            "text": "Drag and drop your image onto the page, paste from clipboard, or use the file picker. NukeBG accepts PNG, JPEG, WebP, and other common formats."
+          },
+          {
+            "@type": "HowToStep",
+            "position": 3,
+            "name": "Wait for processing",
+            "text": "NukeBG runs an ML model (RMBG-1.4) directly in your browser to detect and remove the background. It also checks for painted checkerboard patterns and Gemini watermarks. Processing takes a few seconds depending on your device."
+          },
+          {
+            "@type": "HowToStep",
+            "position": 4,
+            "name": "Download the transparent PNG",
+            "text": "Preview the result using the before/after comparison view. When satisfied, download the image as a PNG with true alpha transparency. Your image was never uploaded. Everything happened on your device."
+          }
+        ]
+      }
+    </script>
+  </head>
+  <body>
+    <a href="#main" class="skip-link" id="skip-link">Skip to main content</a>
+
+    <header class="header hazard-border" role="banner">
+      <div class="header-inner">
+        <div class="header-left">
+          <a href="/" class="logo" id="logo" aria-label="NukeBG - Home"
+            ><span class="logo-accent">Nuke</span>BG</a
+          >
+          <div class="terminal-prompt" id="terminal-prompt">
+            <span class="terminal-prompt-prefix">nukebg@local:~$</span
+            ><span class="terminal-cursor" id="terminal-cursor"></span
+            ><input
+              type="text"
+              class="terminal-input"
+              id="terminal-input"
+              maxlength="12"
+              placeholder=""
+              autocomplete="off"
+              spellcheck="false"
+              aria-label="Terminal prompt"
+            />
+          </div>
+          <span class="mobile-mode-label">> portable mode_</span>
+          <span class="logo-whisper" id="logo-whisper"></span>
         </div>
-        <span class="mobile-mode-label">> portable mode_</span>
-        <span class="logo-whisper" id="logo-whisper"></span>
+        <nav class="header-nav" aria-label="Main navigation">
+          <span class="privacy-badge-header">
+            <ar-privacy></ar-privacy>
+          </span>
+          <select
+            id="lang-selector"
+            aria-label="Language"
+            style="
+              background: #000;
+              color: var(--color-accent-primary);
+              border: 1px solid #1a3a1a;
+              border-radius: 0;
+              padding: 2px 6px;
+              font-family: 'JetBrains Mono', monospace;
+              font-size: 12px;
+              cursor: pointer;
+              text-transform: uppercase;
+              letter-spacing: 0.05em;
+            "
+          >
+            <option value="en">EN</option>
+            <option value="es">ES</option>
+            <option value="fr">FR</option>
+            <option value="de">DE</option>
+            <option value="pt">PT</option>
+            <option value="zh">ZH</option>
+          </select>
+          <button class="header-share-btn" id="share-btn" title="Copy share message">Share</button>
+        </nav>
       </div>
-      <nav class="header-nav" aria-label="Main navigation">
-        <span class="privacy-badge-header">
-          <ar-privacy></ar-privacy>
-        </span>
-        <select id="lang-selector" aria-label="Language" style="background:#000;color:var(--color-accent-primary);border:1px solid #1a3a1a;border-radius:0;padding:2px 6px;font-family:'JetBrains Mono',monospace;font-size:12px;cursor:pointer;text-transform:uppercase;letter-spacing:0.05em;">
-          <option value="en">EN</option>
-          <option value="es">ES</option>
-          <option value="fr">FR</option>
-          <option value="de">DE</option>
-          <option value="pt">PT</option>
-          <option value="zh">ZH</option>
-        </select>
-        <button class="header-share-btn" id="share-btn" title="Copy share message">Share</button>
-      </nav>
-    </div>
-  </header>
+    </header>
 
-  <main class="main-content" id="main" role="main">
-    <div id="seo-content" style="display:block;max-width:720px;margin:0 auto;padding:2rem 1rem;color:#ccc;font-family:'JetBrains Mono',monospace;font-size:14px;line-height:1.7;">
-      <h1 style="color:#00ff41;font-size:1.5rem;margin:0 0 0.5rem;">NukeBG. Background Remover That Never Uploads Your Images</h1>
-      <p>Remove backgrounds from any image, 100% in your browser. Your images never leave your device. No upload, no account, no tracking. Free and open source.</p>
+    <main class="main-content" id="main" role="main">
+      <div
+        id="seo-content"
+        style="
+          display: block;
+          max-width: 720px;
+          margin: 0 auto;
+          padding: 2rem 1rem;
+          color: #ccc;
+          font-family: 'JetBrains Mono', monospace;
+          font-size: 14px;
+          line-height: 1.7;
+        "
+      >
+        <h1 style="color: #00ff41; font-size: 1.5rem; margin: 0 0 0.5rem">
+          NukeBG. Background Remover That Never Uploads Your Images
+        </h1>
+        <p>
+          Remove backgrounds from any image, 100% in your browser. Your images never leave your
+          device. No upload, no account, no tracking. Free and open source.
+        </p>
 
-      <h2 style="color:#00ff41;font-size:1.1rem;margin:1.5rem 0 0.5rem;">How It Works</h2>
-      <ol>
-        <li>Open <strong>nukebg.app</strong> in any modern browser.</li>
-        <li>Drop, paste, or pick your image (PNG, JPG, WebP).</li>
-        <li>NukeBG processes everything locally using an ML model in your browser.</li>
-        <li>Download your clean transparent PNG. Your image was never uploaded.</li>
-      </ol>
+        <h2 style="color: #00ff41; font-size: 1.1rem; margin: 1.5rem 0 0.5rem">How It Works</h2>
+        <ol>
+          <li>Open <strong>nukebg.app</strong> in any modern browser.</li>
+          <li>Drop, paste, or pick your image (PNG, JPG, WebP).</li>
+          <li>NukeBG processes everything locally using an ML model in your browser.</li>
+          <li>Download your clean transparent PNG. Your image was never uploaded.</li>
+        </ol>
 
-      <h2 style="color:#00ff41;font-size:1.1rem;margin:1.5rem 0 0.5rem;">Features</h2>
-      <ul>
-        <li>100% client-side processing. Your images never touch a server.</li>
-        <li>ML-powered background removal (RMBG-1.4 via WebAssembly)</li>
-        <li>Auto-detects image type: photo, illustration, signature, icon</li>
-        <li>Before/after comparison view and manual editor</li>
-        <li>Works offline after first visit (PWA)</li>
-        <li>No account, no watermarks on output, no limits</li>
-        <li>Open source (GPL-3.0)</li>
-      </ul>
+        <h2 style="color: #00ff41; font-size: 1.1rem; margin: 1.5rem 0 0.5rem">Features</h2>
+        <ul>
+          <li>100% client-side processing. Your images never touch a server.</li>
+          <li>ML-powered background removal (RMBG-1.4 via WebAssembly)</li>
+          <li>Auto-detects image type: photo, illustration, signature, icon</li>
+          <li>Before/after comparison view and manual editor</li>
+          <li>Works offline after first visit (PWA)</li>
+          <li>No account, no watermarks on output, no limits</li>
+          <li>Open source (GPL-3.0)</li>
+        </ul>
 
-      <h2 style="color:#00ff41;font-size:1.1rem;margin:1.5rem 0 0.5rem;">FAQ</h2>
-      <dl>
-        <dt><strong>Are my images uploaded?</strong></dt>
-        <dd>No. Everything runs in your browser using WebAssembly. Your images never leave your device. Verify it yourself: open DevTools and check the Network tab.</dd>
-        <dt><strong>Is it really free?</strong></dt>
-        <dd>Yes. No premium tier, no watermarks on output, no account required. The code is open source under GPL-3.0.</dd>
-        <dt><strong>Does it work offline?</strong></dt>
-        <dd>Yes. After your first visit, all assets including the ML model are cached via Service Worker.</dd>
-        <dt><strong>What formats are supported?</strong></dt>
-        <dd>PNG, JPEG, and WebP input up to 4096x4096. Output is always a transparent PNG or WebP.</dd>
-      </dl>
+        <h2 style="color: #00ff41; font-size: 1.1rem; margin: 1.5rem 0 0.5rem">FAQ</h2>
+        <dl>
+          <dt><strong>Are my images uploaded?</strong></dt>
+          <dd>
+            No. Everything runs in your browser using WebAssembly. Your images never leave your
+            device. Verify it yourself: open DevTools and check the Network tab.
+          </dd>
+          <dt><strong>Is it really free?</strong></dt>
+          <dd>
+            Yes. No premium tier, no watermarks on output, no account required. The code is open
+            source under GPL-3.0.
+          </dd>
+          <dt><strong>Does it work offline?</strong></dt>
+          <dd>
+            Yes. After your first visit, all assets including the ML model are cached via Service
+            Worker.
+          </dd>
+          <dt><strong>What formats are supported?</strong></dt>
+          <dd>
+            PNG, JPEG, and WebP input up to 4096x4096. Output is always a transparent PNG or WebP.
+          </dd>
+        </dl>
 
-      <noscript>
-        <p><strong>NukeBG requires JavaScript to run.</strong> Please enable JavaScript in your browser to use the background remover.</p>
-      </noscript>
-    </div>
-    <ar-app></ar-app>
-  </main>
+        <noscript>
+          <p>
+            <strong>NukeBG requires JavaScript to run.</strong> Please enable JavaScript in your
+            browser to use the background remover.
+          </p>
+        </noscript>
+      </div>
+      <ar-app></ar-app>
+    </main>
 
-  <ar-reactor id="reactor-section" hidden></ar-reactor>
-  <ar-post-cta id="post-cta"></ar-post-cta>
+    <ar-reactor id="reactor-section" hidden></ar-reactor>
+    <ar-post-cta id="post-cta"></ar-post-cta>
 
-  <footer class="footer hazard-border-top" role="contentinfo">
-    <span>NukeBG <span style="color:var(--color-text-tertiary)">v2.8.0</span></span>
-    <span class="footer-sep">|</span>
-    <span>GPL-3.0</span>
-    <span class="footer-sep">|</span>
-    <a href="https://github.com/yocreoquesi/nukebg" target="_blank" rel="noopener noreferrer">GitHub</a>
-    <span class="footer-sep">|</span>
-    <a href="https://ko-fi.com/yocreoquesi" target="_blank" rel="noopener noreferrer" class="kofi-link" id="kofi-link" aria-label="Tip the reactor">☕ Tip the reactor →</a>
-    <span class="footer-sep">|</span>
-    <a href="#" id="clear-cache-btn" class="footer-cache-btn" title="Clear cached data and reload">☢ Clear cache</a>
-    <span class="footer-sep">|</span>
-    <div class="theme-picker" role="radiogroup" id="theme-picker" aria-label="Theme">
-      <span class="theme-picker-label"># theme</span>
-      <button type="button" class="theme-swatch" role="radio" data-theme="green" aria-checked="true" aria-label="Terminal green (default)" title="Terminal green"></button>
-      <button type="button" class="theme-swatch" role="radio" data-theme="amber" aria-checked="false" aria-label="Amber" title="Amber"></button>
-      <button type="button" class="theme-swatch" role="radio" data-theme="cyan" aria-checked="false" aria-label="Cyan" title="Cyan"></button>
-      <button type="button" class="theme-swatch" role="radio" data-theme="magenta" aria-checked="false" aria-label="Magenta" title="Magenta"></button>
-      <button type="button" class="theme-swatch" role="radio" data-theme="red" aria-checked="false" aria-label="Red" title="Red"></button>
-      <button type="button" class="theme-swatch" role="radio" data-theme="yellow" aria-checked="false" aria-label="Yellow" title="Yellow"></button>
-    </div>
-    <span class="footer-privacy" id="footer-privacy">Your images never leave your device. Zero uploads. Zero BS.</span>
-    <span class="footer-reactor-status" id="footer-reactor-status">Ships only while the budget holds (€91/mo). Currently funded for 0 months.</span>
-    <span class="footer-holiday" id="footer-holiday"></span>
-  </footer>
+    <footer class="footer hazard-border-top" role="contentinfo">
+      <span>NukeBG <span style="color: var(--color-text-tertiary)">v2.8.0</span></span>
+      <span class="footer-sep">|</span>
+      <span>GPL-3.0</span>
+      <span class="footer-sep">|</span>
+      <a href="https://github.com/yocreoquesi/nukebg" target="_blank" rel="noopener noreferrer"
+        >GitHub</a
+      >
+      <span class="footer-sep">|</span>
+      <a
+        href="https://ko-fi.com/yocreoquesi"
+        target="_blank"
+        rel="noopener noreferrer"
+        class="kofi-link"
+        id="kofi-link"
+        aria-label="Tip the reactor"
+        >☕ Tip the reactor →</a
+      >
+      <span class="footer-sep">|</span>
+      <a href="#" id="clear-cache-btn" class="footer-cache-btn" title="Clear cached data and reload"
+        >☢ Clear cache</a
+      >
+      <span class="footer-sep">|</span>
+      <div class="theme-picker" role="radiogroup" id="theme-picker" aria-label="Theme">
+        <span class="theme-picker-label"># theme</span>
+        <button
+          type="button"
+          class="theme-swatch"
+          role="radio"
+          data-theme="green"
+          aria-checked="true"
+          aria-label="Terminal green (default)"
+          title="Terminal green"
+        ></button>
+        <button
+          type="button"
+          class="theme-swatch"
+          role="radio"
+          data-theme="amber"
+          aria-checked="false"
+          aria-label="Amber"
+          title="Amber"
+        ></button>
+        <button
+          type="button"
+          class="theme-swatch"
+          role="radio"
+          data-theme="cyan"
+          aria-checked="false"
+          aria-label="Cyan"
+          title="Cyan"
+        ></button>
+        <button
+          type="button"
+          class="theme-swatch"
+          role="radio"
+          data-theme="magenta"
+          aria-checked="false"
+          aria-label="Magenta"
+          title="Magenta"
+        ></button>
+        <button
+          type="button"
+          class="theme-swatch"
+          role="radio"
+          data-theme="red"
+          aria-checked="false"
+          aria-label="Red"
+          title="Red"
+        ></button>
+        <button
+          type="button"
+          class="theme-swatch"
+          role="radio"
+          data-theme="yellow"
+          aria-checked="false"
+          aria-label="Yellow"
+          title="Yellow"
+        ></button>
+      </div>
+      <span class="footer-privacy" id="footer-privacy"
+        >Your images never leave your device. Zero uploads. Zero BS.</span
+      >
+      <span class="footer-reactor-status" id="footer-reactor-status"
+        >Ships only while the budget holds (€91/mo). Currently funded for 0 months.</span
+      >
+      <span class="footer-holiday" id="footer-holiday"></span>
+    </footer>
 
-  <div class="kbd-toast" id="kbd-toast" role="status" aria-live="polite"></div>
+    <div class="kbd-toast" id="kbd-toast" role="status" aria-live="polite"></div>
 
-  <!-- Auto-recovery: if main JS fails to load (stale SW cache), clear and reload.
+    <!-- Auto-recovery: if main JS fails to load (stale SW cache), clear and reload.
        Externalized so CSP can drop script-src 'unsafe-inline'. -->
-  <script src="/sw-recovery.js"></script>
-  <script type="module" src="/src/main.ts"></script>
-</body>
+    <script src="/sw-recovery.js"></script>
+    <script type="module" src="/src/main.ts"></script>
+  </body>
 </html>

--- a/infra/nginx.conf
+++ b/infra/nginx.conf
@@ -31,7 +31,7 @@ server {
     #   new Function() WASM bootstrap.
     # - sha256 hashes cover the 3 inline JSON-LD blocks in index.html.
     #   Regenerate with `node scripts/compute-csp-hashes.mjs` after edits.
-    add_header Content-Security-Policy "default-src 'self'; script-src 'self' blob: 'wasm-unsafe-eval' 'unsafe-eval' 'sha256-jMZpGuW3zrsQYt0F7sBciOSXuZAS5SS3c5xiqrSBVEA=' 'sha256-SzSpABgAR0NQroLM6JrGu4Sw+a01dpq3UNlybakcesw=' 'sha256-n+hPDoKBtir6IJzQxsYO0Jml5FRgLaNreG+d2UAvfFw=' https://cdn.jsdelivr.net; worker-src 'self' blob:; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; connect-src 'self' https://huggingface.co https://cdn-lfs.huggingface.co https://cdn-lfs-us-1.huggingface.co https://cdn.jsdelivr.net https://cas-bridge.xethub.hf.co; font-src 'self'; object-src 'none'; base-uri 'self'; form-action 'none'" always;
+    add_header Content-Security-Policy "default-src 'self'; script-src 'self' blob: 'wasm-unsafe-eval' 'unsafe-eval' 'sha256-LAtNqeqhdzzGqXdTx12HjOtj8QmXv4qw7OsNW7BCFUw=' 'sha256-uZm4Xh9FxR3B7WjPHL5pbehtSMYTCy9JWzQzl3/UKA0=' 'sha256-o1DLxvGFHY9H1AG6Sro58slSTxU3T7zb020gfyqbFwM=' https://cdn.jsdelivr.net; worker-src 'self' blob:; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; connect-src 'self' https://huggingface.co https://cdn-lfs.huggingface.co https://cdn-lfs-us-1.huggingface.co https://cdn.jsdelivr.net https://cas-bridge.xethub.hf.co; font-src 'self'; object-src 'none'; base-uri 'self'; form-action 'none'" always;
 
     # Cache static assets
     # Note: add_header in location blocks replaces parent headers in nginx,
@@ -46,7 +46,7 @@ server {
         add_header Strict-Transport-Security "max-age=63072000; includeSubDomains; preload" always;
         add_header Cross-Origin-Opener-Policy "same-origin" always;
         add_header X-DNS-Prefetch-Control "off" always;
-        add_header Content-Security-Policy "default-src 'self'; script-src 'self' blob: 'wasm-unsafe-eval' 'unsafe-eval' 'sha256-jMZpGuW3zrsQYt0F7sBciOSXuZAS5SS3c5xiqrSBVEA=' 'sha256-SzSpABgAR0NQroLM6JrGu4Sw+a01dpq3UNlybakcesw=' 'sha256-n+hPDoKBtir6IJzQxsYO0Jml5FRgLaNreG+d2UAvfFw=' https://cdn.jsdelivr.net; worker-src 'self' blob:; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; connect-src 'self' https://huggingface.co https://cdn-lfs.huggingface.co https://cdn-lfs-us-1.huggingface.co https://cdn.jsdelivr.net https://cas-bridge.xethub.hf.co; font-src 'self'; object-src 'none'; base-uri 'self'; form-action 'none'" always;
+        add_header Content-Security-Policy "default-src 'self'; script-src 'self' blob: 'wasm-unsafe-eval' 'unsafe-eval' 'sha256-LAtNqeqhdzzGqXdTx12HjOtj8QmXv4qw7OsNW7BCFUw=' 'sha256-uZm4Xh9FxR3B7WjPHL5pbehtSMYTCy9JWzQzl3/UKA0=' 'sha256-o1DLxvGFHY9H1AG6Sro58slSTxU3T7zb020gfyqbFwM=' https://cdn.jsdelivr.net; worker-src 'self' blob:; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; connect-src 'self' https://huggingface.co https://cdn-lfs.huggingface.co https://cdn-lfs-us-1.huggingface.co https://cdn.jsdelivr.net https://cas-bridge.xethub.hf.co; font-src 'self'; object-src 'none'; base-uri 'self'; form-action 'none'" always;
     }
 
     # ONNX model files — cache aggressively, same-origin so CORP is fine
@@ -60,7 +60,7 @@ server {
         add_header Strict-Transport-Security "max-age=63072000; includeSubDomains; preload" always;
         add_header Cross-Origin-Opener-Policy "same-origin" always;
         add_header X-DNS-Prefetch-Control "off" always;
-        add_header Content-Security-Policy "default-src 'self'; script-src 'self' blob: 'wasm-unsafe-eval' 'unsafe-eval' 'sha256-jMZpGuW3zrsQYt0F7sBciOSXuZAS5SS3c5xiqrSBVEA=' 'sha256-SzSpABgAR0NQroLM6JrGu4Sw+a01dpq3UNlybakcesw=' 'sha256-n+hPDoKBtir6IJzQxsYO0Jml5FRgLaNreG+d2UAvfFw=' https://cdn.jsdelivr.net; worker-src 'self' blob:; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; connect-src 'self' https://huggingface.co https://cdn-lfs.huggingface.co https://cdn-lfs-us-1.huggingface.co https://cdn.jsdelivr.net https://cas-bridge.xethub.hf.co; font-src 'self'; object-src 'none'; base-uri 'self'; form-action 'none'" always;
+        add_header Content-Security-Policy "default-src 'self'; script-src 'self' blob: 'wasm-unsafe-eval' 'unsafe-eval' 'sha256-LAtNqeqhdzzGqXdTx12HjOtj8QmXv4qw7OsNW7BCFUw=' 'sha256-uZm4Xh9FxR3B7WjPHL5pbehtSMYTCy9JWzQzl3/UKA0=' 'sha256-o1DLxvGFHY9H1AG6Sro58slSTxU3T7zb020gfyqbFwM=' https://cdn.jsdelivr.net; worker-src 'self' blob:; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; connect-src 'self' https://huggingface.co https://cdn-lfs.huggingface.co https://cdn-lfs-us-1.huggingface.co https://cdn.jsdelivr.net https://cas-bridge.xethub.hf.co; font-src 'self'; object-src 'none'; base-uri 'self'; form-action 'none'" always;
     }
 
     # SPA fallback

--- a/public/_headers
+++ b/public/_headers
@@ -7,7 +7,7 @@
   Cross-Origin-Resource-Policy: same-origin
   X-DNS-Prefetch-Control: off
   Strict-Transport-Security: max-age=63072000; includeSubDomains; preload
-  Content-Security-Policy: default-src 'self'; script-src 'self' blob: 'wasm-unsafe-eval' 'unsafe-eval' 'sha256-jMZpGuW3zrsQYt0F7sBciOSXuZAS5SS3c5xiqrSBVEA=' 'sha256-SzSpABgAR0NQroLM6JrGu4Sw+a01dpq3UNlybakcesw=' 'sha256-n+hPDoKBtir6IJzQxsYO0Jml5FRgLaNreG+d2UAvfFw=' https://cdn.jsdelivr.net; worker-src 'self' blob:; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; connect-src 'self' https://huggingface.co https://cdn-lfs.huggingface.co https://cdn-lfs-us-1.huggingface.co https://cdn.jsdelivr.net https://cas-bridge.xethub.hf.co; font-src 'self'; object-src 'none'; base-uri 'self'; form-action 'none'
+  Content-Security-Policy: default-src 'self'; script-src 'self' blob: 'wasm-unsafe-eval' 'unsafe-eval' 'sha256-LAtNqeqhdzzGqXdTx12HjOtj8QmXv4qw7OsNW7BCFUw=' 'sha256-uZm4Xh9FxR3B7WjPHL5pbehtSMYTCy9JWzQzl3/UKA0=' 'sha256-o1DLxvGFHY9H1AG6Sro58slSTxU3T7zb020gfyqbFwM=' https://cdn.jsdelivr.net; worker-src 'self' blob:; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; connect-src 'self' https://huggingface.co https://cdn-lfs.huggingface.co https://cdn-lfs-us-1.huggingface.co https://cdn.jsdelivr.net https://cas-bridge.xethub.hf.co; font-src 'self'; object-src 'none'; base-uri 'self'; form-action 'none'
 
 /assets/*
   Cache-Control: public, max-age=31536000, immutable

--- a/public/manifest.webmanifest
+++ b/public/manifest.webmanifest
@@ -25,7 +25,12 @@
     { "src": "/favicon.svg", "sizes": "any", "type": "image/svg+xml" },
     { "src": "/icon-192.png", "sizes": "192x192", "type": "image/png" },
     { "src": "/icon-512.png", "sizes": "512x512", "type": "image/png" },
-    { "src": "/icon-512-maskable.png", "sizes": "512x512", "type": "image/png", "purpose": "maskable" }
+    {
+      "src": "/icon-512-maskable.png",
+      "sizes": "512x512",
+      "type": "image/png",
+      "purpose": "maskable"
+    }
   ],
   "shortcuts": [
     {

--- a/public/sw-recovery.js
+++ b/public/sw-recovery.js
@@ -5,8 +5,17 @@
 // hatch. The file is tiny and served once per navigation.
 setTimeout(function () {
   if (document.getElementById('seo-content') && 'serviceWorker' in navigator) {
-    caches.keys().then(function (keys) {
-      return Promise.all(keys.map(function (k) { return caches.delete(k); }));
-    }).then(function () { location.reload(); });
+    caches
+      .keys()
+      .then(function (keys) {
+        return Promise.all(
+          keys.map(function (k) {
+            return caches.delete(k);
+          }),
+        );
+      })
+      .then(function () {
+        location.reload();
+      });
   }
 }, 5000);

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -6,8 +6,8 @@ documents its own usage at the top of the file.
 
 ## Build / CI helpers
 
-| Script | Purpose |
-| --- | --- |
+| Script                   | Purpose                                                                                                                                                                                                                                                                                         |
+| ------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `compute-csp-hashes.mjs` | Recompute the `'sha256-…'` directives for every inline `<script>` block in `index.html`. Run after editing JSON-LD or any other inline script, then paste the printed line into `nginx.conf` + `public/_headers`. The companion test (`tests/csp-hashes.test.ts`) fails CI if the hashes drift. |
 
 ## Pipeline diagnostics (one-off)
@@ -16,13 +16,13 @@ These helpers exist to debug the alpha pipeline against fixed input
 images. They write JSON / PNG dumps to `dist/` or stdout and are not
 called by the runtime:
 
-| Script | Purpose |
-| --- | --- |
-| `analyze-holes.mjs` | Detect interior holes (transparent islands) in an alpha mask and report counts + sizes. Used to tune cluster-size thresholds. |
+| Script                 | Purpose                                                                                                                                    |
+| ---------------------- | ------------------------------------------------------------------------------------------------------------------------------------------ |
+| `analyze-holes.mjs`    | Detect interior holes (transparent islands) in an alpha mask and report counts + sizes. Used to tune cluster-size thresholds.              |
 | `analyze-lowalpha.mjs` | Histogram the alpha channel and surface low-confidence bands (α ∈ [10..240]). Used when the RMBG threshold needs adjusting per image type. |
-| `analyze-region.mjs` | Crop a rectangular region and report per-pixel RGB + alpha statistics. |
-| `analyze-speckle.mjs` | Count tiny disconnected alpha blobs (speckle), grouped by size. Drives the `MIN_CLUSTER_SIZE` constants. |
-| `remove-bg-rmbg.ts` | Run the RMBG-1.4 segmenter against a single image, save the mask + composited PNG. Used to compare model upgrades. |
-| `validate.ts` | Run a full pipeline pass over every fixture in `tests/fixtures/` and emit a per-image report (timing, content-type, watermark hits). |
-| `validate-mascots.ts` | Same as `validate.ts` but scoped to the cartoon-mascot fixtures used to tune the illustration branch. |
-| `test-ml.ts` | Smoke-test the ML worker contract end-to-end against a single fixture. |
+| `analyze-region.mjs`   | Crop a rectangular region and report per-pixel RGB + alpha statistics.                                                                     |
+| `analyze-speckle.mjs`  | Count tiny disconnected alpha blobs (speckle), grouped by size. Drives the `MIN_CLUSTER_SIZE` constants.                                   |
+| `remove-bg-rmbg.ts`    | Run the RMBG-1.4 segmenter against a single image, save the mask + composited PNG. Used to compare model upgrades.                         |
+| `validate.ts`          | Run a full pipeline pass over every fixture in `tests/fixtures/` and emit a per-image report (timing, content-type, watermark hits).       |
+| `validate-mascots.ts`  | Same as `validate.ts` but scoped to the cartoon-mascot fixtures used to tune the illustration branch.                                      |
+| `test-ml.ts`           | Smoke-test the ML worker contract end-to-end against a single fixture.                                                                     |

--- a/scripts/analyze-holes.mjs
+++ b/scripts/analyze-holes.mjs
@@ -16,14 +16,32 @@ for (let i = 0; i < n; i++) alpha[i] = data[i * 4 + 3];
 // BFS from border marking α=0 connected to edge.
 const bgVisited = new Uint8Array(n);
 const queue = new Int32Array(n);
-let head = 0, tail = 0;
-const seed = (i) => { if (alpha[i] === 0 && !bgVisited[i]) { bgVisited[i] = 1; queue[tail++] = i; } };
-for (let x = 0; x < w; x++) { seed(x); seed((h - 1) * w + x); }
-for (let y = 1; y < h - 1; y++) { seed(y * w); seed(y * w + w - 1); }
+let head = 0,
+  tail = 0;
+const seed = (i) => {
+  if (alpha[i] === 0 && !bgVisited[i]) {
+    bgVisited[i] = 1;
+    queue[tail++] = i;
+  }
+};
+for (let x = 0; x < w; x++) {
+  seed(x);
+  seed((h - 1) * w + x);
+}
+for (let y = 1; y < h - 1; y++) {
+  seed(y * w);
+  seed(y * w + w - 1);
+}
 while (head < tail) {
   const i = queue[head++];
-  const x = i % w, y = (i - x) / w;
-  const push = (ni) => { if (alpha[ni] === 0 && !bgVisited[ni]) { bgVisited[ni] = 1; queue[tail++] = ni; } };
+  const x = i % w,
+    y = (i - x) / w;
+  const push = (ni) => {
+    if (alpha[ni] === 0 && !bgVisited[ni]) {
+      bgVisited[ni] = 1;
+      queue[tail++] = ni;
+    }
+  };
   if (x > 0) push(i - 1);
   if (x < w - 1) push(i + 1);
   if (y > 0) push(i - w);
@@ -35,18 +53,30 @@ const visited = new Uint8Array(n);
 const holes = [];
 for (let start = 0; start < n; start++) {
   if (alpha[start] !== 0 || bgVisited[start] || visited[start]) continue;
-  head = 0; tail = 0;
+  head = 0;
+  tail = 0;
   queue[tail++] = start;
   visited[start] = 1;
   let size = 0;
-  let minX = w, minY = h, maxX = 0, maxY = 0;
+  let minX = w,
+    minY = h,
+    maxX = 0,
+    maxY = 0;
   while (head < tail) {
     const i = queue[head++];
     size++;
-    const x = i % w, y = (i - x) / w;
-    if (x < minX) minX = x; if (x > maxX) maxX = x;
-    if (y < minY) minY = y; if (y > maxY) maxY = y;
-    const push = (ni) => { if (alpha[ni] === 0 && !bgVisited[ni] && !visited[ni]) { visited[ni] = 1; queue[tail++] = ni; } };
+    const x = i % w,
+      y = (i - x) / w;
+    if (x < minX) minX = x;
+    if (x > maxX) maxX = x;
+    if (y < minY) minY = y;
+    if (y > maxY) maxY = y;
+    const push = (ni) => {
+      if (alpha[ni] === 0 && !bgVisited[ni] && !visited[ni]) {
+        visited[ni] = 1;
+        queue[tail++] = ni;
+      }
+    };
     if (x > 0) push(i - 1);
     if (x < w - 1) push(i + 1);
     if (y > 0) push(i - w);
@@ -57,7 +87,15 @@ for (let start = 0; start < n; start++) {
 
 holes.sort((a, b) => b.size - a.size);
 console.log(`\nFound ${holes.length} ENCLOSED α=0 holes (topologically inside the subject):`);
-const bucket = { '1': 0, '2-10': 0, '11-50': 0, '51-200': 0, '201-500': 0, '501-2000': 0, '2001+': 0 };
+const bucket = {
+  1: 0,
+  '2-10': 0,
+  '11-50': 0,
+  '51-200': 0,
+  '201-500': 0,
+  '501-2000': 0,
+  '2001+': 0,
+};
 for (const h of holes) {
   if (h.size === 1) bucket['1']++;
   else if (h.size <= 10) bucket['2-10']++;
@@ -70,5 +108,7 @@ for (const h of holes) {
 console.log('Size histogram:', bucket);
 console.log('\nTop 20 largest enclosed holes:');
 for (const h of holes.slice(0, 20)) {
-  console.log(`  size=${h.size}  bbox=(${h.minX},${h.minY})-(${h.maxX},${h.maxY})  wh=${h.maxX - h.minX + 1}x${h.maxY - h.minY + 1}`);
+  console.log(
+    `  size=${h.size}  bbox=(${h.minX},${h.minY})-(${h.maxX},${h.maxY})  wh=${h.maxX - h.minX + 1}x${h.maxY - h.minY + 1}`,
+  );
 }

--- a/scripts/analyze-lowalpha.mjs
+++ b/scripts/analyze-lowalpha.mjs
@@ -17,8 +17,12 @@ const hist = new Array(256).fill(0);
 for (let i = 0; i < n; i++) hist[alpha[i]]++;
 const buckets = {
   'α=0': hist[0],
-  'α=1..31': 0, 'α=32..63': 0, 'α=64..127': 0,
-  'α=128..191': 0, 'α=192..223': 0, 'α=224..254': 0,
+  'α=1..31': 0,
+  'α=32..63': 0,
+  'α=64..127': 0,
+  'α=128..191': 0,
+  'α=192..223': 0,
+  'α=224..254': 0,
   'α=255': hist[255],
 };
 for (let a = 1; a <= 31; a++) buckets['α=1..31'] += hist[a];
@@ -29,7 +33,7 @@ for (let a = 192; a <= 223; a++) buckets['α=192..223'] += hist[a];
 for (let a = 224; a <= 254; a++) buckets['α=224..254'] += hist[a];
 console.log('Alpha histogram:');
 for (const [k, v] of Object.entries(buckets)) {
-  const pct = (v / n * 100).toFixed(2);
+  const pct = ((v / n) * 100).toFixed(2);
   console.log(`  ${k.padEnd(14)} ${String(v).padStart(8)}  ${pct}%`);
 }
 

--- a/scripts/analyze-region.mjs
+++ b/scripts/analyze-region.mjs
@@ -16,14 +16,32 @@ console.log(`Image: ${path}  ${w}x${h}`);
 // Mark α=0 connected to border.
 const queue = new Int32Array(n);
 const bgVisited = new Uint8Array(n);
-let head = 0, tail = 0;
-const seed = (i) => { if (alpha[i] === 0 && !bgVisited[i]) { bgVisited[i] = 1; queue[tail++] = i; } };
-for (let x = 0; x < w; x++) { seed(x); seed((h - 1) * w + x); }
-for (let y = 1; y < h - 1; y++) { seed(y * w); seed(y * w + w - 1); }
+let head = 0,
+  tail = 0;
+const seed = (i) => {
+  if (alpha[i] === 0 && !bgVisited[i]) {
+    bgVisited[i] = 1;
+    queue[tail++] = i;
+  }
+};
+for (let x = 0; x < w; x++) {
+  seed(x);
+  seed((h - 1) * w + x);
+}
+for (let y = 1; y < h - 1; y++) {
+  seed(y * w);
+  seed(y * w + w - 1);
+}
 while (head < tail) {
   const i = queue[head++];
-  const x = i % w, y = (i - x) / w;
-  const push = (ni) => { if (alpha[ni] === 0 && !bgVisited[ni]) { bgVisited[ni] = 1; queue[tail++] = ni; } };
+  const x = i % w,
+    y = (i - x) / w;
+  const push = (ni) => {
+    if (alpha[ni] === 0 && !bgVisited[ni]) {
+      bgVisited[ni] = 1;
+      queue[tail++] = ni;
+    }
+  };
   if (x > 0) push(i - 1);
   if (x < w - 1) push(i + 1);
   if (y > 0) push(i - w);
@@ -34,11 +52,13 @@ while (head < tail) {
 // (i.e. they poke INTO the subject). These are "thin channels" / "cracks".
 const isCrackSeed = (i) => {
   if (!bgVisited[i]) return false;
-  const x = i % w, y = (i - x) / w;
+  const x = i % w,
+    y = (i - x) / w;
   for (let dy = -1; dy <= 1; dy++) {
     for (let dx = -1; dx <= 1; dx++) {
       if (dx === 0 && dy === 0) continue;
-      const nx = x + dx, ny = y + dy;
+      const nx = x + dx,
+        ny = y + dy;
       if (nx < 0 || nx >= w || ny < 0 || ny >= h) continue;
       if (alpha[ny * w + nx] >= 200) return true;
     }
@@ -69,7 +89,7 @@ for (let y = r; y < h - r; y++) {
 }
 
 // Cluster candidates by 4-connectivity to get regions.
-const cset = new Set(candidates.map(c => c.y * w + c.x));
+const cset = new Set(candidates.map((c) => c.y * w + c.x));
 const cvisited = new Set();
 const regions = [];
 for (const c of candidates) {
@@ -77,16 +97,27 @@ for (const c of candidates) {
   if (cvisited.has(start)) continue;
   const stack = [start];
   const pts = [];
-  let minX = w, minY = h, maxX = 0, maxY = 0;
+  let minX = w,
+    minY = h,
+    maxX = 0,
+    maxY = 0;
   while (stack.length) {
     const i = stack.pop();
     if (cvisited.has(i)) continue;
     cvisited.add(i);
     pts.push(i);
-    const x = i % w, y = (i - x) / w;
-    if (x < minX) minX = x; if (x > maxX) maxX = x;
-    if (y < minY) minY = y; if (y > maxY) maxY = y;
-    for (const [dx, dy] of [[1,0],[-1,0],[0,1],[0,-1]]) {
+    const x = i % w,
+      y = (i - x) / w;
+    if (x < minX) minX = x;
+    if (x > maxX) maxX = x;
+    if (y < minY) minY = y;
+    if (y > maxY) maxY = y;
+    for (const [dx, dy] of [
+      [1, 0],
+      [-1, 0],
+      [0, 1],
+      [0, -1],
+    ]) {
       const ni = (y + dy) * w + (x + dx);
       if (cset.has(ni) && !cvisited.has(ni)) stack.push(ni);
     }
@@ -99,5 +130,7 @@ console.log(`\n"Crack" candidates (α=0 border-connected but with ≥50% opaque 
 console.log(`Total ${candidates.length} pixels in ${regions.length} regions`);
 console.log(`\nTop 15 regions by size:`);
 for (const r of regions.slice(0, 15)) {
-  console.log(`  size=${r.size}  bbox=(${r.minX},${r.minY})-(${r.maxX},${r.maxY})  wh=${r.maxX - r.minX + 1}x${r.maxY - r.minY + 1}`);
+  console.log(
+    `  size=${r.size}  bbox=(${r.minX},${r.minY})-(${r.maxX},${r.maxY})  wh=${r.maxX - r.minX + 1}x${r.maxY - r.minY + 1}`,
+  );
 }

--- a/scripts/analyze-speckle.mjs
+++ b/scripts/analyze-speckle.mjs
@@ -33,7 +33,9 @@ const check = (r, ratioThresh) => {
       }
     }
   }
-  console.log(`r=${r} thresh=${ratioThresh}: ${count} suspicious α=0 pixels (mostly surrounded by α>0)`);
+  console.log(
+    `r=${r} thresh=${ratioThresh}: ${count} suspicious α=0 pixels (mostly surrounded by α>0)`,
+  );
   if (xs.length > 0) {
     console.log(`  sample locations (first 30):`);
     for (const s of xs) console.log(`    (${s.x},${s.y}) opaque_neighbors=${s.opaque}/${s.area}`);
@@ -41,6 +43,6 @@ const check = (r, ratioThresh) => {
 };
 
 console.log(`Image: ${path}  ${w}x${h}`);
-check(1, 0.75);  // 3x3 window, at least 6/8 opaque
-check(2, 0.75);  // 5x5 window, at least 18/24 opaque
-check(3, 0.80);  // 7x7 window, at least 38/48 opaque
+check(1, 0.75); // 3x3 window, at least 6/8 opaque
+check(2, 0.75); // 5x5 window, at least 18/24 opaque
+check(3, 0.8); // 7x7 window, at least 38/48 opaque

--- a/scripts/compute-csp-hashes.mjs
+++ b/scripts/compute-csp-hashes.mjs
@@ -38,5 +38,5 @@ while ((m = re.exec(html)) !== null) {
 }
 
 console.log('# CSP hashes for inline <script> blocks in index.html');
-console.log('# Paste into the script-src directive after \'self\'.');
+console.log("# Paste into the script-src directive after 'self'.");
 console.log(hashes.join(' '));

--- a/scripts/remove-bg-rmbg.ts
+++ b/scripts/remove-bg-rmbg.ts
@@ -73,13 +73,14 @@ async function testImage(inputPath: string): Promise<boolean> {
     }
   }
 
-  const fgPct = (100 * fgCount / (width * height)).toFixed(1);
+  const fgPct = ((100 * fgCount) / (width * height)).toFixed(1);
   console.log(`  Foreground: ${fgPct}%`);
 
   // Save next to input as <name>-clean.png
   const outPath = path.join(path.dirname(inputPath), `${name}-clean.png`);
   await sharp(resultPixels, { raw: { width, height, channels: 4 } })
-    .png().toFile(outPath);
+    .png()
+    .toFile(outPath);
 
   console.log(`  Output: ${outPath}`);
   console.log(`  PASS`);
@@ -97,7 +98,8 @@ let passed = 0;
 let failed = 0;
 for (const file of files) {
   const ok = await testImage(file);
-  if (ok) passed++; else failed++;
+  if (ok) passed++;
+  else failed++;
 }
 
 console.log(`\n${passed} passed, ${failed} failed`);

--- a/scripts/test-ml.ts
+++ b/scripts/test-ml.ts
@@ -77,13 +77,14 @@ async function testImage(inputPath: string): Promise<boolean> {
     }
   }
 
-  const fgPct = (100 * fgCount / (width * height)).toFixed(1);
+  const fgPct = ((100 * fgCount) / (width * height)).toFixed(1);
   console.log(`  Foreground: ${fgPct}%`);
 
   // Save
   const outPath = path.join(OUT_DIR, `${name}-ml-test.png`);
   await sharp(resultPixels, { raw: { width, height, channels: 4 } })
-    .png().toFile(outPath);
+    .png()
+    .toFile(outPath);
 
   // On white
   const whitePixels = Buffer.alloc(width * height * 4);
@@ -96,7 +97,8 @@ async function testImage(inputPath: string): Promise<boolean> {
   }
   const whitePath = path.join(OUT_DIR, `${name}-ml-test-on-white.png`);
   await sharp(whitePixels, { raw: { width, height, channels: 4 } })
-    .png().toFile(whitePath);
+    .png()
+    .toFile(whitePath);
 
   console.log(`  Output: ${outPath}`);
   console.log(`  PASS`);
@@ -116,7 +118,8 @@ let passed = 0;
 let failed = 0;
 for (const file of files) {
   const ok = await testImage(file);
-  if (ok) passed++; else failed++;
+  if (ok) passed++;
+  else failed++;
 }
 
 console.log(`\n${passed} passed, ${failed} failed`);

--- a/scripts/validate-mascots.ts
+++ b/scripts/validate-mascots.ts
@@ -40,8 +40,11 @@ function solidImage(w: number, h: number, r: number, g: number, b: number): Uint
 
 /** Crea una imagen checkerboard */
 function checkerboardImage(
-  w: number, h: number, gs: number,
-  dark: [number, number, number], light: [number, number, number]
+  w: number,
+  h: number,
+  gs: number,
+  dark: [number, number, number],
+  light: [number, number, number],
 ): Uint8ClampedArray {
   const data = new Uint8ClampedArray(w * h * 4);
   for (let y = 0; y < h; y++) {
@@ -62,9 +65,15 @@ function checkerboardImage(
 
 /** Pinta un rectangulo */
 function paintRect(
-  data: Uint8ClampedArray, w: number,
-  x0: number, y0: number, rw: number, rh: number,
-  r: number, g: number, b: number
+  data: Uint8ClampedArray,
+  w: number,
+  x0: number,
+  y0: number,
+  rw: number,
+  rh: number,
+  r: number,
+  g: number,
+  b: number,
 ): void {
   for (let y = y0; y < y0 + rh; y++) {
     for (let x = x0; x < x0 + rw; x++) {
@@ -89,18 +98,26 @@ function runCvPipeline(pixels: Uint8ClampedArray, width: number, height: number)
     const grid = detectCheckerGrid(pixels, width, height, bgInfo.colorA, bgInfo.colorB);
     if (grid.gridSize > 0) {
       bgMask = gridFloodFill(
-        pixels, width, height,
-        bgInfo.colorA, bgInfo.colorB,
-        grid.gridSize, grid.phase
+        pixels,
+        width,
+        height,
+        bgInfo.colorA,
+        bgInfo.colorB,
+        grid.gridSize,
+        grid.phase,
       );
       let bgCount = 0;
       for (let i = 0; i < bgMask.length; i++) if (bgMask[i]) bgCount++;
       const coverage = bgCount / (width * height);
       if (coverage < CV_PARAMS.LOW_COVERAGE_THRESHOLD) {
         const exclMask = subjectExclusion(
-          pixels, width, height,
-          bgInfo.colorA, bgInfo.colorB,
-          grid.gridSize, grid.phase
+          pixels,
+          width,
+          height,
+          bgInfo.colorA,
+          bgInfo.colorB,
+          grid.gridSize,
+          grid.phase,
         );
         const floodMask = simpleFloodFill(pixels, width, height, bgInfo.colorA, bgInfo.colorB);
         bgMask = new Uint8Array(width * height);
@@ -149,50 +166,55 @@ interface MascotDef {
 const mascots: MascotDef[] = [
   {
     name: 'mascot-cartoon-checker',
-    width: 256, height: 256,
+    width: 256,
+    height: 256,
     build() {
       const p = checkerboardImage(256, 256, 16, [191, 191, 191], [255, 255, 255]);
       paintRect(p, 256, 80, 40, 96, 176, 220, 60, 60);
       paintRect(p, 256, 100, 50, 56, 40, 255, 200, 150);
       paintRect(p, 256, 100, 150, 56, 40, 60, 60, 200);
       return p;
-    }
+    },
   },
   {
     name: 'mascot-geometric-white',
-    width: 256, height: 256,
+    width: 256,
+    height: 256,
     build() {
       const p = solidImage(256, 256, 255, 255, 255);
       paintRect(p, 256, 60, 30, 136, 196, 50, 150, 200);
       paintRect(p, 256, 90, 50, 76, 76, 255, 200, 50);
       paintRect(p, 256, 100, 180, 56, 40, 50, 200, 50);
       return p;
-    }
+    },
   },
   {
     name: 'mascot-realistic-black',
-    width: 256, height: 256,
+    width: 256,
+    height: 256,
     build() {
       const p = solidImage(256, 256, 0, 0, 0);
       paintRect(p, 256, 70, 30, 116, 196, 180, 130, 90);
       paintRect(p, 256, 90, 40, 76, 76, 220, 180, 150);
       paintRect(p, 256, 70, 140, 116, 86, 50, 50, 150);
       return p;
-    }
+    },
   },
   {
     name: 'mascot-pixel-checker',
-    width: 128, height: 128,
+    width: 128,
+    height: 128,
     build() {
       const p = checkerboardImage(128, 128, 8, [191, 191, 191], [255, 255, 255]);
       paintRect(p, 128, 40, 16, 48, 96, 200, 80, 80);
       paintRect(p, 128, 48, 24, 32, 24, 255, 200, 160);
       return p;
-    }
+    },
   },
   {
     name: 'mascot-icon-m-gray',
-    width: 128, height: 128,
+    width: 128,
+    height: 128,
     build() {
       const p = solidImage(128, 128, 220, 220, 220);
       paintRect(p, 128, 20, 20, 88, 88, 30, 30, 150);
@@ -200,7 +222,7 @@ const mascots: MascotDef[] = [
       paintRect(p, 128, 86, 30, 12, 68, 255, 255, 255);
       paintRect(p, 128, 50, 55, 14, 15, 255, 255, 255);
       return p;
-    }
+    },
   },
 ];
 
@@ -219,7 +241,9 @@ for (const m of mascots) {
   const status = passed ? 'PASS' : 'FAIL';
   if (!passed) allPassed = false;
 
-  console.log(`[${status}] ${m.name}: ${bgType}, ${fgPercent.toFixed(1)}% fg, ${elapsed.toFixed(0)}ms`);
+  console.log(
+    `[${status}] ${m.name}: ${bgType}, ${fgPercent.toFixed(1)}% fg, ${elapsed.toFixed(0)}ms`,
+  );
 
   // Guardar resultado como PNG
   const resultPixels = Buffer.alloc(m.width * m.height * 4);

--- a/scripts/validate.ts
+++ b/scripts/validate.ts
@@ -47,16 +47,23 @@ async function processImage(inputPath: string): Promise<void> {
 
   if (bgInfo.isCheckerboard) {
     const grid = detectCheckerGrid(
-      new Uint8ClampedArray(pixels), width, height,
-      bgInfo.colorA, bgInfo.colorB
+      new Uint8ClampedArray(pixels),
+      width,
+      height,
+      bgInfo.colorA,
+      bgInfo.colorB,
     );
     console.log(`  Grid: size=${grid.gridSize}, phase=${grid.phase}`);
 
     if (grid.gridSize > 0) {
       bgMask = gridFloodFill(
-        new Uint8ClampedArray(pixels), width, height,
-        bgInfo.colorA, bgInfo.colorB,
-        grid.gridSize, grid.phase
+        new Uint8ClampedArray(pixels),
+        width,
+        height,
+        bgInfo.colorA,
+        bgInfo.colorB,
+        grid.gridSize,
+        grid.phase,
       );
 
       let bgCount = 0;
@@ -67,13 +74,20 @@ async function processImage(inputPath: string): Promise<void> {
       if (coverage < CV_PARAMS.LOW_COVERAGE_THRESHOLD) {
         console.log(`  Low coverage — subject exclusion + simple flood...`);
         const exclMask = subjectExclusion(
-          new Uint8ClampedArray(pixels), width, height,
-          bgInfo.colorA, bgInfo.colorB,
-          grid.gridSize, grid.phase
+          new Uint8ClampedArray(pixels),
+          width,
+          height,
+          bgInfo.colorA,
+          bgInfo.colorB,
+          grid.gridSize,
+          grid.phase,
         );
         const floodMask = simpleFloodFill(
-          new Uint8ClampedArray(pixels), width, height,
-          bgInfo.colorA, bgInfo.colorB
+          new Uint8ClampedArray(pixels),
+          width,
+          height,
+          bgInfo.colorA,
+          bgInfo.colorB,
         );
         bgMask = new Uint8Array(width * height);
         for (let i = 0; i < bgMask.length; i++) {
@@ -82,31 +96,43 @@ async function processImage(inputPath: string): Promise<void> {
       }
     } else {
       bgMask = simpleFloodFill(
-        new Uint8ClampedArray(pixels), width, height,
-        bgInfo.colorA, bgInfo.colorB
+        new Uint8ClampedArray(pixels),
+        width,
+        height,
+        bgInfo.colorA,
+        bgInfo.colorB,
       );
     }
   } else if (bgInfo.cornerVariance < CV_PARAMS.SOLID_BG_VARIANCE) {
     bgMask = simpleFloodFill(
-      new Uint8ClampedArray(pixels), width, height,
-      bgInfo.colorA, bgInfo.colorB
+      new Uint8ClampedArray(pixels),
+      width,
+      height,
+      bgInfo.colorA,
+      bgInfo.colorB,
     );
   } else {
     console.log(`  Complex background — would need ML`);
     bgMask = simpleFloodFill(
-      new Uint8ClampedArray(pixels), width, height,
-      bgInfo.colorA, bgInfo.colorB
+      new Uint8ClampedArray(pixels),
+      width,
+      height,
+      bgInfo.colorA,
+      bgInfo.colorB,
     );
   }
 
   let bgCount = 0;
   for (let i = 0; i < bgMask.length; i++) if (bgMask[i]) bgCount++;
-  console.log(`  BG after flood: ${(bgCount / (width * height) * 100).toFixed(1)}%`);
+  console.log(`  BG after flood: ${((bgCount / (width * height)) * 100).toFixed(1)}%`);
 
   // Step 3: Watermark
   const wmResult = watermarkDetect(
-    new Uint8ClampedArray(pixels), width, height,
-    bgInfo.colorA, bgInfo.colorB
+    new Uint8ClampedArray(pixels),
+    width,
+    height,
+    bgInfo.colorA,
+    bgInfo.colorB,
   );
   if (wmResult.detected && wmResult.mask) {
     const newMask = new Uint8Array(width * height);
@@ -120,10 +146,7 @@ async function processImage(inputPath: string): Promise<void> {
   }
 
   // Step 4: Shadow cleanup
-  bgMask = shadowCleanup(
-    new Uint8ClampedArray(pixels), width, height,
-    bgMask
-  );
+  bgMask = shadowCleanup(new Uint8ClampedArray(pixels), width, height, bgMask);
 
   // Step 5: Alpha refinement
   const alpha = alphaRefine(bgMask, width, height);
@@ -141,7 +164,7 @@ async function processImage(inputPath: string): Promise<void> {
 
   let transparent = 0;
   for (let i = 0; i < width * height; i++) if (alpha[i] === 0) transparent++;
-  console.log(`  Final: ${(transparent / (width * height) * 100).toFixed(1)}% transparent`);
+  console.log(`  Final: ${((transparent / (width * height)) * 100).toFixed(1)}% transparent`);
   console.log(`  Time: ${totalMs.toFixed(0)}ms`);
 
   // Save transparent PNG

--- a/src/components/ar-app.ts
+++ b/src/components/ar-app.ts
@@ -11,7 +11,12 @@ import type { ArDropzone } from './ar-dropzone';
 import type { ArBatchGrid } from './ar-batch-grid';
 import type { BatchItem, StageSnapshot } from '../types/batch';
 import { createZip, safeZipEntryName, downloadBlob } from '../utils/zip';
-import { refineEdges, dropOrphanBlobs, fillSubjectHoles, promoteSpeckleAlpha } from '../pipeline/finalize';
+import {
+  refineEdges,
+  dropOrphanBlobs,
+  fillSubjectHoles,
+  promoteSpeckleAlpha,
+} from '../pipeline/finalize';
 import { composeAtOriginal } from '../utils/final-composite';
 import { exportPng } from '../utils/image-io';
 import type { ArEditorAdvanced } from './ar-editor-advanced';
@@ -78,7 +83,7 @@ export class ArApp extends HTMLElement {
         if (!m) return;
         const pct = Math.min(100, Math.max(0, parseInt(m[1], 10)));
         this.dropzone.setLoadingState({ visible: true, pct, label: message });
-      }
+      },
     );
 
     const el = statusEl();
@@ -102,42 +107,46 @@ export class ArApp extends HTMLElement {
       this.dropzone.setLoadingState({ visible: false, ready });
     };
 
-    this.pipeline.preloadModel(ArApp.MODEL_ID).then(() => {
-      finish(true);
-      const s = statusEl();
-      if (s) {
-        (s as HTMLElement).dataset.state = 'ready';
-        s.textContent = t('hero.modelStatus');
-        s.classList.add('ready');
-      }
-      const r = this.shadowRoot?.querySelector('#status-reactor') as HTMLElement | null;
-      if (r) {
-        r.dataset.state = 'online';
-        r.textContent = t('status.reactor.online');
-      }
-      this.dropzone.setEnabled(true);
-    }).catch((err: unknown) => {
-      finish(false);
-      console.error('[NukeBG] Model preload failed, falling back to lazy load:', err);
-      const s = statusEl();
-      if (s) {
-        (s as HTMLElement).dataset.state = 'lazy';
-        s.textContent = t('status.model.lazy');
-      }
-      // Reactor stays "offline" — preload didn't resolve. The lazy-load
-      // path will flip it once the first real process() succeeds; until
-      // then the user sees an honest "reactor idle" state.
-      this.dropzone.setEnabled(true);
-    });
+    this.pipeline
+      .preloadModel(ArApp.MODEL_ID)
+      .then(() => {
+        finish(true);
+        const s = statusEl();
+        if (s) {
+          (s as HTMLElement).dataset.state = 'ready';
+          s.textContent = t('hero.modelStatus');
+          s.classList.add('ready');
+        }
+        const r = this.shadowRoot?.querySelector('#status-reactor') as HTMLElement | null;
+        if (r) {
+          r.dataset.state = 'online';
+          r.textContent = t('status.reactor.online');
+        }
+        this.dropzone.setEnabled(true);
+      })
+      .catch((err: unknown) => {
+        finish(false);
+        console.error('[NukeBG] Model preload failed, falling back to lazy load:', err);
+        const s = statusEl();
+        if (s) {
+          (s as HTMLElement).dataset.state = 'lazy';
+          s.textContent = t('status.model.lazy');
+        }
+        // Reactor stays "offline" — preload didn't resolve. The lazy-load
+        // path will flip it once the first real process() succeeds; until
+        // then the user sees an honest "reactor idle" state.
+        this.dropzone.setEnabled(true);
+      });
   }
 
   disconnectedCallback(): void {
-    if (this.boundLocaleHandler) document.removeEventListener('nukebg:locale-changed', this.boundLocaleHandler);
-    if (this.boundPwaInstallableHandler) document.removeEventListener('nukebg:pwa-installable', this.boundPwaInstallableHandler);
+    if (this.boundLocaleHandler)
+      document.removeEventListener('nukebg:locale-changed', this.boundLocaleHandler);
+    if (this.boundPwaInstallableHandler)
+      document.removeEventListener('nukebg:pwa-installable', this.boundPwaInstallableHandler);
     this.abortController?.abort();
     this.abortController = null;
   }
-
 
   private render(): void {
     this.shadowRoot!.innerHTML = `
@@ -1036,24 +1045,31 @@ export class ArApp extends HTMLElement {
   private updateTexts(): void {
     const root = this.shadowRoot!;
     const h1 = root.querySelector('h1');
-    if (h1) h1.innerHTML =
-      `<span class="hero-title-long"><span class="accent">${t('hero.title.accent')}</span> ${t('hero.title.rest')}</span>` +
-      `<span class="hero-title-short"><span class="accent">${t('hero.title.short')}</span></span>`;
+    if (h1)
+      h1.innerHTML =
+        `<span class="hero-title-long"><span class="accent">${t('hero.title.accent')}</span> ${t('hero.title.rest')}</span>` +
+        `<span class="hero-title-short"><span class="accent">${t('hero.title.short')}</span></span>`;
     const subline = root.querySelector('.subline');
-    if (subline) subline.innerHTML =
-      `<span class="subline-long">${t('hero.subtitle').replace(/\n/g, ' ')}</span>` +
-      `<span class="subline-short"># ${t('hero.subtitle.short')}</span>`;
+    if (subline)
+      subline.innerHTML =
+        `<span class="subline-long">${t('hero.subtitle').replace(/\n/g, ' ')}</span>` +
+        `<span class="subline-short"># ${t('hero.subtitle.short')}</span>`;
     const statusReactor = root.querySelector('#status-reactor');
     if (statusReactor) {
       const state = (statusReactor as HTMLElement).dataset.state ?? 'offline';
-      statusReactor.textContent = t(state === 'online' ? 'status.reactor.online' : 'status.reactor.offline');
+      statusReactor.textContent = t(
+        state === 'online' ? 'status.reactor.online' : 'status.reactor.offline',
+      );
     }
     const statusModel = root.querySelector('#status-model');
     if (statusModel) {
       const state = (statusModel as HTMLElement).dataset.state ?? 'loading';
-      const key = state === 'ready' ? 'hero.modelStatus'
-                : state === 'lazy' ? 'status.model.lazy'
-                : 'status.model.loading';
+      const key =
+        state === 'ready'
+          ? 'hero.modelStatus'
+          : state === 'lazy'
+            ? 'status.model.lazy'
+            : 'status.model.loading';
       statusModel.textContent = t(key);
     }
     const heroDisclaimer = root.querySelector('#hero-disclaimer');
@@ -1089,9 +1105,12 @@ export class ArApp extends HTMLElement {
     const cmdStateHost = root.querySelector('#cmd-state') as HTMLElement | null;
     if (cmdStateLabel && cmdStateHost) {
       const state = cmdStateHost.getAttribute('data-state') ?? 'running';
-      const key = state === 'running' ? 'cmdbar.running'
-                : state === 'ready' ? 'cmdbar.ready'
-                : 'cmdbar.failed';
+      const key =
+        state === 'running'
+          ? 'cmdbar.running'
+          : state === 'ready'
+            ? 'cmdbar.ready'
+            : 'cmdbar.failed';
       cmdStateLabel.textContent = t(key);
     }
   }
@@ -1125,16 +1144,22 @@ export class ArApp extends HTMLElement {
     // the shadow-root level so legacy listeners (progress component,
     // tests) still work.
     const bubbleCancel = (): void => {
-      this.dispatchEvent(new CustomEvent('ar:cancel-processing', { bubbles: true, composed: true }));
+      this.dispatchEvent(
+        new CustomEvent('ar:cancel-processing', { bubbles: true, composed: true }),
+      );
     };
-    this.shadowRoot!.addEventListener('ar:cancel-processing', () => {
-      if (this.processingAbortController && !this.processingAbortController.signal.aborted) {
-        this.processingAbortController.abort('user cancelled');
-      }
-      if (this.batchMode !== 'off') {
-        this.batchAborted = true;
-      }
-    }, { signal });
+    this.shadowRoot!.addEventListener(
+      'ar:cancel-processing',
+      () => {
+        if (this.processingAbortController && !this.processingAbortController.signal.aborted) {
+          this.processingAbortController.abort('user cancelled');
+        }
+        if (this.batchMode !== 'off') {
+          this.batchAborted = true;
+        }
+      },
+      { signal },
+    );
 
     const cmdCancel = this.shadowRoot!.querySelector('#cmd-cancel') as HTMLButtonElement | null;
     cmdCancel?.addEventListener('click', bubbleCancel, { signal });
@@ -1144,23 +1169,31 @@ export class ArApp extends HTMLElement {
     // GitHub issue URL with browser + session hints; reload is
     // handled by ar-progress itself (location.reload).
     this.progress.addEventListener('ar:stage-retry', () => this.retryFromError(), { signal });
-    this.progress.addEventListener('ar:stage-report', (ev) => {
-      const stage = (ev as CustomEvent<{ stage: string }>).detail.stage;
-      const ua = encodeURIComponent(navigator.userAgent);
-      const title = encodeURIComponent(`[stage:${stage}] pipeline error`);
-      const body = encodeURIComponent(
-        `**Stage:** \`${stage}\`\n**UA:** ${decodeURIComponent(ua)}\n**Locale:** ${document.documentElement.lang}\n\n<!-- what were you trying to do? drag the image that failed if possible -->`,
-      );
-      window.open(
-        `https://github.com/yocreoquesi/nukebg/issues/new?title=${title}&body=${body}`,
-        '_blank',
-        'noopener',
-      );
-    }, { signal });
+    this.progress.addEventListener(
+      'ar:stage-report',
+      (ev) => {
+        const stage = (ev as CustomEvent<{ stage: string }>).detail.stage;
+        const ua = encodeURIComponent(navigator.userAgent);
+        const title = encodeURIComponent(`[stage:${stage}] pipeline error`);
+        const body = encodeURIComponent(
+          `**Stage:** \`${stage}\`\n**UA:** ${decodeURIComponent(ua)}\n**Locale:** ${document.documentElement.lang}\n\n<!-- what were you trying to do? drag the image that failed if possible -->`,
+        );
+        window.open(
+          `https://github.com/yocreoquesi/nukebg/issues/new?title=${title}&body=${body}`,
+          '_blank',
+          'noopener',
+        );
+      },
+      { signal },
+    );
 
     // Error modal wiring (#36).
-    const retryBtn = this.shadowRoot!.querySelector('#error-modal-retry') as HTMLButtonElement | null;
-    const dismissBtn = this.shadowRoot!.querySelector('#error-modal-dismiss') as HTMLButtonElement | null;
+    const retryBtn = this.shadowRoot!.querySelector(
+      '#error-modal-retry',
+    ) as HTMLButtonElement | null;
+    const dismissBtn = this.shadowRoot!.querySelector(
+      '#error-modal-dismiss',
+    ) as HTMLButtonElement | null;
     const backdrop = this.shadowRoot!.querySelector('#error-modal-backdrop') as HTMLElement | null;
     retryBtn?.addEventListener('click', () => this.retryFromError());
     dismissBtn?.addEventListener('click', () => this.hideErrorModal());
@@ -1210,72 +1243,102 @@ export class ArApp extends HTMLElement {
       }, 2000);
     }
 
-    installBtn.addEventListener('click', async () => {
-      // If native prompt available (Chromium), use it
-      if (hasNativePrompt) {
-        const accepted = await installApp();
-        if (accepted) {
-          installBtn.textContent = t('pwa.installed');
-          installBtn.disabled = true;
-          installGuide.classList.remove('visible');
+    installBtn.addEventListener(
+      'click',
+      async () => {
+        // If native prompt available (Chromium), use it
+        if (hasNativePrompt) {
+          const accepted = await installApp();
+          if (accepted) {
+            installBtn.textContent = t('pwa.installed');
+            installBtn.disabled = true;
+            installGuide.classList.remove('visible');
+          }
+          return;
         }
-        return;
-      }
-      // Otherwise show browser-specific instructions
-      const guide = this.getInstallGuide();
-      installGuide.innerHTML = guide;
-      installGuide.classList.toggle('visible');
-      const closeBtn = installGuide.querySelector('.install-guide-close');
-      if (closeBtn) {
-        closeBtn.addEventListener('click', () => installGuide.classList.remove('visible'), { signal });
-      }
-    }, { signal });
+        // Otherwise show browser-specific instructions
+        const guide = this.getInstallGuide();
+        installGuide.innerHTML = guide;
+        installGuide.classList.toggle('visible');
+        const closeBtn = installGuide.querySelector('.install-guide-close');
+        if (closeBtn) {
+          closeBtn.addEventListener('click', () => installGuide.classList.remove('visible'), {
+            signal,
+          });
+        }
+      },
+      { signal },
+    );
 
-    this.shadowRoot!.addEventListener('ar:image-loaded', async (e: Event) => {
-      const detail = (e as CustomEvent).detail;
-      this.currentFileName = detail.file.name || 'image.png';
+    this.shadowRoot!.addEventListener(
+      'ar:image-loaded',
+      async (e: Event) => {
+        const detail = (e as CustomEvent).detail;
+        this.currentFileName = detail.file.name || 'image.png';
 
-      // If currently processing, abort the in-flight pipeline and reset
-      if (this.isProcessing) {
-        this.processingAborted = true;
-        this.isProcessing = false;
-        this.enableWorkspaceButtons();
-      }
+        // If currently processing, abort the in-flight pipeline and reset
+        if (this.isProcessing) {
+          this.processingAborted = true;
+          this.isProcessing = false;
+          this.enableWorkspaceButtons();
+        }
 
-      await this.processImage(detail.imageData, detail.originalImageData ?? detail.imageData, detail.file.size);
-    }, { signal });
+        await this.processImage(
+          detail.imageData,
+          detail.originalImageData ?? detail.imageData,
+          detail.file.size,
+        );
+      },
+      { signal },
+    );
 
-    this.shadowRoot!.addEventListener('ar:images-loaded', async (e: Event) => {
-      const detail = (e as CustomEvent).detail as {
-        images: Array<{
-          file: File;
-          imageData: ImageData;
-          originalImageData: ImageData;
-          originalWidth: number;
-          originalHeight: number;
-          wasDownsampled: boolean;
-        }>;
-      };
-      if (this.isProcessing) {
-        this.processingAborted = true;
-        this.isProcessing = false;
-        this.enableWorkspaceButtons();
-      }
-      await this.startBatch(detail.images);
-    }, { signal });
+    this.shadowRoot!.addEventListener(
+      'ar:images-loaded',
+      async (e: Event) => {
+        const detail = (e as CustomEvent).detail as {
+          images: Array<{
+            file: File;
+            imageData: ImageData;
+            originalImageData: ImageData;
+            originalWidth: number;
+            originalHeight: number;
+            wasDownsampled: boolean;
+          }>;
+        };
+        if (this.isProcessing) {
+          this.processingAborted = true;
+          this.isProcessing = false;
+          this.enableWorkspaceButtons();
+        }
+        await this.startBatch(detail.images);
+      },
+      { signal },
+    );
 
-    this.shadowRoot!.addEventListener('batch:item-click', (e: Event) => {
-      const detail = (e as CustomEvent).detail as { id: string; state: string };
-      this.openBatchDetail(detail.id);
-    }, { signal });
+    this.shadowRoot!.addEventListener(
+      'batch:item-click',
+      (e: Event) => {
+        const detail = (e as CustomEvent).detail as { id: string; state: string };
+        this.openBatchDetail(detail.id);
+      },
+      { signal },
+    );
 
-    this.shadowRoot!.addEventListener('batch:download-zip', async () => {
-      await this.downloadBatchZip();
-    }, { signal });
+    this.shadowRoot!.addEventListener(
+      'batch:download-zip',
+      async () => {
+        await this.downloadBatchZip();
+      },
+      { signal },
+    );
 
-    this.shadowRoot!.addEventListener('batch:cancel', () => {
-      this.resetToIdle();
-    }, { signal });
+    this.shadowRoot!.addEventListener(
+      'batch:cancel',
+      () => {
+        this.resetToIdle();
+      },
+      { signal },
+    );
 
     const backBtn = this.shadowRoot!.querySelector('#back-to-grid-btn');
     if (backBtn) {
@@ -1290,124 +1353,150 @@ export class ArApp extends HTMLElement {
       discardBtn.addEventListener('click', () => this.discardBatchItem(), { signal });
     }
 
-    this.shadowRoot!.addEventListener('ar:process-another', () => {
-      this.resetToIdle();
-    }, { signal });
+    this.shadowRoot!.addEventListener(
+      'ar:process-another',
+      () => {
+        this.resetToIdle();
+      },
+      { signal },
+    );
 
     // Disclaimer click - toggle limitations detail
     // Limitations now live inside <details id="status-limits"> — native
     // disclosure widget handles open/close. No click wiring needed.
 
     // Edit button - opens editor or discards edits
-    this.shadowRoot!.querySelector('#edit-btn')?.addEventListener('click', async () => {
-      if (!this.lastResultImageData) return;
+    this.shadowRoot!.querySelector('#edit-btn')?.addEventListener(
+      'click',
+      async () => {
+        if (!this.lastResultImageData) return;
 
-      if (this.preEditResult) {
-        // Discard mode: restore pre-edit result, cache edit for instant re-apply
-        this.cachedEditResult = this.lastResultImageData;
-        this.lastResultImageData = this.preEditResult;
-        this.preEditResult = null;
+        if (this.preEditResult) {
+          // Discard mode: restore pre-edit result, cache edit for instant re-apply
+          this.cachedEditResult = this.lastResultImageData;
+          this.lastResultImageData = this.preEditResult;
+          this.preEditResult = null;
 
-        const blob = await exportPng(this.lastResultImageData);
-        const originalForViewer = this.currentOriginalImageData ?? this.currentImageData;
-        if (originalForViewer) this.viewer.setOriginal(originalForViewer, this.currentFileSize);
-        this.viewer.setResult(this.lastResultImageData, blob);
-        await this.download.setResult(this.lastResultImageData, this.currentFileName, 0, blob);
+          const blob = await exportPng(this.lastResultImageData);
+          const originalForViewer = this.currentOriginalImageData ?? this.currentImageData;
+          if (originalForViewer) this.viewer.setOriginal(originalForViewer, this.currentFileSize);
+          this.viewer.setResult(this.lastResultImageData, blob);
+          await this.download.setResult(this.lastResultImageData, this.currentFileName, 0, blob);
 
-        // Switch button back to "Edit manually"
-        const editBtn = this.shadowRoot!.querySelector('#edit-btn') as HTMLElement;
-        if (editBtn) editBtn.textContent = t('edit.btn');
-      } else {
-        // Edit mode: open editor, pass cached edit result for instant toggle if available
-        const editorSection = this.shadowRoot!.querySelector('#editor-section') as HTMLElement;
-        editorSection.style.display = 'block';
-        this.editor.setImage(
-          this.cachedEditResult ?? this.lastResultImageData,
-          (this.currentOriginalImageData ?? this.currentImageData)!,
-        );
-        this.cachedEditResult = null;
-        (this.shadowRoot!.querySelector('#edit-btn') as HTMLElement).style.display = 'none';
-      }
-    }, { signal });
-
-
+          // Switch button back to "Edit manually"
+          const editBtn = this.shadowRoot!.querySelector('#edit-btn') as HTMLElement;
+          if (editBtn) editBtn.textContent = t('edit.btn');
+        } else {
+          // Edit mode: open editor, pass cached edit result for instant toggle if available
+          const editorSection = this.shadowRoot!.querySelector('#editor-section') as HTMLElement;
+          editorSection.style.display = 'block';
+          this.editor.setImage(
+            this.cachedEditResult ?? this.lastResultImageData,
+            (this.currentOriginalImageData ?? this.currentImageData)!,
+          );
+          this.cachedEditResult = null;
+          (this.shadowRoot!.querySelector('#edit-btn') as HTMLElement).style.display = 'none';
+        }
+      },
+      { signal },
+    );
 
     // Editor cancel - discard edits, close editor
-    this.shadowRoot!.addEventListener('ar:editor-cancel', () => {
-      (this.shadowRoot!.querySelector('#editor-section') as HTMLElement).style.display = 'none';
-      (this.shadowRoot!.querySelector('#edit-btn') as HTMLElement).style.display = 'block';
-    }, { signal });
+    this.shadowRoot!.addEventListener(
+      'ar:editor-cancel',
+      () => {
+        (this.shadowRoot!.querySelector('#editor-section') as HTMLElement).style.display = 'none';
+        (this.shadowRoot!.querySelector('#edit-btn') as HTMLElement).style.display = 'block';
+      },
+      { signal },
+    );
 
     // Editor done - update viewer and download with edited result
-    this.shadowRoot!.addEventListener('ar:editor-done', async (e: Event) => {
-      const rawEdited = (e as CustomEvent).detail.imageData as ImageData;
-      // Refine: foreground decontamination + quintic alpha sharpening so manual
-      // brush strokes inherit the same studio-quality edge as the main pipeline.
-      // Topology cleanup is skipped — keepLargestComponent would discard manual
-      // restores that don't connect to the main subject body.
-      const editedData = await refineEdges(this.pipeline, rawEdited, {
-        skipTopologyCleanup: true,
-      });
-      const blob = await exportPng(editedData);
+    this.shadowRoot!.addEventListener(
+      'ar:editor-done',
+      async (e: Event) => {
+        const rawEdited = (e as CustomEvent).detail.imageData as ImageData;
+        // Refine: foreground decontamination + quintic alpha sharpening so manual
+        // brush strokes inherit the same studio-quality edge as the main pipeline.
+        // Topology cleanup is skipped — keepLargestComponent would discard manual
+        // restores that don't connect to the main subject body.
+        const editedData = await refineEdges(this.pipeline, rawEdited, {
+          skipTopologyCleanup: true,
+        });
+        const blob = await exportPng(editedData);
 
-      // Save pre-edit for discard functionality
-      this.preEditResult = this.lastResultImageData;
-      this.cachedEditResult = editedData;
-      this.lastResultImageData = editedData;
+        // Save pre-edit for discard functionality
+        this.preEditResult = this.lastResultImageData;
+        this.cachedEditResult = editedData;
+        this.lastResultImageData = editedData;
 
-      // "Before" stays as the original input image; only "after" updates
-      this.viewer.setResult(editedData, blob);
-      await this.download.setResult(editedData, this.currentFileName, 0, blob);
+        // "Before" stays as the original input image; only "after" updates
+        this.viewer.setResult(editedData, blob);
+        await this.download.setResult(editedData, this.currentFileName, 0, blob);
 
-      // Hide editor, show discard button
-      (this.shadowRoot!.querySelector('#editor-section') as HTMLElement).style.display = 'none';
-      const editBtn = this.shadowRoot!.querySelector('#edit-btn') as HTMLElement;
-      editBtn.style.display = 'block';
-      editBtn.textContent = t('edit.discard');
-    }, { signal });
+        // Hide editor, show discard button
+        (this.shadowRoot!.querySelector('#editor-section') as HTMLElement).style.display = 'none';
+        const editBtn = this.shadowRoot!.querySelector('#edit-btn') as HTMLElement;
+        editBtn.style.display = 'block';
+        editBtn.textContent = t('edit.discard');
+      },
+      { signal },
+    );
 
     // Advanced editor CTA toggle
-    this.shadowRoot!.querySelector('#advanced-cta')?.addEventListener('click', () => {
-      const adv = this.shadowRoot!.querySelector('#editor-advanced') as ArEditorAdvanced | null;
-      const btn = this.shadowRoot!.querySelector('#advanced-cta') as HTMLElement | null;
-      if (!adv || !btn) return;
-      const isOpen = adv.hasAttribute('active');
-      if (isOpen) {
-        adv.removeAttribute('active');
-        btn.removeAttribute('data-active');
-        return;
-      }
-      const current = this.lastResultImageData ?? this.currentImageData;
-      const original = this.currentOriginalImageData ?? this.currentImageData;
-      if (!current || !original) return;
-      adv.setImage(current, original);
-      adv.setAttribute('active', '');
-      btn.setAttribute('data-active', 'true');
-      adv.scrollIntoView({ behavior: 'smooth', block: 'center' });
-    }, { signal });
+    this.shadowRoot!.querySelector('#advanced-cta')?.addEventListener(
+      'click',
+      () => {
+        const adv = this.shadowRoot!.querySelector('#editor-advanced') as ArEditorAdvanced | null;
+        const btn = this.shadowRoot!.querySelector('#advanced-cta') as HTMLElement | null;
+        if (!adv || !btn) return;
+        const isOpen = adv.hasAttribute('active');
+        if (isOpen) {
+          adv.removeAttribute('active');
+          btn.removeAttribute('data-active');
+          return;
+        }
+        const current = this.lastResultImageData ?? this.currentImageData;
+        const original = this.currentOriginalImageData ?? this.currentImageData;
+        if (!current || !original) return;
+        adv.setImage(current, original);
+        adv.setAttribute('active', '');
+        btn.setAttribute('data-active', 'true');
+        adv.scrollIntoView({ behavior: 'smooth', block: 'center' });
+      },
+      { signal },
+    );
 
     // Advanced editor — cancel
-    this.shadowRoot!.addEventListener('ar:advanced-cancel', () => {
-      const btn = this.shadowRoot!.querySelector('#advanced-cta') as HTMLElement | null;
-      btn?.removeAttribute('data-active');
-    }, { signal });
+    this.shadowRoot!.addEventListener(
+      'ar:advanced-cancel',
+      () => {
+        const btn = this.shadowRoot!.querySelector('#advanced-cta') as HTMLElement | null;
+        btn?.removeAttribute('data-active');
+      },
+      { signal },
+    );
 
     // Advanced editor — done
-    this.shadowRoot!.addEventListener('ar:advanced-done', async (e: Event) => {
-      const detail = (e as CustomEvent<{ imageData: ImageData }>).detail;
-      const btn = this.shadowRoot!.querySelector('#advanced-cta') as HTMLElement | null;
-      btn?.removeAttribute('data-active');
+    this.shadowRoot!.addEventListener(
+      'ar:advanced-done',
+      async (e: Event) => {
+        const detail = (e as CustomEvent<{ imageData: ImageData }>).detail;
+        const btn = this.shadowRoot!.querySelector('#advanced-cta') as HTMLElement | null;
+        btn?.removeAttribute('data-active');
 
-      // Same reasoning as the basic editor: skip topology cleanup so the
-      // user's lasso crops / restores survive the refinement pass.
-      const refined = await refineEdges(this.pipeline, detail.imageData, {
-        skipTopologyCleanup: true,
-      });
-      const blob = await exportPng(refined);
-      this.viewer.setResult(refined, blob);
-      await this.download.setResult(refined, this.currentFileName, 0, blob);
-      this.lastResultImageData = refined;
-    }, { signal });
+        // Same reasoning as the basic editor: skip topology cleanup so the
+        // user's lasso crops / restores survive the refinement pass.
+        const refined = await refineEdges(this.pipeline, detail.imageData, {
+          skipTopologyCleanup: true,
+        });
+        const blob = await exportPng(refined);
+        this.viewer.setResult(refined, blob);
+        await this.download.setResult(refined, this.currentFileName, 0, blob);
+        this.lastResultImageData = refined;
+      },
+      { signal },
+    );
   }
 
   // Advanced CTA replaces the edit-btn when visible.
@@ -1461,7 +1550,11 @@ export class ArApp extends HTMLElement {
     }
   }
 
-  private async processImage(imageData: ImageData, originalImageData: ImageData, fileSize: number): Promise<void> {
+  private async processImage(
+    imageData: ImageData,
+    originalImageData: ImageData,
+    fileSize: number,
+  ): Promise<void> {
     // If a previous run is still going, hard-abort it so workers stop
     // immediately. Dropping a new image always wins over the previous one.
     if (this.processingAbortController && !this.processingAbortController.signal.aborted) {
@@ -1505,19 +1598,22 @@ export class ArApp extends HTMLElement {
       this.pipeline = new PipelineOrchestrator(
         (stage: PipelineStage, status: StageStatus, message?: string) => {
           this.progress.setStage(stage, status, message);
-        }
+        },
       );
     } else {
       // Update the callback to point to current progress component
       this.pipeline.setStageCallback(
         (stage: PipelineStage, status: StageStatus, message?: string) => {
           this.progress.setStage(stage, status, message);
-        }
+        },
       );
     }
 
     try {
-      if (originalImageData.width !== imageData.width || originalImageData.height !== imageData.height) {
+      if (
+        originalImageData.width !== imageData.width ||
+        originalImageData.height !== imageData.height
+      ) {
         const msg = t('progress.downscaled', {
           w: String(imageData.width),
           h: String(imageData.height),
@@ -1624,9 +1720,7 @@ export class ArApp extends HTMLElement {
     if (fn) fn.textContent = payload.filename;
     const meta = root.querySelector('#cmd-meta');
     if (meta) {
-      const kb = payload.sizeBytes > 0
-        ? ` · ${this.formatBytes(payload.sizeBytes)}`
-        : '';
+      const kb = payload.sizeBytes > 0 ? ` · ${this.formatBytes(payload.sizeBytes)}` : '';
       meta.textContent = ` · ${payload.width}×${payload.height}${kb}`;
     }
     this.updateCommandBarState(payload.state);
@@ -1640,9 +1734,8 @@ export class ArApp extends HTMLElement {
     if (!stateEl || !label || !cancelBtn) return;
     stateEl.hidden = false;
     stateEl.setAttribute('data-state', state);
-    const key = state === 'running' ? 'cmdbar.running'
-              : state === 'ready' ? 'cmdbar.ready'
-              : 'cmdbar.failed';
+    const key =
+      state === 'running' ? 'cmdbar.running' : state === 'ready' ? 'cmdbar.ready' : 'cmdbar.failed';
     label.textContent = t(key);
     cancelBtn.hidden = state !== 'running';
   }
@@ -1663,7 +1756,9 @@ export class ArApp extends HTMLElement {
   private showErrorModal(msg: string): void {
     const modal = this.shadowRoot?.querySelector('#error-modal') as HTMLElement | null;
     const messageEl = this.shadowRoot?.querySelector('#error-modal-message');
-    const retryBtn = this.shadowRoot?.querySelector('#error-modal-retry') as HTMLButtonElement | null;
+    const retryBtn = this.shadowRoot?.querySelector(
+      '#error-modal-retry',
+    ) as HTMLButtonElement | null;
     if (!modal || !messageEl) return;
     messageEl.textContent = msg;
     const canRetry = !!(this.currentImageData && this.currentOriginalImageData);
@@ -1672,7 +1767,10 @@ export class ArApp extends HTMLElement {
     // Shift focus to the primary action so keyboard users can act
     // without hunting for the dialog.
     queueMicrotask(() => {
-      (canRetry ? retryBtn : (this.shadowRoot?.querySelector('#error-modal-dismiss') as HTMLElement | null))?.focus();
+      (canRetry
+        ? retryBtn
+        : (this.shadowRoot?.querySelector('#error-modal-dismiss') as HTMLElement | null)
+      )?.focus();
     });
   }
 
@@ -1689,11 +1787,7 @@ export class ArApp extends HTMLElement {
     this.hideErrorModal();
     // Re-run processing with the same inputs. processImage() already
     // handles the state reset (progress, viewer, abort controller, etc).
-    this.processImage(
-      this.currentImageData,
-      this.currentOriginalImageData,
-      this.currentFileSize,
-    );
+    this.processImage(this.currentImageData, this.currentOriginalImageData, this.currentFileSize);
   }
 
   private makeThumbnail(imageData: ImageData, maxSide = 200): string {
@@ -1746,14 +1840,16 @@ export class ArApp extends HTMLElement {
     this.batchMode = mode;
   }
 
-  private async startBatch(images: Array<{
-    file: File;
-    imageData: ImageData;
-    originalImageData: ImageData;
-    originalWidth: number;
-    originalHeight: number;
-    wasDownsampled: boolean;
-  }>): Promise<void> {
+  private async startBatch(
+    images: Array<{
+      file: File;
+      imageData: ImageData;
+      originalImageData: ImageData;
+      originalWidth: number;
+      originalHeight: number;
+      wasDownsampled: boolean;
+    }>,
+  ): Promise<void> {
     this.batchAborted = false;
     this.batchItems = images.map((img, i) => ({
       id: `batch-${Date.now()}-${i}`,
@@ -1780,7 +1876,11 @@ export class ArApp extends HTMLElement {
     // event into the item being processed so we can replay the exact
     // sequence (running → done / skipped / error) if the user reopens
     // that item's detail later.
-    const batchStageCallback = (stage: PipelineStage, status: StageStatus, message?: string): void => {
+    const batchStageCallback = (
+      stage: PipelineStage,
+      status: StageStatus,
+      message?: string,
+    ): void => {
       this.progress.setStage(stage, status, message);
       const current = this.batchCurrentProcessingItem;
       if (current) current.stageHistory.push({ stage, status, message });
@@ -1873,7 +1973,7 @@ export class ArApp extends HTMLElement {
   }
 
   private async openBatchDetail(id: string): Promise<void> {
-    const item = this.batchItems.find(i => i.id === id);
+    const item = this.batchItems.find((i) => i.id === id);
     if (!item) return;
     this.batchDetailId = id;
 
@@ -1995,7 +2095,7 @@ export class ArApp extends HTMLElement {
 
   private async retryBatchItem(): Promise<void> {
     if (!this.batchDetailId) return;
-    const item = this.batchItems.find(i => i.id === this.batchDetailId);
+    const item = this.batchItems.find((i) => i.id === this.batchDetailId);
     if (!item) return;
     item.state = 'pending';
     item.errorMessage = undefined;
@@ -2007,7 +2107,7 @@ export class ArApp extends HTMLElement {
 
   private discardBatchItem(): void {
     if (!this.batchDetailId) return;
-    const item = this.batchItems.find(i => i.id === this.batchDetailId);
+    const item = this.batchItems.find((i) => i.id === this.batchDetailId);
     if (!item) return;
     item.state = 'discarded';
     if (this.batchGrid) this.batchGrid.updateItem(item.id, 'discarded');
@@ -2015,7 +2115,7 @@ export class ArApp extends HTMLElement {
   }
 
   private async downloadBatchZip(): Promise<void> {
-    const done = this.batchItems.filter(i => i.state === 'done' && i.result);
+    const done = this.batchItems.filter((i) => i.state === 'done' && i.result);
     if (done.length === 0) return;
     const files = await Promise.all(
       done.map(async (item, idx) => ({

--- a/src/components/ar-batch-grid.ts
+++ b/src/components/ar-batch-grid.ts
@@ -38,7 +38,7 @@ export class ArBatchGrid extends HTMLElement {
   }
 
   updateItem(id: string, state: BatchItemState, thumbnailUrl?: string | null): void {
-    const item = this.items.find(i => i.id === id);
+    const item = this.items.find((i) => i.id === id);
     if (item) {
       item.state = state;
       if (thumbnailUrl !== undefined) item.thumbnailUrl = thumbnailUrl;
@@ -133,17 +133,21 @@ export class ArBatchGrid extends HTMLElement {
     `;
 
     this.shadowRoot!.querySelector('#zip-btn')!.addEventListener('click', () => {
-      this.dispatchEvent(new CustomEvent('batch:download-zip', {
-        bubbles: true,
-        composed: true,
-      }));
+      this.dispatchEvent(
+        new CustomEvent('batch:download-zip', {
+          bubbles: true,
+          composed: true,
+        }),
+      );
     });
 
     this.shadowRoot!.querySelector('#cancel-btn')!.addEventListener('click', () => {
-      this.dispatchEvent(new CustomEvent('batch:cancel', {
-        bubbles: true,
-        composed: true,
-      }));
+      this.dispatchEvent(
+        new CustomEvent('batch:cancel', {
+          bubbles: true,
+          composed: true,
+        }),
+      );
     });
   }
 
@@ -165,9 +169,9 @@ export class ArBatchGrid extends HTMLElement {
     const header = this.shadowRoot!.querySelector('#header') as HTMLElement;
     const zipBtn = this.shadowRoot!.querySelector('#zip-btn') as HTMLButtonElement;
 
-    const done = this.items.filter(i => i.state === 'done').length;
-    const failed = this.items.filter(i => i.state === 'failed').length;
-    const processing = this.items.some(i => i.state === 'processing');
+    const done = this.items.filter((i) => i.state === 'done').length;
+    const failed = this.items.filter((i) => i.state === 'failed').length;
+    const processing = this.items.some((i) => i.state === 'processing');
     const total = this.items.length;
 
     if (processing) {

--- a/src/components/ar-batch-item.ts
+++ b/src/components/ar-batch-item.ts
@@ -25,22 +25,26 @@ export class ArBatchItem extends HTMLElement {
       // Pending slots are non-interactive. Processing IS clickable so the
       // user can open the live progress console for the current item.
       if (this.itemState === 'pending') return;
-      this.dispatchEvent(new CustomEvent('batch:item-click', {
-        bubbles: true,
-        composed: true,
-        detail: { id: this.itemId, state: this.itemState },
-      }));
+      this.dispatchEvent(
+        new CustomEvent('batch:item-click', {
+          bubbles: true,
+          composed: true,
+          detail: { id: this.itemId, state: this.itemState },
+        }),
+      );
     });
     this.shadowRoot!.addEventListener('keydown', (e) => {
       const ke = e as KeyboardEvent;
       if (ke.key !== 'Enter' && ke.key !== ' ') return;
       if (this.itemState === 'pending') return;
       ke.preventDefault();
-      this.dispatchEvent(new CustomEvent('batch:item-click', {
-        bubbles: true,
-        composed: true,
-        detail: { id: this.itemId, state: this.itemState },
-      }));
+      this.dispatchEvent(
+        new CustomEvent('batch:item-click', {
+          bubbles: true,
+          composed: true,
+          detail: { id: this.itemId, state: this.itemState },
+        }),
+      );
     });
     this.boundLocaleHandler = () => this.updateView();
     document.addEventListener('nukebg:locale-changed', this.boundLocaleHandler);
@@ -53,7 +57,12 @@ export class ArBatchItem extends HTMLElement {
     }
   }
 
-  setItem(id: string, originalName: string, thumbnailUrl: string | null, state: BatchItemState): void {
+  setItem(
+    id: string,
+    originalName: string,
+    thumbnailUrl: string | null,
+    state: BatchItemState,
+  ): void {
     this.itemId = id;
     this.originalName = originalName;
     this.thumbnailUrl = thumbnailUrl;
@@ -185,9 +194,7 @@ export class ArBatchItem extends HTMLElement {
     const root = this.shadowRoot;
     this.setAttribute('data-state', this.itemState);
     const clickable =
-      this.itemState === 'done' ||
-      this.itemState === 'failed' ||
-      this.itemState === 'processing';
+      this.itemState === 'done' || this.itemState === 'failed' || this.itemState === 'processing';
     this.setAttribute('data-clickable', clickable ? 'true' : 'false');
 
     const img = root.querySelector('.thumb') as HTMLImageElement | null;

--- a/src/components/ar-download.ts
+++ b/src/components/ar-download.ts
@@ -29,7 +29,8 @@ export class ArDownload extends HTMLElement {
   private updateTexts(): void {
     const root = this.shadowRoot!;
     const copyBtn = root.querySelector('#copy-btn');
-    if (copyBtn && !copyBtn.classList.contains('copied')) copyBtn.innerHTML = `${t('download.copy')}<br><small>PNG</small>`;
+    if (copyBtn && !copyBtn.classList.contains('copied'))
+      copyBtn.innerHTML = `${t('download.copy')}<br><small>PNG</small>`;
     const anotherBtn = root.querySelector('#another-btn');
     if (anotherBtn) anotherBtn.textContent = t('download.another');
     this.updateCtaLabels();
@@ -46,10 +47,16 @@ export class ArDownload extends HTMLElement {
   disconnectedCallback(): void {
     if (this.pngBlobUrl) URL.revokeObjectURL(this.pngBlobUrl);
     if (this.webpBlobUrl) URL.revokeObjectURL(this.webpBlobUrl);
-    if (this.boundLocaleHandler) document.removeEventListener('nukebg:locale-changed', this.boundLocaleHandler);
+    if (this.boundLocaleHandler)
+      document.removeEventListener('nukebg:locale-changed', this.boundLocaleHandler);
   }
 
-  async setResult(imageData: ImageData, inputFilename: string, _totalTimeMs: number, blob?: Blob): Promise<void> {
+  async setResult(
+    imageData: ImageData,
+    inputFilename: string,
+    _totalTimeMs: number,
+    blob?: Blob,
+  ): Promise<void> {
     this.currentImageData = imageData;
     this.selectedFormat = 'png';
     this.pngFilename = generateOutputFilename(inputFilename, 'png', getLocale());
@@ -329,9 +336,7 @@ export class ArDownload extends HTMLElement {
         this.pngBlob = pngBlob;
       }
       try {
-        await navigator.clipboard.write([
-          new ClipboardItem({ 'image/png': pngBlob }),
-        ]);
+        await navigator.clipboard.write([new ClipboardItem({ 'image/png': pngBlob })]);
         const btn = this.shadowRoot!.querySelector('#copy-btn')!;
         btn.classList.add('copied');
         btn.innerHTML = `${t('download.copied')}<br><small>PNG</small>`;
@@ -397,8 +402,14 @@ export class ArDownload extends HTMLElement {
   reset(): void {
     const bar = this.shadowRoot!.querySelector('#bar');
     if (bar) bar.classList.remove('visible');
-    if (this.pngBlobUrl) { URL.revokeObjectURL(this.pngBlobUrl); this.pngBlobUrl = null; }
-    if (this.webpBlobUrl) { URL.revokeObjectURL(this.webpBlobUrl); this.webpBlobUrl = null; }
+    if (this.pngBlobUrl) {
+      URL.revokeObjectURL(this.pngBlobUrl);
+      this.pngBlobUrl = null;
+    }
+    if (this.webpBlobUrl) {
+      URL.revokeObjectURL(this.webpBlobUrl);
+      this.webpBlobUrl = null;
+    }
     this.pngBlob = null;
     this.webpBlob = null;
     this.currentImageData = null;
@@ -406,8 +417,14 @@ export class ArDownload extends HTMLElement {
     const root = this.shadowRoot!;
     const png = root.querySelector('#dl-png') as HTMLAnchorElement | null;
     const webp = root.querySelector('#dl-webp') as HTMLAnchorElement | null;
-    if (png) { png.hidden = true; png.removeAttribute('href'); }
-    if (webp) { webp.hidden = true; webp.removeAttribute('href'); }
+    if (png) {
+      png.hidden = true;
+      png.removeAttribute('href');
+    }
+    if (webp) {
+      webp.hidden = true;
+      webp.removeAttribute('href');
+    }
   }
 }
 

--- a/src/components/ar-dropzone.ts
+++ b/src/components/ar-dropzone.ts
@@ -376,7 +376,8 @@ export class ArDropzone extends HTMLElement {
   }
 
   disconnectedCallback(): void {
-    if (this.boundLocaleHandler) document.removeEventListener('nukebg:locale-changed', this.boundLocaleHandler);
+    if (this.boundLocaleHandler)
+      document.removeEventListener('nukebg:locale-changed', this.boundLocaleHandler);
     if (this.boundPasteHandler) document.removeEventListener('paste', this.boundPasteHandler);
   }
 
@@ -401,7 +402,12 @@ export class ArDropzone extends HTMLElement {
    *   then hide after a short delay so the user sees completion
    * - `{ visible: false }` → hide immediately (error/abort fallback)
    */
-  setLoadingState(state: { visible: boolean; pct?: number; label?: string; ready?: boolean }): void {
+  setLoadingState(state: {
+    visible: boolean;
+    pct?: number;
+    label?: string;
+    ready?: boolean;
+  }): void {
     const root = this.shadowRoot;
     if (!root) return;
     const slot = root.getElementById('dz-loading') as HTMLElement | null;
@@ -440,18 +446,20 @@ export class ArDropzone extends HTMLElement {
 
     try {
       const result = await loadImage(file);
-      this.dispatchEvent(new CustomEvent('ar:image-loaded', {
-        bubbles: true,
-        composed: true,
-        detail: {
-          file,
-          imageData: result.imageData,
-          originalImageData: result.originalImageData,
-          originalWidth: result.originalWidth,
-          originalHeight: result.originalHeight,
-          wasDownsampled: result.wasDownsampled,
-        },
-      }));
+      this.dispatchEvent(
+        new CustomEvent('ar:image-loaded', {
+          bubbles: true,
+          composed: true,
+          detail: {
+            file,
+            imageData: result.imageData,
+            originalImageData: result.originalImageData,
+            originalWidth: result.originalWidth,
+            originalHeight: result.originalHeight,
+            wasDownsampled: result.wasDownsampled,
+          },
+        }),
+      );
     } catch (err) {
       const msg = err instanceof Error ? err.message : 'Failed to load image.';
       this.showError(msg);
@@ -519,11 +527,13 @@ export class ArDropzone extends HTMLElement {
       this.showError(t('batch.limitExceeded', { limit: String(limit) }));
     }
 
-    this.dispatchEvent(new CustomEvent('ar:images-loaded', {
-      bubbles: true,
-      composed: true,
-      detail: { images: loaded },
-    }));
+    this.dispatchEvent(
+      new CustomEvent('ar:images-loaded', {
+        bubbles: true,
+        composed: true,
+        detail: { images: loaded },
+      }),
+    );
   }
 
   private showError(message?: string): void {

--- a/src/components/ar-editor-advanced.ts
+++ b/src/components/ar-editor-advanced.ts
@@ -257,7 +257,15 @@ export class ArEditorAdvanced extends HTMLElement {
     const shadow = this.shadowRoot;
     if (!shadow) return;
 
-    const ids = ['tool-brush', 'tool-eraser', 'tool-lasso', 'restore-original', 'reprocess', 'cancel', 'done'];
+    const ids = [
+      'tool-brush',
+      'tool-eraser',
+      'tool-lasso',
+      'restore-original',
+      'reprocess',
+      'cancel',
+      'done',
+    ];
     for (const id of ids) {
       const el = shadow.getElementById(id) as HTMLButtonElement | null;
       if (el) el.disabled = this.busy;
@@ -1667,9 +1675,7 @@ export class ArEditorAdvanced extends HTMLElement {
    * working buffer is NOT modified — the display renders a red/green tint
    * overlay so the user can confirm or cancel before the action is committed.
    */
-  private async previewAction(
-    kind: Exclude<LassoAction, 'remove-watermark'>,
-  ): Promise<void> {
+  private async previewAction(kind: Exclude<LassoAction, 'remove-watermark'>): Promise<void> {
     // 'remove-watermark' has its own handler (removeWatermarkInLasso) that
     // skips the preview/confirm pattern — inpainting is non-destructive
     // and any mistake is one Ctrl+Z away.

--- a/src/components/ar-editor.ts
+++ b/src/components/ar-editor.ts
@@ -25,9 +25,7 @@ function makeBrushCursor(
   const raw = size * zoom;
   // Defensive: Number.isFinite guards against NaN from upstream state bugs.
   // Math.round(NaN) → NaN, which poisons min/max and produces a NaN-sized SVG.
-  const displaySize = Number.isFinite(raw)
-    ? Math.min(64, Math.max(8, Math.round(raw)))
-    : 32;
+  const displaySize = Number.isFinite(raw) ? Math.min(64, Math.max(8, Math.round(raw))) : 32;
   const r = displaySize / 2;
   const svgSize = displaySize + 2; // 1px padding
   const center = svgSize / 2;
@@ -50,8 +48,8 @@ function makeBrushCursor(
   }
 
   // Crosshair at center
-  const cross = `<line x1="${center}" y1="${center-3}" x2="${center}" y2="${center+3}" stroke="${stroke}" stroke-width="0.8" opacity="0.7"/>
-                 <line x1="${center-3}" y1="${center}" x2="${center+3}" y2="${center}" stroke="${stroke}" stroke-width="0.8" opacity="0.7"/>`;
+  const cross = `<line x1="${center}" y1="${center - 3}" x2="${center}" y2="${center + 3}" stroke="${stroke}" stroke-width="0.8" opacity="0.7"/>
+                 <line x1="${center - 3}" y1="${center}" x2="${center + 3}" y2="${center}" stroke="${stroke}" stroke-width="0.8" opacity="0.7"/>`;
 
   const svg = `<svg xmlns="http://www.w3.org/2000/svg" width="${svgSize}" height="${svgSize}">${shapeEl}${cross}</svg>`;
   const encoded = encodeURIComponent(svg);
@@ -121,7 +119,8 @@ export class ArEditor extends HTMLElement {
   }
 
   disconnectedCallback(): void {
-    if (this.boundLocaleHandler) document.removeEventListener('nukebg:locale-changed', this.boundLocaleHandler);
+    if (this.boundLocaleHandler)
+      document.removeEventListener('nukebg:locale-changed', this.boundLocaleHandler);
     this.abortController?.abort();
     this.abortController = null;
   }
@@ -772,51 +771,85 @@ export class ArEditor extends HTMLElement {
     const signal = this.abortController!.signal;
 
     // Brush shape
-    this.shadowRoot!.querySelector('#brush-tool')!.addEventListener('change', (e) => {
-      this.tool = (e.target as HTMLSelectElement).value as 'erase' | 'restore';
-      this.updateCursor();
-      this.syncCmdBarMeta();
-    }, { signal });
+    this.shadowRoot!.querySelector('#brush-tool')!.addEventListener(
+      'change',
+      (e) => {
+        this.tool = (e.target as HTMLSelectElement).value as 'erase' | 'restore';
+        this.updateCursor();
+        this.syncCmdBarMeta();
+      },
+      { signal },
+    );
 
-    this.shadowRoot!.querySelector('#brush-shape')!.addEventListener('change', (e) => {
-      this.brushShape = (e.target as HTMLSelectElement).value as BrushShape;
-      this.updateCursor();
-    }, { signal });
+    this.shadowRoot!.querySelector('#brush-shape')!.addEventListener(
+      'change',
+      (e) => {
+        this.brushShape = (e.target as HTMLSelectElement).value as BrushShape;
+        this.updateCursor();
+      },
+      { signal },
+    );
 
     // Brush size
     const sizeInput = this.shadowRoot!.querySelector('#brush-size') as HTMLInputElement;
     const sizeDisplay = this.shadowRoot!.querySelector('#size-display')!;
-    sizeInput.addEventListener('input', () => {
-      this.brushSize = parseInt(sizeInput.value);
-      sizeDisplay.textContent = `${this.brushSize}px`;
-      this.updateCursor();
-      this.syncCmdBarMeta();
-    }, { signal });
+    sizeInput.addEventListener(
+      'input',
+      () => {
+        this.brushSize = parseInt(sizeInput.value);
+        sizeDisplay.textContent = `${this.brushSize}px`;
+        this.updateCursor();
+        this.syncCmdBarMeta();
+      },
+      { signal },
+    );
 
     // Undo/Redo
-    this.shadowRoot!.querySelector('#undo-btn')!.addEventListener('click', () => this.undo(), { signal });
-    this.shadowRoot!.querySelector('#redo-btn')!.addEventListener('click', () => this.redo(), { signal });
+    this.shadowRoot!.querySelector('#undo-btn')!.addEventListener('click', () => this.undo(), {
+      signal,
+    });
+    this.shadowRoot!.querySelector('#redo-btn')!.addEventListener('click', () => this.redo(), {
+      signal,
+    });
 
     // Zoom
-    this.shadowRoot!.querySelector('#zoom-in')!.addEventListener('click', () => this.setZoom(this.zoom * 1.5), { signal });
-    this.shadowRoot!.querySelector('#zoom-out')!.addEventListener('click', () => this.setZoom(this.zoom / 1.5), { signal });
-    this.shadowRoot!.querySelector('#zoom-fit')!.addEventListener('click', () => this.fitToView(), { signal });
+    this.shadowRoot!.querySelector('#zoom-in')!.addEventListener(
+      'click',
+      () => this.setZoom(this.zoom * 1.5),
+      { signal },
+    );
+    this.shadowRoot!.querySelector('#zoom-out')!.addEventListener(
+      'click',
+      () => this.setZoom(this.zoom / 1.5),
+      { signal },
+    );
+    this.shadowRoot!.querySelector('#zoom-fit')!.addEventListener('click', () => this.fitToView(), {
+      signal,
+    });
 
     // Mouse wheel zoom
-    wrap.addEventListener('wheel', (e) => {
-      e.preventDefault();
-      const factor = e.deltaY < 0 ? 1.15 : 1 / 1.15;
-      this.setZoom(this.zoom * factor);
-    }, { passive: false, signal });
+    wrap.addEventListener(
+      'wheel',
+      (e) => {
+        e.preventDefault();
+        const factor = e.deltaY < 0 ? 1.15 : 1 / 1.15;
+        this.setZoom(this.zoom * factor);
+      },
+      { passive: false, signal },
+    );
 
     // Background buttons
-    this.shadowRoot!.querySelectorAll('.bg-btn').forEach(btn => {
-      btn.addEventListener('click', () => {
-        this.shadowRoot!.querySelectorAll('.bg-btn').forEach(b => b.classList.remove('active'));
-        btn.classList.add('active');
-        this.editorBg = (btn as HTMLElement).dataset.bg || 'checker';
-        this.redraw();
-      }, { signal });
+    this.shadowRoot!.querySelectorAll('.bg-btn').forEach((btn) => {
+      btn.addEventListener(
+        'click',
+        () => {
+          this.shadowRoot!.querySelectorAll('.bg-btn').forEach((b) => b.classList.remove('active'));
+          btn.classList.add('active');
+          this.editorBg = (btn as HTMLElement).dataset.bg || 'checker';
+          this.redraw();
+        },
+        { signal },
+      );
     });
 
     // Help tooltip toggle
@@ -824,19 +857,27 @@ export class ArEditor extends HTMLElement {
     const helpTooltip = this.shadowRoot!.querySelector('#help-tooltip')!;
     helpBtn.addEventListener('click', () => helpTooltip.classList.toggle('visible'), { signal });
     // Close on click outside
-    this.shadowRoot!.addEventListener('click', (e) => {
-      if (e.target !== helpBtn && !helpTooltip.contains(e.target as Node)) {
-        helpTooltip.classList.remove('visible');
-      }
-    }, { signal });
+    this.shadowRoot!.addEventListener(
+      'click',
+      (e) => {
+        if (e.target !== helpBtn && !helpTooltip.contains(e.target as Node)) {
+          helpTooltip.classList.remove('visible');
+        }
+      },
+      { signal },
+    );
     // Close on Escape — keyboard users otherwise have no way out of
     // the help overlay short of clicking the button again.
-    window.addEventListener('keydown', (e) => {
-      if (e.key === 'Escape' && helpTooltip.classList.contains('visible')) {
-        e.preventDefault();
-        helpTooltip.classList.remove('visible');
-      }
-    }, { signal });
+    window.addEventListener(
+      'keydown',
+      (e) => {
+        if (e.key === 'Escape' && helpTooltip.classList.contains('visible')) {
+          e.preventDefault();
+          helpTooltip.classList.remove('visible');
+        }
+      },
+      { signal },
+    );
 
     // Canvas mouse events
     this.canvas.addEventListener('mousedown', (e) => this.onMouseDown(e), { signal });
@@ -853,38 +894,70 @@ export class ArEditor extends HTMLElement {
     wrap.addEventListener('touchcancel', () => this.onTouchEnd(), { signal });
 
     // Cancel button - discard all edits
-    this.shadowRoot!.querySelector('#cancel-btn')!.addEventListener('click', () => {
-      this.dispatchEvent(new CustomEvent('ar:editor-cancel', {
-        bubbles: true,
-        composed: true,
-      }));
-    }, { signal });
+    this.shadowRoot!.querySelector('#cancel-btn')!.addEventListener(
+      'click',
+      () => {
+        this.dispatchEvent(
+          new CustomEvent('ar:editor-cancel', {
+            bubbles: true,
+            composed: true,
+          }),
+        );
+      },
+      { signal },
+    );
 
     // Done button
-    this.shadowRoot!.querySelector('#done-btn')!.addEventListener('click', () => {
-      this.dispatchEvent(new CustomEvent('ar:editor-done', {
-        bubbles: true,
-        composed: true,
-        detail: { imageData: this.getResultImageData() },
-      }));
-    }, { signal });
+    this.shadowRoot!.querySelector('#done-btn')!.addEventListener(
+      'click',
+      () => {
+        this.dispatchEvent(
+          new CustomEvent('ar:editor-done', {
+            bubbles: true,
+            composed: true,
+            detail: { imageData: this.getResultImageData() },
+          }),
+        );
+      },
+      { signal },
+    );
 
     // Keyboard shortcuts
-    this.addEventListener('keydown', (e) => {
-      if ((e.ctrlKey || e.metaKey) && e.key === 'z') {
-        e.preventDefault();
-        if (e.shiftKey) this.redo(); else this.undo();
-      }
-      if (e.key === '[') { this.brushSize = Math.max(2, this.brushSize - 5); this.updateSizeUI(); this.updateCursor(); }
-      if (e.key === ']') { this.brushSize = Math.min(100, this.brushSize + 5); this.updateSizeUI(); this.updateCursor(); }
-      if (e.key === '0' || e.key === 'Home') { this.resetView(); }
-    }, { signal });
+    this.addEventListener(
+      'keydown',
+      (e) => {
+        if ((e.ctrlKey || e.metaKey) && e.key === 'z') {
+          e.preventDefault();
+          if (e.shiftKey) this.redo();
+          else this.undo();
+        }
+        if (e.key === '[') {
+          this.brushSize = Math.max(2, this.brushSize - 5);
+          this.updateSizeUI();
+          this.updateCursor();
+        }
+        if (e.key === ']') {
+          this.brushSize = Math.min(100, this.brushSize + 5);
+          this.updateSizeUI();
+          this.updateCursor();
+        }
+        if (e.key === '0' || e.key === 'Home') {
+          this.resetView();
+        }
+      },
+      { signal },
+    );
   }
 
   /** Update the canvas cursor to match brush shape and size */
   private updateCursor(): void {
     if (!this.canvas) return;
-    this.canvas.style.cursor = makeBrushCursor(this.brushSize, this.brushShape, this.zoom, this.tool);
+    this.canvas.style.cursor = makeBrushCursor(
+      this.brushSize,
+      this.brushShape,
+      this.zoom,
+      this.tool,
+    );
   }
 
   private updateSizeUI(): void {
@@ -917,11 +990,7 @@ export class ArEditor extends HTMLElement {
   setImage(imageData: ImageData, original: ImageData): void {
     this.width = imageData.width;
     this.height = imageData.height;
-    this.imageData = new ImageData(
-      new Uint8ClampedArray(imageData.data),
-      this.width,
-      this.height,
-    );
+    this.imageData = new ImageData(new Uint8ClampedArray(imageData.data), this.width, this.height);
     this.originalImage = new ImageData(
       new Uint8ClampedArray(original.data),
       this.width,
@@ -1000,7 +1069,11 @@ export class ArEditor extends HTMLElement {
     // Draw image with current alpha on top
     // Reuse temp canvas because putImageData ignores compositing
     // Fallback to HTMLCanvasElement if OffscreenCanvas is not available (Safari iOS <16.4)
-    if (!this.tempCanvas || this.tempCanvas.width !== this.width || this.tempCanvas.height !== this.height) {
+    if (
+      !this.tempCanvas ||
+      this.tempCanvas.width !== this.width ||
+      this.tempCanvas.height !== this.height
+    ) {
       if (typeof OffscreenCanvas !== 'undefined') {
         this.tempCanvas = new OffscreenCanvas(this.width, this.height);
       } else {

--- a/src/components/ar-post-cta.ts
+++ b/src/components/ar-post-cta.ts
@@ -61,7 +61,10 @@ class ArPostCta extends HTMLElement {
   private onSuccess = (): void => {
     const newCount = recordSuccessfulNuke();
     const dismissed = new Set<CtaKey>(); // selectCta will re-check via storage in the helper
-    const picked = selectCta(newCount, dismissed.size === 0 ? this.dismissedFromStorage() : dismissed);
+    const picked = selectCta(
+      newCount,
+      dismissed.size === 0 ? this.dismissedFromStorage() : dismissed,
+    );
     if (picked) {
       // Delay 1s so it doesn't feel pushy — let the result settle first
       setTimeout(() => this.show(picked), 1000);

--- a/src/components/ar-privacy.ts
+++ b/src/components/ar-privacy.ts
@@ -17,7 +17,8 @@ export class ArPrivacy extends HTMLElement {
   }
 
   disconnectedCallback(): void {
-    if (this.boundLocaleHandler) document.removeEventListener('nukebg:locale-changed', this.boundLocaleHandler);
+    if (this.boundLocaleHandler)
+      document.removeEventListener('nukebg:locale-changed', this.boundLocaleHandler);
   }
 
   private updateTexts(): void {
@@ -118,44 +119,44 @@ export class ArPrivacy extends HTMLElement {
       en: [
         "> Don't trust us? DevTools > Network tab. Zero requests. We dare you.",
         "> Go ahead, check. We'll wait.",
-        "> Still here? Open the source code. GPL-3.0. Read every line.",
-        "> Your pixels. Your device. Our code. Verified.",
+        '> Still here? Open the source code. GPL-3.0. Read every line.',
+        '> Your pixels. Your device. Our code. Verified.',
         "> Other tools upload your images. We don't even know you exist.",
       ],
       es: [
-        "> No te fias? DevTools > pesta\u00F1a Red. Cero peticiones. Te retamos.",
-        "> Venga, comprueba. Esperamos.",
-        "> Sigues aqui? Abre el codigo fuente. GPL-3.0. Lee cada linea.",
-        "> Tus pixeles. Tu dispositivo. Nuestro codigo. Verificado.",
-        "> Otras herramientas suben tus imagenes. Nosotros ni sabemos que existes.",
+        '> No te fias? DevTools > pesta\u00F1a Red. Cero peticiones. Te retamos.',
+        '> Venga, comprueba. Esperamos.',
+        '> Sigues aqui? Abre el codigo fuente. GPL-3.0. Lee cada linea.',
+        '> Tus pixeles. Tu dispositivo. Nuestro codigo. Verificado.',
+        '> Otras herramientas suben tus imagenes. Nosotros ni sabemos que existes.',
       ],
       fr: [
-        "> Tu nous fais pas confiance? DevTools > onglet R\u00E9seau. Z\u00E9ro requ\u00EAte. Chiche.",
-        "> Vas-y, v\u00E9rifie. On attend.",
-        "> Encore l\u00E0? Ouvre le code source. GPL-3.0. Lis chaque ligne.",
-        "> Tes pixels. Ton appareil. Notre code. V\u00E9rifi\u00E9.",
-        "> Les autres uploadent tes images. Nous, on sait m\u00EAme pas que tu existes.",
+        '> Tu nous fais pas confiance? DevTools > onglet R\u00E9seau. Z\u00E9ro requ\u00EAte. Chiche.',
+        '> Vas-y, v\u00E9rifie. On attend.',
+        '> Encore l\u00E0? Ouvre le code source. GPL-3.0. Lis chaque ligne.',
+        '> Tes pixels. Ton appareil. Notre code. V\u00E9rifi\u00E9.',
+        '> Les autres uploadent tes images. Nous, on sait m\u00EAme pas que tu existes.',
       ],
       de: [
-        "> Vertraust du uns nicht? DevTools > Netzwerk-Tab. Null Anfragen. Trau dich.",
-        "> Nur zu, pr\u00FCf nach. Wir warten.",
-        "> Immer noch da? \u00D6ffne den Quellcode. GPL-3.0. Lies jede Zeile.",
-        "> Deine Pixel. Dein Ger\u00E4t. Unser Code. Verifiziert.",
-        "> Andere Tools laden deine Bilder hoch. Wir wissen nichtmal, dass du existierst.",
+        '> Vertraust du uns nicht? DevTools > Netzwerk-Tab. Null Anfragen. Trau dich.',
+        '> Nur zu, pr\u00FCf nach. Wir warten.',
+        '> Immer noch da? \u00D6ffne den Quellcode. GPL-3.0. Lies jede Zeile.',
+        '> Deine Pixel. Dein Ger\u00E4t. Unser Code. Verifiziert.',
+        '> Andere Tools laden deine Bilder hoch. Wir wissen nichtmal, dass du existierst.',
       ],
       pt: [
-        "> N\u00E3o confia? DevTools > aba Rede. Zero requisi\u00E7\u00F5es. Te desafiamos.",
-        "> Vai l\u00E1, confere. A gente espera.",
-        "> Ainda aqui? Abre o c\u00F3digo fonte. GPL-3.0. L\u00EA cada linha.",
-        "> Seus pixels. Seu dispositivo. Nosso c\u00F3digo. Verificado.",
-        "> Outras ferramentas sobem suas imagens. A gente nem sabe que voc\u00EA existe.",
+        '> N\u00E3o confia? DevTools > aba Rede. Zero requisi\u00E7\u00F5es. Te desafiamos.',
+        '> Vai l\u00E1, confere. A gente espera.',
+        '> Ainda aqui? Abre o c\u00F3digo fonte. GPL-3.0. L\u00EA cada linha.',
+        '> Seus pixels. Seu dispositivo. Nosso c\u00F3digo. Verificado.',
+        '> Outras ferramentas sobem suas imagens. A gente nem sabe que voc\u00EA existe.',
       ],
       zh: [
-        "> \u4E0D\u4FE1\uFF1FDevTools > \u7F51\u7EDC\u9762\u677F\u3002\u96F6\u8BF7\u6C42\u3002\u4E0D\u4FE1\u4F60\u6765\u67E5\u3002",
-        "> \u53BB\u5427\uFF0C\u67E5\u770B\u5427\u3002\u6211\u4EEC\u7B49\u3002",
-        "> \u8FD8\u5728\uFF1F\u6253\u5F00\u6E90\u7801\u3002GPL-3.0\u3002\u6BCF\u884C\u90FD\u770B\u3002",
-        "> \u4F60\u7684\u50CF\u7D20\u3002\u4F60\u7684\u8BBE\u5907\u3002\u6211\u4EEC\u7684\u4EE3\u7801\u3002\u5DF2\u9A8C\u8BC1\u3002",
-        "> \u5176\u4ED6\u5DE5\u5177\u4F1A\u4E0A\u4F20\u4F60\u7684\u56FE\u7247\u3002\u6211\u4EEC\u8FDE\u4F60\u662F\u8C01\u90FD\u4E0D\u77E5\u9053\u3002",
+        '> \u4E0D\u4FE1\uFF1FDevTools > \u7F51\u7EDC\u9762\u677F\u3002\u96F6\u8BF7\u6C42\u3002\u4E0D\u4FE1\u4F60\u6765\u67E5\u3002',
+        '> \u53BB\u5427\uFF0C\u67E5\u770B\u5427\u3002\u6211\u4EEC\u7B49\u3002',
+        '> \u8FD8\u5728\uFF1F\u6253\u5F00\u6E90\u7801\u3002GPL-3.0\u3002\u6BCF\u884C\u90FD\u770B\u3002',
+        '> \u4F60\u7684\u50CF\u7D20\u3002\u4F60\u7684\u8BBE\u5907\u3002\u6211\u4EEC\u7684\u4EE3\u7801\u3002\u5DF2\u9A8C\u8BC1\u3002',
+        '> \u5176\u4ED6\u5DE5\u5177\u4F1A\u4E0A\u4F20\u4F60\u7684\u56FE\u7247\u3002\u6211\u4EEC\u8FDE\u4F60\u662F\u8C01\u90FD\u4E0D\u77E5\u9053\u3002',
       ],
     };
     let dareIndex = 0;

--- a/src/components/ar-progress.ts
+++ b/src/components/ar-progress.ts
@@ -24,7 +24,7 @@ export class ArProgress extends HTMLElement {
     this.render();
     this.boundLocaleHandler = () => {
       // Re-translate labels for active stages
-      this.stages.forEach(s => {
+      this.stages.forEach((s) => {
         if (s.stage === 'detect-background') s.label = t('progress.detectBg');
         else if (s.stage === 'watermark-scan') s.label = t('progress.watermarkScan');
         else if (s.stage === 'inpaint') s.label = t('progress.inpaint');
@@ -45,9 +45,13 @@ export class ArProgress extends HTMLElement {
       if (!target) return;
       const stage = target.getAttribute('data-stage') ?? '';
       if (target.classList.contains('stage-action-retry')) {
-        this.dispatchEvent(new CustomEvent('ar:stage-retry', { bubbles: true, composed: true, detail: { stage } }));
+        this.dispatchEvent(
+          new CustomEvent('ar:stage-retry', { bubbles: true, composed: true, detail: { stage } }),
+        );
       } else if (target.classList.contains('stage-action-report')) {
-        this.dispatchEvent(new CustomEvent('ar:stage-report', { bubbles: true, composed: true, detail: { stage } }));
+        this.dispatchEvent(
+          new CustomEvent('ar:stage-report', { bubbles: true, composed: true, detail: { stage } }),
+        );
       } else if (target.classList.contains('stage-action-reload')) {
         location.reload();
       }
@@ -55,7 +59,8 @@ export class ArProgress extends HTMLElement {
   }
 
   disconnectedCallback(): void {
-    if (this.boundLocaleHandler) document.removeEventListener('nukebg:locale-changed', this.boundLocaleHandler);
+    if (this.boundLocaleHandler)
+      document.removeEventListener('nukebg:locale-changed', this.boundLocaleHandler);
   }
 
   reset(): void {
@@ -84,7 +89,6 @@ export class ArProgress extends HTMLElement {
     // command bar's data-state attribute instead.
   }
 
-
   setStage(stage: PipelineStage, status: StageStatus, message?: string): void {
     // Extract content type from detect-background done message (e.g. "solid detected [signature]")
     if (stage === 'detect-background' && status === 'done' && message) {
@@ -92,14 +96,14 @@ export class ArProgress extends HTMLElement {
       if (typeMatch) {
         this.detectedContentType = typeMatch[1];
         // Enrich the stage 1 label with the detected content type
-        const detectStage = this.stages.find(s => s.stage === 'detect-background');
+        const detectStage = this.stages.find((s) => s.stage === 'detect-background');
         if (detectStage) {
           detectStage.label = `${t('progress.detectBg')} [${this.detectedContentType}]`;
         }
       }
     }
 
-    const existing = this.stages.find(s => s.stage === stage);
+    const existing = this.stages.find((s) => s.stage === stage);
     if (existing) {
       existing.status = status;
       existing.message = message;
@@ -110,7 +114,7 @@ export class ArProgress extends HTMLElement {
     } else if (status === 'done') {
       const start = this.startTimes.get(stage);
       if (start) {
-        const stageInfo = this.stages.find(s => s.stage === stage);
+        const stageInfo = this.stages.find((s) => s.stage === stage);
         if (stageInfo) {
           stageInfo.timeMs = performance.now() - start;
         }
@@ -309,32 +313,33 @@ export class ArProgress extends HTMLElement {
     if (!container) return;
 
     // Filter out stages that shouldn't be shown
-    const visibleStages = this.stages.filter(s => {
+    const visibleStages = this.stages.filter((s) => {
       // Hide inpaint if skipped (no watermark)
       if (s.stage === 'inpaint' && s.status === 'skipped') return false;
       return true;
     });
 
-    container.innerHTML = visibleStages.map(s => {
-      const icon = this.getIcon(s.status);
-      const timeStr = s.timeMs !== undefined ? `${(s.timeMs / 1000).toFixed(1)}s` : '';
-      const safeMessage = s.message ? this.escapeHtml(s.message) : '';
-      const msgStr = safeMessage ? `<span class="stage-message">${safeMessage}</span>` : '';
+    container.innerHTML = visibleStages
+      .map((s) => {
+        const icon = this.getIcon(s.status);
+        const timeStr = s.timeMs !== undefined ? `${(s.timeMs / 1000).toFixed(1)}s` : '';
+        const safeMessage = s.message ? this.escapeHtml(s.message) : '';
+        const msgStr = safeMessage ? `<span class="stage-message">${safeMessage}</span>` : '';
 
-      // Extract percentage from message like "Loading AI model... 45%"
-      const pctMatch = safeMessage.match(/(\d+)%/);
-      let progressBar = '';
-      if (s.status === 'running' && pctMatch) {
-        const pct = parseInt(pctMatch[1]);
-        // At 85% the model is being initialized (WASM compilation) - show pulsing bar
-        const isParsing = pct >= 80 && pct < 100;
-        const barClass = isParsing ? 'progress-fill parsing' : 'progress-fill';
-        const label = isParsing ? t('progress.initAI') : safeMessage;
-        progressBar = `<div class="progress-bar"><div class="${barClass}" style="width: ${pct}%"></div></div>`;
-        // Override message during parsing phase
-        if (isParsing) {
-          const msgEl = `<span class="stage-message">${label}</span>`;
-          return `
+        // Extract percentage from message like "Loading AI model... 45%"
+        const pctMatch = safeMessage.match(/(\d+)%/);
+        let progressBar = '';
+        if (s.status === 'running' && pctMatch) {
+          const pct = parseInt(pctMatch[1]);
+          // At 85% the model is being initialized (WASM compilation) - show pulsing bar
+          const isParsing = pct >= 80 && pct < 100;
+          const barClass = isParsing ? 'progress-fill parsing' : 'progress-fill';
+          const label = isParsing ? t('progress.initAI') : safeMessage;
+          progressBar = `<div class="progress-bar"><div class="${barClass}" style="width: ${pct}%"></div></div>`;
+          // Override message during parsing phase
+          if (isParsing) {
+            const msgEl = `<span class="stage-message">${label}</span>`;
+            return `
             <div class="stage ${this.escapeHtml(s.status)}">
               <span class="stage-icon">${icon}</span>
               <span class="stage-label">${this.escapeHtml(s.label)}</span>
@@ -343,21 +348,22 @@ export class ArProgress extends HTMLElement {
             </div>
             ${progressBar}
           `;
+          }
         }
-      }
 
-      // #78 — when a stage errors, render retry / report / reload
-      // actions inline so the user can recover without hunting the
-      // modal that the pipeline error surface also raises from #65.
-      const errorActions = s.status === 'error'
-        ? `<div class="stage-actions" role="group" aria-label="Error recovery">
+        // #78 — when a stage errors, render retry / report / reload
+        // actions inline so the user can recover without hunting the
+        // modal that the pipeline error surface also raises from #65.
+        const errorActions =
+          s.status === 'error'
+            ? `<div class="stage-actions" role="group" aria-label="Error recovery">
              <button type="button" class="stage-action stage-action-retry" data-stage="${this.escapeHtml(s.stage)}">${this.escapeHtml(t('error.retry'))}</button>
              <button type="button" class="stage-action stage-action-report" data-stage="${this.escapeHtml(s.stage)}">${this.escapeHtml(t('error.report'))}</button>
              <button type="button" class="stage-action stage-action-reload">${this.escapeHtml(t('error.reload'))}</button>
            </div>`
-        : '';
+            : '';
 
-      return `
+        return `
         <div class="stage ${this.escapeHtml(s.status)}">
           <span class="stage-icon">${icon}</span>
           <span class="stage-label">${this.escapeHtml(s.label)}</span>
@@ -367,7 +373,8 @@ export class ArProgress extends HTMLElement {
         ${progressBar}
         ${errorActions}
       `;
-    }).join('');
+      })
+      .join('');
 
     // Auto-scroll to bottom (terminal console behavior)
     container.scrollTop = container.scrollHeight;
@@ -380,7 +387,8 @@ export class ArProgress extends HTMLElement {
     const svg = (path: string): string =>
       `<svg viewBox="0 0 16 16" width="14" height="14" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="square">${path}</svg>`;
     switch (status) {
-      case 'pending': return '';
+      case 'pending':
+        return '';
       case 'running':
         // Arc — rotates via parent .stage.running animation to form a spinner
         return svg('<circle cx="8" cy="8" r="5" stroke-dasharray="18 10"/>');

--- a/src/components/ar-reactor.ts
+++ b/src/components/ar-reactor.ts
@@ -307,12 +307,18 @@ class ArReactor extends HTMLElement {
 function escapeHtml(s: string): string {
   return s.replace(/[&<>"']/g, (c) => {
     switch (c) {
-      case '&': return '&amp;';
-      case '<': return '&lt;';
-      case '>': return '&gt;';
-      case '"': return '&quot;';
-      case "'": return '&#39;';
-      default: return c;
+      case '&':
+        return '&amp;';
+      case '<':
+        return '&lt;';
+      case '>':
+        return '&gt;';
+      case '"':
+        return '&quot;';
+      case "'":
+        return '&#39;';
+      default:
+        return c;
     }
   });
 }

--- a/src/components/ar-viewer.ts
+++ b/src/components/ar-viewer.ts
@@ -44,7 +44,8 @@ export class ArViewer extends HTMLElement {
     if (this.boundMouseUp) document.removeEventListener('mouseup', this.boundMouseUp);
     if (this.boundTouchMove) document.removeEventListener('touchmove', this.boundTouchMove);
     if (this.boundTouchEnd) document.removeEventListener('touchend', this.boundTouchEnd);
-    if (this.boundLocaleHandler) document.removeEventListener('nukebg:locale-changed', this.boundLocaleHandler);
+    if (this.boundLocaleHandler)
+      document.removeEventListener('nukebg:locale-changed', this.boundLocaleHandler);
   }
 
   private render(): void {
@@ -307,17 +308,30 @@ export class ArViewer extends HTMLElement {
       onMove(e.clientX);
     });
     this.boundMouseMove = (e: MouseEvent) => onMove(e.clientX);
-    this.boundMouseUp = () => { this.isDragging = false; };
+    this.boundMouseUp = () => {
+      this.isDragging = false;
+    };
     document.addEventListener('mousemove', this.boundMouseMove);
     document.addEventListener('mouseup', this.boundMouseUp);
 
     // Touch support
-    this.container.addEventListener('touchstart', (e) => {
-      this.isDragging = true;
-      onMove(e.touches[0].clientX);
-    }, { passive: true });
-    this.boundTouchMove = (e: TouchEvent) => { if (this.isDragging) { e.preventDefault(); onMove(e.touches[0].clientX); } };
-    this.boundTouchEnd = () => { this.isDragging = false; };
+    this.container.addEventListener(
+      'touchstart',
+      (e) => {
+        this.isDragging = true;
+        onMove(e.touches[0].clientX);
+      },
+      { passive: true },
+    );
+    this.boundTouchMove = (e: TouchEvent) => {
+      if (this.isDragging) {
+        e.preventDefault();
+        onMove(e.touches[0].clientX);
+      }
+    };
+    this.boundTouchEnd = () => {
+      this.isDragging = false;
+    };
     document.addEventListener('touchmove', this.boundTouchMove, { passive: false });
     document.addEventListener('touchend', this.boundTouchEnd);
 
@@ -361,9 +375,9 @@ export class ArViewer extends HTMLElement {
   }
 
   private setupBgButtons(): void {
-    this.shadowRoot!.querySelectorAll('.bg-btn').forEach(btn => {
+    this.shadowRoot!.querySelectorAll('.bg-btn').forEach((btn) => {
       btn.addEventListener('click', () => {
-        this.shadowRoot!.querySelectorAll('.bg-btn').forEach(b => b.classList.remove('active'));
+        this.shadowRoot!.querySelectorAll('.bg-btn').forEach((b) => b.classList.remove('active'));
         btn.classList.add('active');
         this.bgColor = (btn as HTMLElement).dataset.bg || 'transparent';
         this.applyBgColor();

--- a/src/main.ts
+++ b/src/main.ts
@@ -44,8 +44,13 @@ function initKeyboardShortcuts(): void {
   // wars.
   const overlay = createShortcutOverlay();
   document.body.appendChild(overlay);
-  const openOverlay = () => { overlay.hidden = false; overlay.focus(); };
-  const closeOverlay = () => { overlay.hidden = true; };
+  const openOverlay = () => {
+    overlay.hidden = false;
+    overlay.focus();
+  };
+  const closeOverlay = () => {
+    overlay.hidden = true;
+  };
   overlay.addEventListener('click', (e) => {
     if (e.target === overlay) closeOverlay();
   });
@@ -112,7 +117,6 @@ function initKeyboardShortcuts(): void {
       closeOverlay();
       return;
     }
-
   });
 }
 
@@ -226,7 +230,18 @@ function initHolidayEasterEgg(): void {
 
 // === Easter Egg: Konami Code ===
 function initKonamiCode(): void {
-  const KONAMI = ['ArrowUp', 'ArrowUp', 'ArrowDown', 'ArrowDown', 'ArrowLeft', 'ArrowRight', 'ArrowLeft', 'ArrowRight', 'b', 'a'];
+  const KONAMI = [
+    'ArrowUp',
+    'ArrowUp',
+    'ArrowDown',
+    'ArrowDown',
+    'ArrowLeft',
+    'ArrowRight',
+    'ArrowLeft',
+    'ArrowRight',
+    'b',
+    'a',
+  ];
   let konamiIndex = 0;
   let activated = false;
 
@@ -249,7 +264,10 @@ function initKonamiCode(): void {
 }
 
 function activateUltraNukeMode(reducedMotion: boolean): void {
-  console.log('%c⚠ ULTRA NUKE MODE ACTIVATED ⚠', 'color: #ff3131; font-family: monospace; font-size: 18px; font-weight: bold;');
+  console.log(
+    '%c⚠ ULTRA NUKE MODE ACTIVATED ⚠',
+    'color: #ff3131; font-family: monospace; font-size: 18px; font-weight: bold;',
+  );
 
   // Intensify scanlines
   const scanlineStyle = document.createElement('style');
@@ -338,7 +356,9 @@ function initLogoClickCounter(): void {
     clickCount++;
 
     if (clickTimer) clearTimeout(clickTimer);
-    clickTimer = setTimeout(() => { clickCount = 0; }, 2000);
+    clickTimer = setTimeout(() => {
+      clickCount = 0;
+    }, 2000);
 
     if (clickCount >= 10) {
       clickCount = 0;
@@ -367,40 +387,76 @@ function initLogoDoubleTap(): void {
 
   const whisperMessages: Record<string, string[]> = {
     en: [
-      'You called?', 'Still here. Still nuking.', 'That tickles.',
-      'Stop poking me.', "I'm working, I'm working...", 'Beep boop. Nuke ready.',
-      'Yes, I\'m open source. Yes, really.', 'Your backgrounds fear me.',
-      'Fun fact: your image never left this device.', 'Powered by radiation and good vibes.',
+      'You called?',
+      'Still here. Still nuking.',
+      'That tickles.',
+      'Stop poking me.',
+      "I'm working, I'm working...",
+      'Beep boop. Nuke ready.',
+      "Yes, I'm open source. Yes, really.",
+      'Your backgrounds fear me.',
+      'Fun fact: your image never left this device.',
+      'Powered by radiation and good vibes.',
     ],
     es: [
-      '\u00BFMe llamaste?', 'Sigo aqu\u00ED. Sigo nukeando.', 'Eso hace cosquillas.',
-      'Deja de tocarme.', 'Estoy trabajando, estoy trabajando...', 'Beep boop. Nuke listo.',
-      'S\u00ED, soy open source. S\u00ED, de verdad.', 'Tus fondos me temen.',
-      'Dato curioso: tu imagen nunca sali\u00F3 de este dispositivo.', 'Impulsado por radiaci\u00F3n y buenas vibras.',
+      '\u00BFMe llamaste?',
+      'Sigo aqu\u00ED. Sigo nukeando.',
+      'Eso hace cosquillas.',
+      'Deja de tocarme.',
+      'Estoy trabajando, estoy trabajando...',
+      'Beep boop. Nuke listo.',
+      'S\u00ED, soy open source. S\u00ED, de verdad.',
+      'Tus fondos me temen.',
+      'Dato curioso: tu imagen nunca sali\u00F3 de este dispositivo.',
+      'Impulsado por radiaci\u00F3n y buenas vibras.',
     ],
     fr: [
-      'Tu m\'as appel\u00E9?', 'Toujours l\u00E0. Toujours en train d\'atomiser.', '\u00C7a chatouille.',
-      'Arr\u00EAte de me toucher.', 'Je bosse, je bosse...', 'Bip boup. Nuke pr\u00EAt.',
-      'Oui, je suis open source. Oui, pour de vrai.', 'Tes fonds me craignent.',
-      'Fun fact: ton image n\'a jamais quitt\u00E9 cet appareil.', 'Aliment\u00E9 par la radiation et la bonne humeur.',
+      "Tu m'as appel\u00E9?",
+      "Toujours l\u00E0. Toujours en train d'atomiser.",
+      '\u00C7a chatouille.',
+      'Arr\u00EAte de me toucher.',
+      'Je bosse, je bosse...',
+      'Bip boup. Nuke pr\u00EAt.',
+      'Oui, je suis open source. Oui, pour de vrai.',
+      'Tes fonds me craignent.',
+      "Fun fact: ton image n'a jamais quitt\u00E9 cet appareil.",
+      'Aliment\u00E9 par la radiation et la bonne humeur.',
     ],
     de: [
-      'Gerufen?', 'Immer noch da. Immer noch am Nuken.', 'Das kitzelt.',
-      'H\u00F6r auf mich anzustupsen.', 'Ich arbeite, ich arbeite...', 'Piep piep. Nuke bereit.',
-      'Ja, ich bin Open Source. Ja, wirklich.', 'Deine Hintergr\u00FCnde f\u00FCrchten mich.',
-      'Fun Fact: Dein Bild hat dieses Ger\u00E4t nie verlassen.', 'Betrieben mit Strahlung und guter Laune.',
+      'Gerufen?',
+      'Immer noch da. Immer noch am Nuken.',
+      'Das kitzelt.',
+      'H\u00F6r auf mich anzustupsen.',
+      'Ich arbeite, ich arbeite...',
+      'Piep piep. Nuke bereit.',
+      'Ja, ich bin Open Source. Ja, wirklich.',
+      'Deine Hintergr\u00FCnde f\u00FCrchten mich.',
+      'Fun Fact: Dein Bild hat dieses Ger\u00E4t nie verlassen.',
+      'Betrieben mit Strahlung und guter Laune.',
     ],
     pt: [
-      'Me chamou?', 'Ainda aqui. Ainda nukeando.', 'Isso faz c\u00F3cegas.',
-      'Para de me cutucar.', 'To trabalhando, to trabalhando...', 'Bip bop. Nuke pronto.',
-      'Sim, sou open source. Sim, de verdade.', 'Seus fundos me temem.',
-      'Curiosidade: sua imagem nunca saiu deste dispositivo.', 'Movido a radia\u00E7\u00E3o e boas vibras.',
+      'Me chamou?',
+      'Ainda aqui. Ainda nukeando.',
+      'Isso faz c\u00F3cegas.',
+      'Para de me cutucar.',
+      'To trabalhando, to trabalhando...',
+      'Bip bop. Nuke pronto.',
+      'Sim, sou open source. Sim, de verdade.',
+      'Seus fundos me temem.',
+      'Curiosidade: sua imagem nunca saiu deste dispositivo.',
+      'Movido a radia\u00E7\u00E3o e boas vibras.',
     ],
     zh: [
-      '\u4F60\u53EB\u6211\uFF1F', '\u8FD8\u5728\u3002\u8FD8\u5728\u6838\u7206\u3002', '\u597D\u75D2\u3002',
-      '\u522B\u6233\u6211\u4E86\u3002', '\u5728\u5E72\u6D3B\u5462\uFF0C\u5728\u5E72\u6D3B\u5462...', '\u6EF4\u6EF4\u3002\u6838\u5F39\u5C31\u7EEA\u3002',
-      '\u5BF9\uFF0C\u6211\u662F\u5F00\u6E90\u7684\u3002\u5BF9\uFF0C\u771F\u7684\u3002', '\u4F60\u7684\u80CC\u666F\u6015\u6211\u3002',
-      '\u51B7\u77E5\u8BC6\uFF1A\u4F60\u7684\u56FE\u7247\u4ECE\u672A\u79BB\u5F00\u8FC7\u8FD9\u53F0\u8BBE\u5907\u3002', '\u9760\u8F90\u5C04\u548C\u597D\u5FC3\u60C5\u9A71\u52A8\u3002',
+      '\u4F60\u53EB\u6211\uFF1F',
+      '\u8FD8\u5728\u3002\u8FD8\u5728\u6838\u7206\u3002',
+      '\u597D\u75D2\u3002',
+      '\u522B\u6233\u6211\u4E86\u3002',
+      '\u5728\u5E72\u6D3B\u5462\uFF0C\u5728\u5E72\u6D3B\u5462...',
+      '\u6EF4\u6EF4\u3002\u6838\u5F39\u5C31\u7EEA\u3002',
+      '\u5BF9\uFF0C\u6211\u662F\u5F00\u6E90\u7684\u3002\u5BF9\uFF0C\u771F\u7684\u3002',
+      '\u4F60\u7684\u80CC\u666F\u6015\u6211\u3002',
+      '\u51B7\u77E5\u8BC6\uFF1A\u4F60\u7684\u56FE\u7247\u4ECE\u672A\u79BB\u5F00\u8FC7\u8FD9\u53F0\u8BBE\u5907\u3002',
+      '\u9760\u8F90\u5C04\u548C\u597D\u5FC3\u60C5\u9A71\u52A8\u3002',
     ],
   };
 
@@ -443,8 +499,8 @@ function initShakeDetection(): void {
       '> SHAKE DETECTED. Nuking harder.',
       '> Careful. This thing is nuclear.',
       '> The reactor is unstable enough already.',
-      '> You break it, you buy it. Wait, it\'s free.',
-      '> Shaking won\'t fix your background. Dropping the image will.',
+      "> You break it, you buy it. Wait, it's free.",
+      "> Shaking won't fix your background. Dropping the image will.",
     ],
     es: [
       '> No es seguro agitar material radiactivo.',
@@ -457,10 +513,10 @@ function initShakeDetection(): void {
     fr: [
       '> Pas prudent de secouer du mat\u00E9riel radioactif.',
       '> SECOUSSE D\u00C9TECT\u00C9E. Atomisation renforc\u00E9e.',
-      '> Doucement. C\'est nucl\u00E9aire.',
+      "> Doucement. C'est nucl\u00E9aire.",
       '> Le r\u00E9acteur est d\u00E9j\u00E0 assez instable.',
-      '> Tu casses, tu paies. Ah non, c\'est gratuit.',
-      '> Secouer ne r\u00E9pare pas ton fond. D\u00E9pose l\'image plut\u00F4t.',
+      "> Tu casses, tu paies. Ah non, c'est gratuit.",
+      "> Secouer ne r\u00E9pare pas ton fond. D\u00E9pose l'image plut\u00F4t.",
     ],
     de: [
       '> Radioaktives Material sch\u00FCtteln: keine gute Idee.',
@@ -506,7 +562,9 @@ function initShakeDetection(): void {
           lastShake = now;
 
           if (shakeTimer) clearTimeout(shakeTimer);
-          shakeTimer = setTimeout(() => { shakeCount = 0; }, 1500);
+          shakeTimer = setTimeout(() => {
+            shakeCount = 0;
+          }, 1500);
 
           if (shakeCount >= 3) {
             shakeCount = 0;
@@ -530,9 +588,13 @@ function initShakeDetection(): void {
   if (typeof dme.requestPermission === 'function') {
     // Request on first user interaction (touch)
     const requestOnce = (): void => {
-      dme.requestPermission!().then((state: string) => {
-        if (state === 'granted') startListening();
-      }).catch(() => { /* permission denied, silent */ });
+      dme.requestPermission!()
+        .then((state: string) => {
+          if (state === 'granted') startListening();
+        })
+        .catch(() => {
+          /* permission denied, silent */
+        });
       document.removeEventListener('touchstart', requestOnce);
     };
     document.addEventListener('touchstart', requestOnce, { once: true });
@@ -585,18 +647,22 @@ function nukeCache(): void {
   // Only clear ML model caches, not the app shell
   // This prevents the blank page bug in Brave and other strict browsers
   Promise.all([
-    caches.keys().then(keys => {
-      const modelCaches = keys.filter(k => k.includes('transformers') || k.includes('onnx') || k.includes('model'));
-      return Promise.all(modelCaches.map(k => caches.delete(k)));
+    caches.keys().then((keys) => {
+      const modelCaches = keys.filter(
+        (k) => k.includes('transformers') || k.includes('onnx') || k.includes('model'),
+      );
+      return Promise.all(modelCaches.map((k) => caches.delete(k)));
     }),
-  ]).then(() => {
-    // Use cache-busting URL param to force fresh load
-    const url = new URL(window.location.href);
-    url.searchParams.set('_cb', Date.now().toString());
-    window.location.href = url.toString();
-  }).catch(() => {
-    window.location.reload();
-  });
+  ])
+    .then(() => {
+      // Use cache-busting URL param to force fresh load
+      const url = new URL(window.location.href);
+      url.searchParams.set('_cb', Date.now().toString());
+      window.location.href = url.toString();
+    })
+    .catch(() => {
+      window.location.reload();
+    });
 }
 
 /** Footer clear cache button */
@@ -620,39 +686,39 @@ function initTerminalPrompt(): void {
 
   const COMMANDS: Record<string, string> = {
     // sudo combos
-    'sudo': '> sudo what? Try \'sudo nuke\' or \'sudo help\'',
+    sudo: "> sudo what? Try 'sudo nuke' or 'sudo help'",
     'sudo nuke': '> LAUNCHING ALL NUKES...',
-    'sudo rm': '> rm: cannot remove \'backgrounds\': already nuked',
+    'sudo rm': "> rm: cannot remove 'backgrounds': already nuked",
     'sudo rm -rf': '> rm -rf /backgrounds/* | 100% nuked. You monster.',
     'sudo help': '> man nukebg: Drop. Nuke. Download. EOF.',
     'sudo sudo': '> inception mode denied. One sudo is enough.',
     'sudo exit': '> nice try. There is no escape.',
-    'sudo hack': '> You\'re already root. What more do you want?',
-    'sudo ls': '> drwxr-xr-x your_images/ (local only, we can\'t see them)',
+    'sudo hack': "> You're already root. What more do you want?",
+    'sudo ls': "> drwxr-xr-x your_images/ (local only, we can't see them)",
     'sudo clear': '> Purging cache...',
     'sudo cat': '> sudo: 🐱: permission denied. Cats obey no one.',
     'sudo vim': '> Opened vim. Good luck getting out.',
     // basic commands
-    'nuke': '> Nuke what? Drop an image first.',
-    'exit': '> There is no escape from NukeBG.',
-    'ls': '> backgrounds/ watermarks/ [scheduled for deletion]',
+    nuke: '> Nuke what? Drop an image first.',
+    exit: '> There is no escape from NukeBG.',
+    ls: '> backgrounds/ watermarks/ [scheduled for deletion]',
     'rm -rf': '> whoa whoa whoa. Not that kind of terminal.',
-    'hack': '> You\'re already in. What more do you want?',
-    'hello': '> Hello, operator. Ready to nuke?',
-    'hi': '> Hello, operator. Ready to nuke?',
-    'clear': '> Purging cache...',
-    'purge': '> Purging cache...',
-    'whoami': '> You\'re the one nuking backgrounds. That\'s who.',
-    'pwd': '> /home/user/images/about-to-be-nuked/',
-    'cat': '> 🐱 meow. Wrong terminal.',
-    'ping': '> pong. But we don\'t do network stuff here.',
-    'cd': '> You\'re already where you need to be.',
-    'vim': '> How do I exit this? Just kidding. Try \'nuke\'.',
-    'man': '> NUKEBG(1) Drop image, nuke background, download PNG. The end.',
-    'echo': '> echo echo echo... is there an echo in here?',
-    'top': '> PID 1: nukebg | CPU: yes. RAM: some. Status: nuking.',
-    'git': '> git commit -m "nuked another background"',
-    'npm': '> npm run nuke | 1 background destroyed, 0 uploaded.',
+    hack: "> You're already in. What more do you want?",
+    hello: '> Hello, operator. Ready to nuke?',
+    hi: '> Hello, operator. Ready to nuke?',
+    clear: '> Purging cache...',
+    purge: '> Purging cache...',
+    whoami: "> You're the one nuking backgrounds. That's who.",
+    pwd: '> /home/user/images/about-to-be-nuked/',
+    cat: '> 🐱 meow. Wrong terminal.',
+    ping: "> pong. But we don't do network stuff here.",
+    cd: "> You're already where you need to be.",
+    vim: "> How do I exit this? Just kidding. Try 'nuke'.",
+    man: '> NUKEBG(1) Drop image, nuke background, download PNG. The end.',
+    echo: '> echo echo echo... is there an echo in here?',
+    top: '> PID 1: nukebg | CPU: yes. RAM: some. Status: nuking.',
+    git: '> git commit -m "nuked another background"',
+    npm: '> npm run nuke | 1 background destroyed, 0 uploaded.',
   };
 
   // Rotating help groups - sudo always first, then 4-5 random commands
@@ -671,7 +737,12 @@ function initTerminalPrompt(): void {
     return `> Commands: ${group.join(', ')}`;
   }
 
-  function showResponse(text: string, isError: boolean = false, keepFocus: boolean = true, durationMs?: number): void {
+  function showResponse(
+    text: string,
+    isError: boolean = false,
+    keepFocus: boolean = true,
+    durationMs?: number,
+  ): void {
     isShowingResponse = true;
     input!.style.display = 'none';
     cursor!.style.display = 'none';
@@ -743,7 +814,8 @@ function initTerminalPrompt(): void {
       showResponse('> Fine, showing all commands...', false, true, 1500);
       const toast = document.getElementById('kbd-toast');
       if (toast) {
-        toast.textContent = 'sudo | nuke | ls | exit | clear | hack | whoami | pwd | cat | ping | cd | vim | man | echo | top | git | npm | help';
+        toast.textContent =
+          'sudo | nuke | ls | exit | clear | hack | whoami | pwd | cat | ping | cd | vim | man | echo | top | git | npm | help';
         toast.classList.add('visible');
         setTimeout(() => toast.classList.remove('visible'), 6000);
       }
@@ -775,7 +847,7 @@ function initShareButton(): void {
 
   const shareMessages: Record<string, string[]> = {
     en: [
-      'Other tools upload your images. This one doesn\'t even know you exist \u2192 https://nukebg.app',
+      "Other tools upload your images. This one doesn't even know you exist \u2192 https://nukebg.app",
       'Found a background remover that never uploads your images \u2192 https://nukebg.app',
       'Drop. Nuke. Download. Your images never leave your device \u2192 https://nukebg.app',
       'Zero uploads, zero tracking, zero BS. Just clean PNGs \u2192 https://nukebg.app',
@@ -792,10 +864,10 @@ function initShareButton(): void {
     ],
     fr: [
       'Les autres outils uploadent tes images. Celui-ci ne sait m\u00EAme pas que tu existes \u2192 https://nukebg.app',
-      'Un d\u00E9toureur qui n\'uploade jamais tes images \u2192 https://nukebg.app',
+      "Un d\u00E9toureur qui n'uploade jamais tes images \u2192 https://nukebg.app",
       'D\u00E9pose. Atomise. T\u00E9l\u00E9charge. Tes images ne quittent jamais ton appareil \u2192 https://nukebg.app',
       'Z\u00E9ro upload, z\u00E9ro tracking, z\u00E9ro baratin \u2192 https://nukebg.app',
-      'https://nukebg.app | parce qu\'uploader ses images pour retirer un fond, c\'est absurde',
+      "https://nukebg.app | parce qu'uploader ses images pour retirer un fond, c'est absurde",
     ],
     de: [
       'Andere Tools laden deine Bilder hoch. Dieses kennt dich nichtmal \u2192 https://nukebg.app',
@@ -829,7 +901,10 @@ function initShareButton(): void {
       await navigator.clipboard.writeText(msg);
       const toast = document.getElementById('kbd-toast');
       if (toast) {
-        toast.textContent = document.documentElement.lang === 'es' ? '> Copiado! P\u00E9galo donde quieras.' : '> Copied! Paste it anywhere.';
+        toast.textContent =
+          document.documentElement.lang === 'es'
+            ? '> Copiado! P\u00E9galo donde quieras.'
+            : '> Copied! Paste it anywhere.';
         toast.classList.add('visible');
         setTimeout(() => toast.classList.remove('visible'), 2000);
       }
@@ -910,7 +985,11 @@ function applyTheme(theme: ThemeName): void {
 
 function initThemeSwitcher(): void {
   const stored = (() => {
-    try { return localStorage.getItem(THEME_STORAGE_KEY); } catch { return null; }
+    try {
+      return localStorage.getItem(THEME_STORAGE_KEY);
+    } catch {
+      return null;
+    }
   })();
   const initial: ThemeName = isThemeName(stored) ? stored : 'green';
   applyTheme(initial);
@@ -923,7 +1002,11 @@ function initThemeSwitcher(): void {
     const next = target.dataset.theme;
     if (!isThemeName(next ?? null)) return;
     applyTheme(next as ThemeName);
-    try { localStorage.setItem(THEME_STORAGE_KEY, next!); } catch { /* ignore */ }
+    try {
+      localStorage.setItem(THEME_STORAGE_KEY, next!);
+    } catch {
+      /* ignore */
+    }
   });
 
   // WAI-ARIA radiogroup keyboard nav: Arrow keys cycle, Home/End jump.
@@ -936,7 +1019,8 @@ function initThemeSwitcher(): void {
     e.preventDefault();
     let nextIdx = idx;
     if (e.key === 'ArrowRight' || e.key === 'ArrowDown') nextIdx = (idx + 1) % swatches.length;
-    else if (e.key === 'ArrowLeft' || e.key === 'ArrowUp') nextIdx = (idx - 1 + swatches.length) % swatches.length;
+    else if (e.key === 'ArrowLeft' || e.key === 'ArrowUp')
+      nextIdx = (idx - 1 + swatches.length) % swatches.length;
     else if (e.key === 'Home') nextIdx = 0;
     else if (e.key === 'End') nextIdx = swatches.length - 1;
     swatches[nextIdx].focus();
@@ -966,12 +1050,9 @@ function init(): void {
 function initReactorStatus(): void {
   const burn = formatBurnRate();
   void applyReactorStatus({
-    footerStatus: (runtime) =>
-      t('footer.reactorStatus', { burn, runtime }),
-    marqueeFunding: (runtime) =>
-      t('marquee.funding', { burn, runtime }),
-    kofiAriaLabel: (runtime) =>
-      t('footer.kofiAria', { runtime }),
+    footerStatus: (runtime) => t('footer.reactorStatus', { burn, runtime }),
+    marqueeFunding: (runtime) => t('marquee.funding', { burn, runtime }),
+    kofiAriaLabel: (runtime) => t('footer.kofiAria', { runtime }),
   });
 }
 

--- a/src/pipeline/constants.ts
+++ b/src/pipeline/constants.ts
@@ -5,10 +5,10 @@ export const CV_PARAMS = {
   MIN_GRID_SIZE: 8,
   COLOR_TOLERANCE: 25,
   BOUNDARY_ZONE: 2,
-  LOW_COVERAGE_THRESHOLD: 0.30,
+  LOW_COVERAGE_THRESHOLD: 0.3,
   CELL_BG_MATCH_HIGH: 0.65,
-  CELL_BG_MATCH_LOW: 0.40,
-  CELL_SATURATION_THRESHOLD: 0.20,
+  CELL_BG_MATCH_LOW: 0.4,
+  CELL_SATURATION_THRESHOLD: 0.2,
   CELL_BRIGHTNESS_THRESHOLD: 50,
   CELL_COLORED_RATIO: 0.15,
   SOLID_BG_VARIANCE: 20,
@@ -31,7 +31,7 @@ export const WATERMARK_PARAMS = {
 export const SPARKLE_PARAMS = {
   /** Fraction of width/height to scan. Gemini always places the sparkle in
    *  the bottom-right; keep this tight to reject distant features. */
-  SCAN_WIDTH_FRACTION: 0.20,
+  SCAN_WIDTH_FRACTION: 0.2,
   SCAN_HEIGHT_FRACTION: 0.25,
   /** Candidate sparkle radii (pixels). Multi-scale sweep. */
   SCALE_RADII: [10, 14, 20, 28, 40, 55] as const,
@@ -120,7 +120,6 @@ export const EDGE_REFINE_PARAMS = {
   BAND_HI: 245,
 } as const;
 
-
 export const PATCHMATCH_PARAMS = {
   /** Patch radius (pixels). 3 → 7×7 patches, the Barnes 2009 sweet-spot
    *  for texture reconstruction on natural photos. */
@@ -168,8 +167,7 @@ export const LAMA_PARAMS = {
   MODEL_URL:
     'https://huggingface.co/opencv/inpainting_lama/resolve/aee6d22f0a13e5e35af1c9a1c3afd62841fc6f3f/inpainting_lama_2025jan.onnx',
   EXPECTED_SIZE: 92_591_623,
-  EXPECTED_SHA256:
-    '7df918ac3921d3daf0aae1d219776cf0dc4e4935f035af81841b40adcf74fdf2',
+  EXPECTED_SHA256: '7df918ac3921d3daf0aae1d219776cf0dc4e4935f035af81841b40adcf74fdf2',
   /** Fixed 1:1 input expected by the ONNX graph. Changing this breaks
    *  inference — it's baked into the Fourier convolution tensor sizes. */
   INPUT_SIZE: 512,
@@ -247,7 +245,7 @@ export const PRECISION_PROFILES: Record<PrecisionMode, PrecisionProfile> = {
     clusterRatio: 0.02,
     minClusterSize: 100,
   },
-  'normal': {
+  normal: {
     rmbgThreshold: 0.5,
     spatialPasses: 1,
     spatialRadius: REFINE_PARAMS.SPATIAL_RADIUS,
@@ -290,11 +288,11 @@ export const IMAGE_CLASSIFY_PARAMS = {
   /** Max saturation mean for signature (very low color) */
   SIGNATURE_SATURATION_MAX: 0.08,
   /** Min near-white ratio for signature background */
-  SIGNATURE_NEAR_WHITE_MIN: 0.50,
+  SIGNATURE_NEAR_WHITE_MIN: 0.5,
   /** Min dark pixel ratio (ink strokes) */
   SIGNATURE_DARK_PIXEL_MIN: 0.01,
   /** Max dark pixel ratio (not too much ink) */
-  SIGNATURE_DARK_PIXEL_MAX: 0.40,
+  SIGNATURE_DARK_PIXEL_MAX: 0.4,
 
   // ICON thresholds
   /** Max total pixels for icon classification */

--- a/src/pipeline/finalize.ts
+++ b/src/pipeline/finalize.ts
@@ -137,7 +137,8 @@ export function fillSubjectHoles(
   const n = width * height;
   const queue = new Int32Array(n);
   const bgVisited = new Uint8Array(n);
-  let head = 0, tail = 0;
+  let head = 0,
+    tail = 0;
 
   const seedBg = (idx: number) => {
     if (data[idx * 4 + 3] === 0 && !bgVisited[idx]) {
@@ -160,19 +161,31 @@ export function fillSubjectHoles(
     const y = (idx - x) / width;
     if (x > 0) {
       const ni = idx - 1;
-      if (!bgVisited[ni] && data[ni * 4 + 3] === 0) { bgVisited[ni] = 1; queue[tail++] = ni; }
+      if (!bgVisited[ni] && data[ni * 4 + 3] === 0) {
+        bgVisited[ni] = 1;
+        queue[tail++] = ni;
+      }
     }
     if (x < width - 1) {
       const ni = idx + 1;
-      if (!bgVisited[ni] && data[ni * 4 + 3] === 0) { bgVisited[ni] = 1; queue[tail++] = ni; }
+      if (!bgVisited[ni] && data[ni * 4 + 3] === 0) {
+        bgVisited[ni] = 1;
+        queue[tail++] = ni;
+      }
     }
     if (y > 0) {
       const ni = idx - width;
-      if (!bgVisited[ni] && data[ni * 4 + 3] === 0) { bgVisited[ni] = 1; queue[tail++] = ni; }
+      if (!bgVisited[ni] && data[ni * 4 + 3] === 0) {
+        bgVisited[ni] = 1;
+        queue[tail++] = ni;
+      }
     }
     if (y < height - 1) {
       const ni = idx + width;
-      if (!bgVisited[ni] && data[ni * 4 + 3] === 0) { bgVisited[ni] = 1; queue[tail++] = ni; }
+      if (!bgVisited[ni] && data[ni * 4 + 3] === 0) {
+        bgVisited[ni] = 1;
+        queue[tail++] = ni;
+      }
     }
   }
 
@@ -184,7 +197,8 @@ export function fillSubjectHoles(
     if (data[start * 4 + 3] !== 0) continue;
     if (bgVisited[start] || holeVisited[start]) continue;
 
-    head = 0; tail = 0;
+    head = 0;
+    tail = 0;
     let size = 0;
     queue[tail++] = start;
     holeVisited[start] = 1;
@@ -197,25 +211,33 @@ export function fillSubjectHoles(
       if (x > 0) {
         const ni = idx - 1;
         if (!holeVisited[ni] && !bgVisited[ni] && data[ni * 4 + 3] === 0) {
-          holeVisited[ni] = 1; queue[tail++] = ni; holeIndices[size++] = ni;
+          holeVisited[ni] = 1;
+          queue[tail++] = ni;
+          holeIndices[size++] = ni;
         }
       }
       if (x < width - 1) {
         const ni = idx + 1;
         if (!holeVisited[ni] && !bgVisited[ni] && data[ni * 4 + 3] === 0) {
-          holeVisited[ni] = 1; queue[tail++] = ni; holeIndices[size++] = ni;
+          holeVisited[ni] = 1;
+          queue[tail++] = ni;
+          holeIndices[size++] = ni;
         }
       }
       if (y > 0) {
         const ni = idx - width;
         if (!holeVisited[ni] && !bgVisited[ni] && data[ni * 4 + 3] === 0) {
-          holeVisited[ni] = 1; queue[tail++] = ni; holeIndices[size++] = ni;
+          holeVisited[ni] = 1;
+          queue[tail++] = ni;
+          holeIndices[size++] = ni;
         }
       }
       if (y < height - 1) {
         const ni = idx + width;
         if (!holeVisited[ni] && !bgVisited[ni] && data[ni * 4 + 3] === 0) {
-          holeVisited[ni] = 1; queue[tail++] = ni; holeIndices[size++] = ni;
+          holeVisited[ni] = 1;
+          queue[tail++] = ni;
+          holeIndices[size++] = ni;
         }
       }
     }
@@ -315,8 +337,14 @@ export function sharpenAlpha(alpha: Uint8Array): Uint8Array {
   const range = SHARPEN_HIGH - SHARPEN_LOW;
   for (let i = 0; i < alpha.length; i++) {
     const a = alpha[i];
-    if (a <= SHARPEN_LOW) { out[i] = 0; continue; }
-    if (a >= SHARPEN_HIGH) { out[i] = 255; continue; }
+    if (a <= SHARPEN_LOW) {
+      out[i] = 0;
+      continue;
+    }
+    if (a >= SHARPEN_HIGH) {
+      out[i] = 255;
+      continue;
+    }
     const n = (a - SHARPEN_LOW) / range;
     const s = n * n * n * (n * (n * 6 - 15) + 10);
     const v = Math.round(s * 255);
@@ -344,7 +372,8 @@ export function keepLargestComponent(bin: Uint8Array, w: number, h: number): voi
     if (bin[i] === 0 || labels[i] !== 0) continue;
     nextId++;
     labels[i] = nextId;
-    let head = 0, tail = 0;
+    let head = 0,
+      tail = 0;
     queue[tail++] = i;
     let size = 0;
     while (head < tail) {
@@ -393,7 +422,10 @@ function dilate1(bin: Uint8Array, w: number, h: number): Uint8Array {
   for (let y = 0; y < h; y++) {
     for (let x = 0; x < w; x++) {
       const idx = y * w + x;
-      if (bin[idx]) { out[idx] = 1; continue; }
+      if (bin[idx]) {
+        out[idx] = 1;
+        continue;
+      }
       let has = 0;
       for (let dy = -1; dy <= 1 && !has; dy++) {
         for (let dx = -1; dx <= 1 && !has; dx++) {
@@ -482,4 +514,3 @@ export async function refineEdges(
 
   return new ImageData(new Uint8ClampedArray(rgba), w, h);
 }
-

--- a/src/pipeline/orchestrator.ts
+++ b/src/pipeline/orchestrator.ts
@@ -6,7 +6,14 @@ import type {
   WatermarkResult,
   ImageContentType,
 } from '../types/pipeline';
-import type { CvWorkerResponse, MlWorkerResponse, InpaintWorkerResponse, LamaWorkerResponse, ModelId, ClassifyImageResult } from '../types/worker-messages';
+import type {
+  CvWorkerResponse,
+  MlWorkerResponse,
+  InpaintWorkerResponse,
+  LamaWorkerResponse,
+  ModelId,
+  ClassifyImageResult,
+} from '../types/worker-messages';
 import { IMAGE_CLASSIFY_PARAMS, INPAINT_PARAMS, PRECISION_PROFILES } from './constants';
 import type { PrecisionMode } from './constants';
 import { compositeWithFeather, dilateMask } from '../workers/cv/inpaint-blend';
@@ -59,15 +66,18 @@ export class PipelineOrchestrator {
   private mlWorker: Worker;
   private inpaintWorker: Worker | null = null;
   private lamaWorker: Worker | null = null;
-  private pendingRequests = new Map<string, {
-    resolve: (val: unknown) => void;
-    reject: (err: Error) => void;
-    expectedType: string;
-    /** Timeout handle associated with this request, so response handlers
-     *  can clear it promptly instead of waiting for the timer to fire
-     *  empty-handed. */
-    timer?: ReturnType<typeof setTimeout>;
-  }>();
+  private pendingRequests = new Map<
+    string,
+    {
+      resolve: (val: unknown) => void;
+      reject: (err: Error) => void;
+      expectedType: string;
+      /** Timeout handle associated with this request, so response handlers
+       *  can clear it promptly instead of waiting for the timer to fire
+       *  empty-handed. */
+      timer?: ReturnType<typeof setTimeout>;
+    }
+  >();
   private pendingTimers = new Set<ReturnType<typeof setTimeout>>();
   private onStageChange: StageCallback;
   private activeSignalCleanup: (() => void) | null = null;
@@ -80,10 +90,7 @@ export class PipelineOrchestrator {
   }
 
   private createCvWorker(): Worker {
-    const w = new Worker(
-      new URL('../workers/cv.worker.ts', import.meta.url),
-      { type: 'module' }
-    );
+    const w = new Worker(new URL('../workers/cv.worker.ts', import.meta.url), { type: 'module' });
     w.onerror = (e) => {
       this.rejectAllPending(`CV Worker error: ${e.message}`);
       w.terminate();
@@ -104,10 +111,7 @@ export class PipelineOrchestrator {
   }
 
   private createMlWorker(): Worker {
-    const w = new Worker(
-      new URL('../workers/ml.worker.ts', import.meta.url),
-      { type: 'module' }
-    );
+    const w = new Worker(new URL('../workers/ml.worker.ts', import.meta.url), { type: 'module' });
     w.onerror = (e) => {
       this.rejectAllPending(`ML Worker error: ${e.message}`);
       w.terminate();
@@ -126,9 +130,10 @@ export class PipelineOrchestrator {
       if (msg.type === 'model-progress') {
         if (this.suppressMlProgress) return; // background preload, don't update UI
         const pct = msg.progress ?? 0;
-        const label = pct >= 96 && pct < 100
-          ? 'Warming up the reactor... [96%]'
-          : `Loading AI model... ${pct}% [${pct}%]`;
+        const label =
+          pct >= 96 && pct < 100
+            ? 'Warming up the reactor... [96%]'
+            : `Loading AI model... ${pct}% [${pct}%]`;
         this.emit('ml-segmentation', 'running', label);
         return;
       }
@@ -160,7 +165,9 @@ export class PipelineOrchestrator {
         } else if (msg.type === 'segment-result') {
           // Only resolve if the request was actually for a segment call
           if (pending.expectedType !== 'segment') {
-            console.warn(`[NukeBG] segment-result arrived for a '${pending.expectedType}' request - ignoring`);
+            console.warn(
+              `[NukeBG] segment-result arrived for a '${pending.expectedType}' request - ignoring`,
+            );
             return;
           }
           this.settlePending(msg.id);
@@ -170,7 +177,9 @@ export class PipelineOrchestrator {
           // This prevents a model-ready message from prematurely resolving
           // a segment request when the worker auto-loads the model.
           if (pending.expectedType !== 'load-model') {
-            console.warn(`[NukeBG] model-ready arrived for a '${pending.expectedType}' request - ignoring`);
+            console.warn(
+              `[NukeBG] model-ready arrived for a '${pending.expectedType}' request - ignoring`,
+            );
             return;
           }
           this.settlePending(msg.id);
@@ -181,7 +190,9 @@ export class PipelineOrchestrator {
   }
 
   /** Extract Transferable buffers from a payload object */
-  private static extractTransferables(payload: Record<string, unknown> | undefined): Transferable[] {
+  private static extractTransferables(
+    payload: Record<string, unknown> | undefined,
+  ): Transferable[] {
     if (!payload) return [];
     const transferables: Transferable[] = [];
     for (const val of Object.values(payload)) {
@@ -269,11 +280,20 @@ export class PipelineOrchestrator {
         }
       }, CV_TIMEOUT_MS);
       this.pendingTimers.add(timer);
-      this.pendingRequests.set(id, { resolve: resolve as (val: unknown) => void, reject, expectedType: type, timer });
+      this.pendingRequests.set(id, {
+        resolve: resolve as (val: unknown) => void,
+        reject,
+        expectedType: type,
+        timer,
+      });
     });
   }
 
-  private mlCall<T>(type: string, payload?: Record<string, unknown>, extra?: Record<string, unknown>): Promise<T> {
+  private mlCall<T>(
+    type: string,
+    payload?: Record<string, unknown>,
+    extra?: Record<string, unknown>,
+  ): Promise<T> {
     return new Promise((resolve, reject) => {
       const id = generateUUID();
       const transferables = PipelineOrchestrator.extractTransferables(payload);
@@ -283,21 +303,29 @@ export class PipelineOrchestrator {
         this.pendingTimers.delete(timer);
         if (this.pendingRequests.has(id)) {
           this.pendingRequests.delete(id);
-          reject(new Error(`ML Worker timeout after ${ML_TIMEOUT_MS}ms: ${type}. Check browser console for errors.`));
+          reject(
+            new Error(
+              `ML Worker timeout after ${ML_TIMEOUT_MS}ms: ${type}. Check browser console for errors.`,
+            ),
+          );
         }
       }, ML_TIMEOUT_MS);
       this.pendingTimers.add(timer);
-      this.pendingRequests.set(id, { resolve: resolve as (val: unknown) => void, reject, expectedType: type, timer });
+      this.pendingRequests.set(id, {
+        resolve: resolve as (val: unknown) => void,
+        reject,
+        expectedType: type,
+        timer,
+      });
     });
   }
 
   /** Create the inpaint worker lazily (only when needed) */
   private createInpaintWorker(): void {
     if (this.inpaintWorker) return;
-    this.inpaintWorker = new Worker(
-      new URL('../workers/inpaint.worker.ts', import.meta.url),
-      { type: 'module' }
-    );
+    this.inpaintWorker = new Worker(new URL('../workers/inpaint.worker.ts', import.meta.url), {
+      type: 'module',
+    });
     this.inpaintWorker.onerror = (e) => this.rejectAllPending(`Inpaint Worker error: ${e.message}`);
     this.inpaintWorker.onmessage = (e: MessageEvent<InpaintWorkerResponse>) => {
       const msg = e.data;
@@ -340,7 +368,12 @@ export class PipelineOrchestrator {
         }
       }, INPAINT_TIMEOUT_MS);
       this.pendingTimers.add(timer);
-      this.pendingRequests.set(id, { resolve: resolve as (val: unknown) => void, reject, expectedType: type, timer });
+      this.pendingRequests.set(id, {
+        resolve: resolve as (val: unknown) => void,
+        reject,
+        expectedType: type,
+        timer,
+      });
     });
   }
 
@@ -355,10 +388,9 @@ export class PipelineOrchestrator {
   /** Create the LaMa worker lazily (only when the router picks it). */
   private createLamaWorker(): void {
     if (this.lamaWorker) return;
-    this.lamaWorker = new Worker(
-      new URL('../workers/lama.worker.ts', import.meta.url),
-      { type: 'module' }
-    );
+    this.lamaWorker = new Worker(new URL('../workers/lama.worker.ts', import.meta.url), {
+      type: 'module',
+    });
     this.lamaWorker.onerror = (e) => this.rejectAllPending(`LaMa Worker error: ${e.message}`);
     this.lamaWorker.onmessage = (e: MessageEvent<LamaWorkerResponse>) => {
       const msg = e.data;
@@ -410,7 +442,12 @@ export class PipelineOrchestrator {
         }
       }, LAMA_TIMEOUT_MS);
       this.pendingTimers.add(timer);
-      this.pendingRequests.set(id, { resolve: resolve as (val: unknown) => void, reject, expectedType: type, timer });
+      this.pendingRequests.set(id, {
+        resolve: resolve as (val: unknown) => void,
+        reject,
+        expectedType: type,
+        timer,
+      });
     });
   }
 
@@ -453,7 +490,10 @@ export class PipelineOrchestrator {
     height: number,
   ): Promise<Uint8ClampedArray> {
     return this.cvCall<Uint8ClampedArray>('foreground-estimate', {
-      pixels, alpha, width, height,
+      pixels,
+      alpha,
+      width,
+      height,
     });
   }
 
@@ -461,10 +501,7 @@ export class PipelineOrchestrator {
    * Combine N watermark masks with logical OR.
    * Returns null if all masks are null.
    */
-  private static combineMasks(
-    masks: Array<Uint8Array | null>,
-    size: number,
-  ): Uint8Array | null {
+  private static combineMasks(masks: Array<Uint8Array | null>, size: number): Uint8Array | null {
     const validMasks = masks.filter((m): m is Uint8Array => m !== null);
     if (validMasks.length === 0) return null;
     if (validMasks.length === 1) return validMasks[0];
@@ -577,7 +614,17 @@ export class PipelineOrchestrator {
       stageTiming['ml-segmentation'] = performance.now() - t;
       this.emit('ml-segmentation', 'done', 'Signature extracted');
 
-      return this.composeResult(originalPixels, sigAlpha, width, height, contentType, false, null, startTime, stageTiming);
+      return this.composeResult(
+        originalPixels,
+        sigAlpha,
+        width,
+        height,
+        contentType,
+        false,
+        null,
+        startTime,
+        stageTiming,
+      );
     }
 
     // ── Stage 2: Watermark detection (CV, no ML, instant) - skip for ICON ──
@@ -631,8 +678,8 @@ export class PipelineOrchestrator {
         if (import.meta.env.DEV) {
           console.log(
             `[NukeBG] Inpaint router: useLama=${routerDecision.useLama} ` +
-            `(variance=${routerDecision.variance.toFixed(1)}, ` +
-            `edgeDensity=${routerDecision.edgeDensity.toFixed(1)})`,
+              `(variance=${routerDecision.variance.toFixed(1)}, ` +
+              `edgeDensity=${routerDecision.edgeDensity.toFixed(1)})`,
           );
         }
 
@@ -687,7 +734,11 @@ export class PipelineOrchestrator {
         watermarkRemoved = true;
         appliedWatermarkMask = combinedMask;
         stageTiming['inpaint'] = performance.now() - t;
-        this.emit('inpaint', 'done', routerDecision.useLama ? 'Zone reconstructed [AI]' : 'Watermark reconstructed');
+        this.emit(
+          'inpaint',
+          'done',
+          routerDecision.useLama ? 'Zone reconstructed [AI]' : 'Watermark reconstructed',
+        );
       } else {
         this.emit('watermark-scan', 'done', 'No watermarks found');
         stageTiming['watermark-scan'] = performance.now() - t;
@@ -708,9 +759,8 @@ export class PipelineOrchestrator {
     const extra: Record<string, unknown> = {};
     if (modelId) extra.modelId = modelId;
     // ICON: use lower threshold for more aggressive removal
-    extra.threshold = contentType === 'ICON'
-      ? IMAGE_CLASSIFY_PARAMS.ICON_RMBG_THRESHOLD
-      : profile.rmbgThreshold;
+    extra.threshold =
+      contentType === 'ICON' ? IMAGE_CLASSIFY_PARAMS.ICON_RMBG_THRESHOLD : profile.rmbgThreshold;
     extra.refine = {
       spatialPasses: profile.spatialPasses,
       spatialRadius: profile.spatialRadius,
@@ -719,18 +769,29 @@ export class PipelineOrchestrator {
       minClusterSize: profile.minClusterSize,
     };
 
-    const mlAlpha = await this.mlCall<Uint8Array>('segment', {
-      pixels: new Uint8ClampedArray(originalPixels),
-      width,
-      height,
-    }, extra);
+    const mlAlpha = await this.mlCall<Uint8Array>(
+      'segment',
+      {
+        pixels: new Uint8ClampedArray(originalPixels),
+        width,
+        height,
+      },
+      extra,
+    );
 
     stageTiming['ml-segmentation'] = performance.now() - t;
     this.emit('ml-segmentation', 'done', 'Background removed');
 
     return this.composeResult(
-      originalPixels, mlAlpha, width, height, contentType,
-      watermarkRemoved, appliedWatermarkMask, startTime, stageTiming,
+      originalPixels,
+      mlAlpha,
+      width,
+      height,
+      contentType,
+      watermarkRemoved,
+      appliedWatermarkMask,
+      startTime,
+      stageTiming,
     );
   }
 
@@ -763,9 +824,11 @@ export class PipelineOrchestrator {
       else if (finalAlpha[i] < 30) transparentPixels++;
     }
     const totalPixels = width * height;
-    const nukedPct = Math.round(100 * transparentPixels / totalPixels);
+    const nukedPct = Math.round((100 * transparentPixels) / totalPixels);
     if (import.meta.env.DEV) {
-      console.log(`[NukeBG] Result: ${nukedPct}% nuked, ${Math.round(100 * opaquePixels / totalPixels)}% kept, ${totalPixels - opaquePixels - transparentPixels} edge pixels`);
+      console.log(
+        `[NukeBG] Result: ${nukedPct}% nuked, ${Math.round((100 * opaquePixels) / totalPixels)}% kept, ${totalPixels - opaquePixels - transparentPixels} edge pixels`,
+      );
     }
 
     const resultImageData = new ImageData(resultPixels, width, height);
@@ -805,6 +868,10 @@ export class PipelineOrchestrator {
   /** Test-only accessors so unit tests can assert the #44 leak is fixed
    *  without touching private state. Cheap in production — the getters
    *  forward straight to the existing collections. */
-  get _pendingTimersSize(): number { return this.pendingTimers.size; }
-  get _pendingRequestsSize(): number { return this.pendingRequests.size; }
+  get _pendingTimersSize(): number {
+    return this.pendingTimers.size;
+  }
+  get _pendingRequestsSize(): number {
+    return this.pendingRequests.size;
+  }
 }

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -35,9 +35,9 @@
 
   /* Semantic */
   --color-success: #00ff41;
-  --color-success-muted: rgba(var(--color-accent-rgb), 0.10);
+  --color-success-muted: rgba(var(--color-accent-rgb), 0.1);
   --color-warning: #ffcc00;
-  --color-warning-muted: rgba(255, 204, 0, 0.10);
+  --color-warning-muted: rgba(255, 204, 0, 0.1);
   --color-error: #ff3131;
   /* Was 0.12 — invisible on black. Bumped to 0.35 so error
      callouts using this as a background read clearly while still
@@ -45,7 +45,7 @@
   --color-error-muted: rgba(255, 49, 49, 0.35);
   --color-error-border: #3a1a1a;
   --color-info: #00ff41;
-  --color-info-muted: rgba(var(--color-accent-rgb), 0.10);
+  --color-info-muted: rgba(var(--color-accent-rgb), 0.1);
 
   /* Checkerboard Preview */
   --color-checker-light: #0a0a0a;
@@ -70,9 +70,9 @@
 
   /* Compressed per design #80 to a clean three-step scale so the low
      end isn't four near-identical sizes doing the same visual job. */
-  --text-xs: 0.75rem;   /* 12px — timestamps, quiet meta */
-  --text-sm: 0.875rem;  /* 14px — body secondary, subline */
-  --text-base: 1rem;    /* 16px — body */
+  --text-xs: 0.75rem; /* 12px — timestamps, quiet meta */
+  --text-sm: 0.875rem; /* 14px — body secondary, subline */
+  --text-base: 1rem; /* 16px — body */
   --text-lg: 1.25rem;
   --text-xl: 1.4375rem;
   --text-2xl: 1.75rem;
@@ -150,7 +150,7 @@
    semantic warning/error colors stay constant so the terminal feel
    doesn't get lost. data-theme is set on <html> by main.ts on boot
    and persisted via localStorage. */
-:root[data-theme="amber"] {
+:root[data-theme='amber'] {
   --color-text-primary: #ff8c00;
   --color-text-secondary: #cc7000;
   --color-text-tertiary: #995300;
@@ -162,7 +162,7 @@
   --color-surface-hover: #2a1f0a;
   --color-surface-active: #302510;
 }
-:root[data-theme="cyan"] {
+:root[data-theme='cyan'] {
   --color-text-primary: #00ddff;
   --color-text-secondary: #00aacc;
   --color-text-tertiary: #0088aa;
@@ -174,7 +174,7 @@
   --color-surface-hover: #0a1f2a;
   --color-surface-active: #102530;
 }
-:root[data-theme="magenta"] {
+:root[data-theme='magenta'] {
   --color-text-primary: #ff33ff;
   --color-text-secondary: #cc22cc;
   --color-text-tertiary: #991199;
@@ -186,7 +186,7 @@
   --color-surface-hover: #2a0a2a;
   --color-surface-active: #301030;
 }
-:root[data-theme="red"] {
+:root[data-theme='red'] {
   --color-text-primary: #ff3344;
   --color-text-secondary: #cc2233;
   --color-text-tertiary: #991122;
@@ -198,7 +198,7 @@
   --color-surface-hover: #2a0a0c;
   --color-surface-active: #301010;
 }
-:root[data-theme="yellow"] {
+:root[data-theme='yellow'] {
   --color-text-primary: #ffee00;
   --color-text-secondary: #ccbb00;
   --color-text-tertiary: #998800;
@@ -212,7 +212,9 @@
 }
 
 /* === Reset === */
-*, *::before, *::after {
+*,
+*::before,
+*::after {
   box-sizing: border-box;
   margin: 0;
   padding: 0;
@@ -405,8 +407,9 @@ body::after {
   font-size: 12px;
   letter-spacing: 0.1em;
   text-transform: uppercase;
-  transition: color var(--duration-normal) var(--ease-default),
-              text-shadow var(--duration-normal) var(--ease-default);
+  transition:
+    color var(--duration-normal) var(--ease-default),
+    text-shadow var(--duration-normal) var(--ease-default);
 }
 
 .header-link:hover {
@@ -468,8 +471,13 @@ body::after {
   color: var(--color-error);
 }
 @keyframes blink-cursor {
-  0%, 100% { opacity: 1; }
-  50% { opacity: 0; }
+  0%,
+  100% {
+    opacity: 1;
+  }
+  50% {
+    opacity: 0;
+  }
 }
 
 /* === Main === */
@@ -498,8 +506,9 @@ body::after {
 .footer a {
   color: var(--color-text-secondary);
   text-decoration: none;
-  transition: color var(--duration-normal) var(--ease-default),
-              text-shadow var(--duration-normal) var(--ease-default);
+  transition:
+    color var(--duration-normal) var(--ease-default),
+    text-shadow var(--duration-normal) var(--ease-default);
 }
 
 .footer a:hover {
@@ -516,7 +525,9 @@ body::after {
   color: var(--color-text-tertiary);
   text-decoration: none;
   cursor: pointer;
-  transition: color var(--duration-normal), text-shadow var(--duration-normal);
+  transition:
+    color var(--duration-normal),
+    text-shadow var(--duration-normal);
 }
 .footer-cache-btn:hover {
   color: var(--color-accent-primary);
@@ -544,36 +555,73 @@ body::after {
   padding: 0;
   cursor: pointer;
   border-radius: 0;
-  transition: outline-offset var(--duration-fast), transform var(--duration-fast);
+  transition:
+    outline-offset var(--duration-fast),
+    transform var(--duration-fast);
   outline: 1px solid transparent;
   outline-offset: 0;
 }
-.theme-swatch[data-theme="green"]   { background: #00ff41; }
-.theme-swatch[data-theme="amber"]   { background: #ff8c00; }
-.theme-swatch[data-theme="cyan"]    { background: #00ddff; }
-.theme-swatch[data-theme="magenta"] { background: #ff33ff; }
-.theme-swatch[data-theme="red"]     { background: #ff3344; }
-.theme-swatch[data-theme="yellow"]  { background: #ffee00; }
+.theme-swatch[data-theme='green'] {
+  background: #00ff41;
+}
+.theme-swatch[data-theme='amber'] {
+  background: #ff8c00;
+}
+.theme-swatch[data-theme='cyan'] {
+  background: #00ddff;
+}
+.theme-swatch[data-theme='magenta'] {
+  background: #ff33ff;
+}
+.theme-swatch[data-theme='red'] {
+  background: #ff3344;
+}
+.theme-swatch[data-theme='yellow'] {
+  background: #ffee00;
+}
 .theme-swatch:hover,
 .theme-swatch:focus-visible {
   outline-color: var(--color-accent-primary);
   outline-offset: 2px;
 }
-.theme-swatch[data-theme="green"]:hover,   .theme-swatch[data-theme="green"]:focus-visible   { box-shadow: 0 0 8px #00ff41; }
-.theme-swatch[data-theme="amber"]:hover,   .theme-swatch[data-theme="amber"]:focus-visible   { box-shadow: 0 0 8px #ff8c00; }
-.theme-swatch[data-theme="cyan"]:hover,    .theme-swatch[data-theme="cyan"]:focus-visible    { box-shadow: 0 0 8px #00ddff; }
-.theme-swatch[data-theme="magenta"]:hover, .theme-swatch[data-theme="magenta"]:focus-visible { box-shadow: 0 0 8px #ff33ff; }
-.theme-swatch[data-theme="red"]:hover,     .theme-swatch[data-theme="red"]:focus-visible     { box-shadow: 0 0 8px #ff3344; }
-.theme-swatch[data-theme="yellow"]:hover,  .theme-swatch[data-theme="yellow"]:focus-visible  { box-shadow: 0 0 8px #ffee00; }
-.theme-swatch[aria-checked="true"] {
+.theme-swatch[data-theme='green']:hover,
+.theme-swatch[data-theme='green']:focus-visible {
+  box-shadow: 0 0 8px #00ff41;
+}
+.theme-swatch[data-theme='amber']:hover,
+.theme-swatch[data-theme='amber']:focus-visible {
+  box-shadow: 0 0 8px #ff8c00;
+}
+.theme-swatch[data-theme='cyan']:hover,
+.theme-swatch[data-theme='cyan']:focus-visible {
+  box-shadow: 0 0 8px #00ddff;
+}
+.theme-swatch[data-theme='magenta']:hover,
+.theme-swatch[data-theme='magenta']:focus-visible {
+  box-shadow: 0 0 8px #ff33ff;
+}
+.theme-swatch[data-theme='red']:hover,
+.theme-swatch[data-theme='red']:focus-visible {
+  box-shadow: 0 0 8px #ff3344;
+}
+.theme-swatch[data-theme='yellow']:hover,
+.theme-swatch[data-theme='yellow']:focus-visible {
+  box-shadow: 0 0 8px #ffee00;
+}
+.theme-swatch[aria-checked='true'] {
   outline: 1px solid var(--color-accent-primary);
   outline-offset: 2px;
 }
 @media (pointer: coarse) {
-  .theme-swatch { width: 18px; height: 18px; }
+  .theme-swatch {
+    width: 18px;
+    height: 18px;
+  }
 }
 @media (max-width: 480px) {
-  .theme-picker-label { display: none; }
+  .theme-picker-label {
+    display: none;
+  }
 }
 
 .footer-privacy {
@@ -627,7 +675,9 @@ body::after {
 
 /* === Reduced Motion === */
 @media (prefers-reduced-motion: reduce) {
-  *, *::before, *::after {
+  *,
+  *::before,
+  *::after {
     animation-duration: 0.01ms !important;
     animation-iteration-count: 1 !important;
     transition-duration: 0.01ms !important;
@@ -653,7 +703,9 @@ body::after {
   z-index: var(--z-toast);
   opacity: 0;
   transform: translateY(8px);
-  transition: opacity var(--duration-normal), transform var(--duration-normal);
+  transition:
+    opacity var(--duration-normal),
+    transform var(--duration-normal);
   pointer-events: none;
 }
 
@@ -675,7 +727,9 @@ body::after {
   padding: var(--space-4);
   z-index: 10000;
 }
-.kbd-overlay[hidden] { display: none; }
+.kbd-overlay[hidden] {
+  display: none;
+}
 .kbd-overlay-card {
   background: #0a0a0a;
   border: 1px solid var(--color-accent-primary, #00ff41);
@@ -712,7 +766,10 @@ body::after {
   align-items: center;
   gap: 4px;
 }
-.kbd-overlay-list dd { margin: 0; opacity: 0.9; }
+.kbd-overlay-list dd {
+  margin: 0;
+  opacity: 0.9;
+}
 .kbd-overlay-list kbd {
   display: inline-block;
   padding: 1px 6px;

--- a/src/sw-register.ts
+++ b/src/sw-register.ts
@@ -32,22 +32,15 @@ if ('serviceWorker' in navigator) {
           if (!newWorker) return;
 
           newWorker.addEventListener('statechange', () => {
-            if (
-              newWorker.state === 'installed' &&
-              navigator.serviceWorker.controller
-            ) {
-              document.dispatchEvent(
-                new CustomEvent('nukebg:sw-update-available')
-              );
+            if (newWorker.state === 'installed' && navigator.serviceWorker.controller) {
+              document.dispatchEvent(new CustomEvent('nukebg:sw-update-available'));
             }
           });
         };
 
         // Check if there's already a waiting worker
         if (registration.waiting && navigator.serviceWorker.controller) {
-          document.dispatchEvent(
-            new CustomEvent('nukebg:sw-update-available')
-          );
+          document.dispatchEvent(new CustomEvent('nukebg:sw-update-available'));
         }
 
         registration.addEventListener('updatefound', onUpdateFound);

--- a/src/types/batch.ts
+++ b/src/types/batch.ts
@@ -1,12 +1,7 @@
 import type { PipelineResult, PipelineStage, StageStatus } from './pipeline';
 
 /** Per-item state in a batch-processing run. */
-export type BatchItemState =
-  | 'pending'
-  | 'processing'
-  | 'done'
-  | 'failed'
-  | 'discarded';
+export type BatchItemState = 'pending' | 'processing' | 'done' | 'failed' | 'discarded';
 
 /**
  * Snapshot of a single stage transition emitted by the pipeline.

--- a/src/types/pipeline.ts
+++ b/src/types/pipeline.ts
@@ -2,11 +2,7 @@
 export type ImageContentType = 'PHOTO' | 'ILLUSTRATION' | 'SIGNATURE' | 'ICON';
 
 /** Stage identifiers for progress reporting */
-export type PipelineStage =
-  | 'detect-background'
-  | 'ml-segmentation'
-  | 'watermark-scan'
-  | 'inpaint';
+export type PipelineStage = 'detect-background' | 'ml-segmentation' | 'watermark-scan' | 'inpaint';
 
 export type StageStatus = 'running' | 'done' | 'skipped' | 'error';
 
@@ -59,8 +55,8 @@ export interface PipelineResult {
 
 /** Result from background color detection */
 export interface BgColorResult {
-  colorA: number[];  // RGB, 3 values
-  colorB: number[];  // RGB, 3 values
+  colorA: number[]; // RGB, 3 values
+  colorB: number[]; // RGB, 3 values
   isCheckerboard: boolean;
   cornerVariance: number;
 }

--- a/src/types/worker-messages.ts
+++ b/src/types/worker-messages.ts
@@ -114,18 +114,19 @@ export type CvWorkerResponse =
   | { id: string; type: 'foreground-estimate'; result: Uint8ClampedArray }
   | { id: string; type: 'error'; error: string };
 
-
 /** ======== ML Worker Messages ======== */
 
 export type ModelId = 'briaai/RMBG-1.4';
 
 export const MODEL_OPTIONS: { id: ModelId; label: string; description: string }[] = [
-  { id: 'briaai/RMBG-1.4', label: 'RMBG 1.4', description: 'Best for illustrations, icons, and AI art' },
+  {
+    id: 'briaai/RMBG-1.4',
+    label: 'RMBG 1.4',
+    description: 'Best for illustrations, icons, and AI art',
+  },
 ];
 
-export type MlWorkerRequest =
-  | MlLoadModelRequest
-  | MlSegmentRequest;
+export type MlWorkerRequest = MlLoadModelRequest | MlSegmentRequest;
 
 export interface MlLoadModelRequest {
   id: string;
@@ -172,12 +173,9 @@ export type MlWorkerResponse =
   | { id: string; type: 'error'; error: string }
   | { id: string; type: 'warmup-diagnostic'; diagnostic: WarmupDiagnostic };
 
-
 /** ======== Inpaint Worker Messages ======== */
 
-export type InpaintWorkerRequest =
-  | InpaintRunRequest
-  | InpaintDisposeRequest;
+export type InpaintWorkerRequest = InpaintRunRequest | InpaintDisposeRequest;
 
 export interface InpaintRunRequest {
   id: string;
@@ -201,13 +199,9 @@ export type InpaintWorkerResponse =
   | { id: string; type: 'disposed' }
   | { id: string; type: 'error'; error: string };
 
-
 /** ======== Lama (ONNX content-aware inpainting) Worker Messages ======== */
 
-export type LamaWorkerRequest =
-  | LamaLoadModelRequest
-  | LamaRunRequest
-  | LamaDisposeRequest;
+export type LamaWorkerRequest = LamaLoadModelRequest | LamaRunRequest | LamaDisposeRequest;
 
 export interface LamaLoadModelRequest {
   id: string;

--- a/src/utils/capability-detector.ts
+++ b/src/utils/capability-detector.ts
@@ -124,7 +124,10 @@ function guessTier(): { tier: CapabilityTier; reason: string } {
 
   // No heap info (Safari / Firefox). Use deviceMemory + cores.
   if (memory !== undefined && memory >= 8) {
-    return { tier: cores >= 8 ? 'ultra' : 'high', reason: `deviceMemory=${memory}GB, cores=${cores}` };
+    return {
+      tier: cores >= 8 ? 'ultra' : 'high',
+      reason: `deviceMemory=${memory}GB, cores=${cores}`,
+    };
   }
   if (memory !== undefined && memory >= 4) {
     return { tier: 'high', reason: `deviceMemory=${memory}GB` };

--- a/src/utils/final-composite.ts
+++ b/src/utils/final-composite.ts
@@ -140,10 +140,7 @@ export function refineUpscaledAlpha(
   const out = new Uint8Array(alpha.length);
   for (let i = 0; i < alpha.length; i++) {
     const a = alpha[i];
-    out[i] =
-      a <= EDGE_REFINE_PARAMS.BAND_LO || a >= EDGE_REFINE_PARAMS.BAND_HI
-        ? a
-        : filtered[i];
+    out[i] = a <= EDGE_REFINE_PARAMS.BAND_LO || a >= EDGE_REFINE_PARAMS.BAND_HI ? a : filtered[i];
   }
   return out;
 }
@@ -180,9 +177,14 @@ export interface ComposeAtOriginalInput {
  */
 export function composeAtOriginal(input: ComposeAtOriginalInput): ImageData {
   const {
-    originalRgba, originalWidth: oW, originalHeight: oH,
-    workingRgba, workingWidth: wW, workingHeight: wH,
-    workingAlpha, inpaintMask,
+    originalRgba,
+    originalWidth: oW,
+    originalHeight: oH,
+    workingRgba,
+    workingWidth: wW,
+    workingHeight: wH,
+    workingAlpha,
+    inpaintMask,
   } = input;
 
   const sameSize = oW === wW && oH === wH;

--- a/src/utils/image-io.ts
+++ b/src/utils/image-io.ts
@@ -23,17 +23,33 @@ async function sniffImageFormat(file: File): Promise<SupportedFormat | null> {
   if (head.length < 12) return null;
 
   // PNG:  89 50 4E 47 0D 0A 1A 0A
-  if (head[0] === 0x89 && head[1] === 0x50 && head[2] === 0x4E && head[3] === 0x47 &&
-      head[4] === 0x0D && head[5] === 0x0A && head[6] === 0x1A && head[7] === 0x0A) {
+  if (
+    head[0] === 0x89 &&
+    head[1] === 0x50 &&
+    head[2] === 0x4e &&
+    head[3] === 0x47 &&
+    head[4] === 0x0d &&
+    head[5] === 0x0a &&
+    head[6] === 0x1a &&
+    head[7] === 0x0a
+  ) {
     return 'image/png';
   }
   // JPEG: FF D8 FF
-  if (head[0] === 0xFF && head[1] === 0xD8 && head[2] === 0xFF) {
+  if (head[0] === 0xff && head[1] === 0xd8 && head[2] === 0xff) {
     return 'image/jpeg';
   }
   // WebP: "RIFF" <size> "WEBP"
-  if (head[0] === 0x52 && head[1] === 0x49 && head[2] === 0x46 && head[3] === 0x46 &&
-      head[8] === 0x57 && head[9] === 0x45 && head[10] === 0x42 && head[11] === 0x50) {
+  if (
+    head[0] === 0x52 &&
+    head[1] === 0x49 &&
+    head[2] === 0x46 &&
+    head[3] === 0x46 &&
+    head[8] === 0x57 &&
+    head[9] === 0x45 &&
+    head[10] === 0x42 &&
+    head[11] === 0x50
+  ) {
     return 'image/webp';
   }
   return null;
@@ -48,7 +64,9 @@ export async function loadImage(file: File): Promise<ImageLoadResult> {
   }
 
   if (file.size > MAX_FILE_SIZE) {
-    throw new Error(`File too large: ${Math.round(file.size / 1024 / 1024)} MB. Maximum is ${Math.round(MAX_FILE_SIZE / 1024 / 1024)} MB.`);
+    throw new Error(
+      `File too large: ${Math.round(file.size / 1024 / 1024)} MB. Maximum is ${Math.round(MAX_FILE_SIZE / 1024 / 1024)} MB.`,
+    );
   }
 
   // Magic-byte sniff: refuses renamed non-image files before the decoder
@@ -114,7 +132,9 @@ async function rasterizeBitmap(
     canvas.width = width;
     canvas.height = height;
   }
-  const ctx = canvas.getContext('2d')! as CanvasRenderingContext2D | OffscreenCanvasRenderingContext2D;
+  const ctx = canvas.getContext('2d')! as
+    | CanvasRenderingContext2D
+    | OffscreenCanvasRenderingContext2D;
   // High-quality downscale for better alpha-edge results after upscale.
   ctx.imageSmoothingEnabled = true;
   ctx.imageSmoothingQuality = 'high';
@@ -148,8 +168,8 @@ export async function exportPng(imageData: ImageData): Promise<Blob> {
     });
   }
   return injectPngMetadata(rawBlob, {
-    'Software': 'NukeBG v2.8.0',
-    'Source': 'https://nukebg.app',
+    Software: 'NukeBG v2.8.0',
+    Source: 'https://nukebg.app',
   });
 }
 
@@ -171,10 +191,14 @@ export async function exportWebp(imageData: ImageData, quality = 0.95): Promise<
   const ctx = canvas.getContext('2d')!;
   ctx.putImageData(imageData, 0, 0);
   return new Promise<Blob>((resolve, reject) => {
-    canvas.toBlob((blob) => {
-      if (blob) resolve(blob);
-      else reject(new Error('Canvas toBlob failed for WebP'));
-    }, 'image/webp', quality);
+    canvas.toBlob(
+      (blob) => {
+        if (blob) resolve(blob);
+        else reject(new Error('Canvas toBlob failed for WebP'));
+      },
+      'image/webp',
+      quality,
+    );
   });
 }
 
@@ -183,10 +207,7 @@ export async function exportWebp(imageData: ImageData, quality = 0.95): Promise<
  * PNG format: signature + chunks. Each chunk = length(4) + type(4) + data + crc(4).
  * We insert tEXt chunks right before the IEND chunk.
  */
-async function injectPngMetadata(
-  blob: Blob,
-  metadata: Record<string, string>,
-): Promise<Blob> {
+async function injectPngMetadata(blob: Blob, metadata: Record<string, string>): Promise<Blob> {
   const buffer = await blob.arrayBuffer();
   const data = new Uint8Array(buffer);
 
@@ -203,13 +224,16 @@ async function injectPngMetadata(
   // Combine: everything before IEND + text chunks + IEND
   const beforeIEND = data.slice(0, iendOffset);
   const iendChunk = data.slice(iendOffset);
-  const totalSize = beforeIEND.length + textChunks.reduce((s, c) => s + c.length, 0) + iendChunk.length;
+  const totalSize =
+    beforeIEND.length + textChunks.reduce((s, c) => s + c.length, 0) + iendChunk.length;
 
   const result = new Uint8Array(totalSize);
   let offset = 0;
-  result.set(beforeIEND, offset); offset += beforeIEND.length;
+  result.set(beforeIEND, offset);
+  offset += beforeIEND.length;
   for (const chunk of textChunks) {
-    result.set(chunk, offset); offset += chunk.length;
+    result.set(chunk, offset);
+    offset += chunk.length;
   }
   result.set(iendChunk, offset);
 
@@ -220,8 +244,7 @@ async function injectPngMetadata(
 function findIEND(data: Uint8Array): number {
   // Search backwards for "IEND" (0x49 0x45 0x4E 0x44)
   for (let i = data.length - 8; i >= 8; i--) {
-    if (data[i] === 0x49 && data[i + 1] === 0x45 &&
-        data[i + 2] === 0x4E && data[i + 3] === 0x44) {
+    if (data[i] === 0x49 && data[i + 1] === 0x45 && data[i + 2] === 0x4e && data[i + 3] === 0x44) {
       return i - 4; // -4 for the length field before the type
     }
   }
@@ -259,65 +282,191 @@ function createTextChunk(keyword: string, text: string): Uint8Array {
 
 /** CRC32 for PNG chunks */
 function crc32(data: Uint8Array): number {
-  let crc = 0xFFFFFFFF;
+  let crc = 0xffffffff;
   for (let i = 0; i < data.length; i++) {
     crc ^= data[i];
     for (let j = 0; j < 8; j++) {
-      crc = (crc >>> 1) ^ (crc & 1 ? 0xEDB88320 : 0);
+      crc = (crc >>> 1) ^ (crc & 1 ? 0xedb88320 : 0);
     }
   }
-  return (crc ^ 0xFFFFFFFF) >>> 0;
+  return (crc ^ 0xffffffff) >>> 0;
 }
 
 /** Nuclear-themed prefixes that rotate randomly, keyed by locale */
 const NUKE_PREFIXES: Record<string, string[]> = {
   en: [
-    'nuked', 'decontaminated', 'defused', 'irradiated', 'fallout-free',
-    'meltdown', 'reactor-clean', 'half-life', 'chain-reaction',
-    'ground-zero', 'critical-mass', 'blast-zone', 'warhead', 'enriched',
-    'fission', 'fusion', 'plutonium', 'uranium', 'chernobyl', 'geiger',
-    'containment', 'bunker', 'hazmat', 'atomic', 'thermonuclear',
-    'payload', 'detonated', 'vaporized', 'obliterated',
+    'nuked',
+    'decontaminated',
+    'defused',
+    'irradiated',
+    'fallout-free',
+    'meltdown',
+    'reactor-clean',
+    'half-life',
+    'chain-reaction',
+    'ground-zero',
+    'critical-mass',
+    'blast-zone',
+    'warhead',
+    'enriched',
+    'fission',
+    'fusion',
+    'plutonium',
+    'uranium',
+    'chernobyl',
+    'geiger',
+    'containment',
+    'bunker',
+    'hazmat',
+    'atomic',
+    'thermonuclear',
+    'payload',
+    'detonated',
+    'vaporized',
+    'obliterated',
   ],
   es: [
-    'nukeado', 'descontaminado', 'desactivado', 'irradiado', 'sin-radiacion',
-    'fusion-nuclear', 'reactor-limpio', 'vida-media', 'reaccion-en-cadena',
-    'zona-cero', 'masa-critica', 'zona-de-impacto', 'ojiva', 'enriquecido',
-    'fision', 'plutonio', 'uranio', 'chernobyl', 'geiger',
-    'contencion', 'bunker', 'atomico', 'termonuclear',
-    'detonado', 'vaporizado', 'obliterado',
+    'nukeado',
+    'descontaminado',
+    'desactivado',
+    'irradiado',
+    'sin-radiacion',
+    'fusion-nuclear',
+    'reactor-limpio',
+    'vida-media',
+    'reaccion-en-cadena',
+    'zona-cero',
+    'masa-critica',
+    'zona-de-impacto',
+    'ojiva',
+    'enriquecido',
+    'fision',
+    'plutonio',
+    'uranio',
+    'chernobyl',
+    'geiger',
+    'contencion',
+    'bunker',
+    'atomico',
+    'termonuclear',
+    'detonado',
+    'vaporizado',
+    'obliterado',
   ],
   fr: [
-    'atomise', 'decontamine', 'desactive', 'irradie', 'sans-retombees',
-    'fusion-nucleaire', 'reacteur-propre', 'demi-vie', 'reaction-en-chaine',
-    'point-zero', 'masse-critique', 'zone-de-tir', 'ogive', 'enrichi',
-    'fission', 'plutonium', 'uranium', 'tchernobyl', 'geiger',
-    'confinement', 'bunker', 'atomique', 'thermonucleaire',
-    'detone', 'vaporise', 'pulverise',
+    'atomise',
+    'decontamine',
+    'desactive',
+    'irradie',
+    'sans-retombees',
+    'fusion-nucleaire',
+    'reacteur-propre',
+    'demi-vie',
+    'reaction-en-chaine',
+    'point-zero',
+    'masse-critique',
+    'zone-de-tir',
+    'ogive',
+    'enrichi',
+    'fission',
+    'plutonium',
+    'uranium',
+    'tchernobyl',
+    'geiger',
+    'confinement',
+    'bunker',
+    'atomique',
+    'thermonucleaire',
+    'detone',
+    'vaporise',
+    'pulverise',
   ],
   de: [
-    'genuked', 'dekontaminiert', 'entschaerft', 'bestrahlt', 'fallout-frei',
-    'kernschmelze', 'reaktor-sauber', 'halbwertszeit', 'kettenreaktion',
-    'ground-zero', 'kritische-masse', 'sprengzone', 'sprengkopf', 'angereichert',
-    'spaltung', 'fusion', 'plutonium', 'uran', 'tschernobyl', 'geiger',
-    'sicherheitsbehaelter', 'bunker', 'gefahrgut', 'atomar', 'thermonuklear',
-    'gezuendet', 'verdampft', 'ausgeloescht',
+    'genuked',
+    'dekontaminiert',
+    'entschaerft',
+    'bestrahlt',
+    'fallout-frei',
+    'kernschmelze',
+    'reaktor-sauber',
+    'halbwertszeit',
+    'kettenreaktion',
+    'ground-zero',
+    'kritische-masse',
+    'sprengzone',
+    'sprengkopf',
+    'angereichert',
+    'spaltung',
+    'fusion',
+    'plutonium',
+    'uran',
+    'tschernobyl',
+    'geiger',
+    'sicherheitsbehaelter',
+    'bunker',
+    'gefahrgut',
+    'atomar',
+    'thermonuklear',
+    'gezuendet',
+    'verdampft',
+    'ausgeloescht',
   ],
   pt: [
-    'nukeado', 'descontaminado', 'desarmado', 'irradiado', 'sem-fallout',
-    'fusao-nuclear', 'reator-limpo', 'meia-vida', 'reacao-em-cadeia',
-    'marco-zero', 'massa-critica', 'zona-de-impacto', 'ogiva', 'enriquecido',
-    'fissao', 'plutonio', 'uranio', 'chernobyl', 'geiger',
-    'contencao', 'bunker', 'atomico', 'termonuclear',
-    'detonado', 'vaporizado', 'obliterado',
+    'nukeado',
+    'descontaminado',
+    'desarmado',
+    'irradiado',
+    'sem-fallout',
+    'fusao-nuclear',
+    'reator-limpo',
+    'meia-vida',
+    'reacao-em-cadeia',
+    'marco-zero',
+    'massa-critica',
+    'zona-de-impacto',
+    'ogiva',
+    'enriquecido',
+    'fissao',
+    'plutonio',
+    'uranio',
+    'chernobyl',
+    'geiger',
+    'contencao',
+    'bunker',
+    'atomico',
+    'termonuclear',
+    'detonado',
+    'vaporizado',
+    'obliterado',
   ],
   zh: [
-    'hebao', 'jinghua', 'paishe', 'fushe', 'ling-wuran',
-    'ronghe', 'fanying-qingjie', 'ban-shuaiqi', 'lianshi-fanying',
-    'yuanbao-zhongxin', 'linjie-zhiliang', 'baozha-quyu', 'dantou', 'nongsu',
-    'liebian', 'jubian', 'bu', 'you', 'qieernobeili', 'gaige',
-    'anquan-ke', 'yanbi', 'yuanzi', 'renhe',
-    'yinbao', 'zhengfa', 'huimie',
+    'hebao',
+    'jinghua',
+    'paishe',
+    'fushe',
+    'ling-wuran',
+    'ronghe',
+    'fanying-qingjie',
+    'ban-shuaiqi',
+    'lianshi-fanying',
+    'yuanbao-zhongxin',
+    'linjie-zhiliang',
+    'baozha-quyu',
+    'dantou',
+    'nongsu',
+    'liebian',
+    'jubian',
+    'bu',
+    'you',
+    'qieernobeili',
+    'gaige',
+    'anquan-ke',
+    'yanbi',
+    'yuanzi',
+    'renhe',
+    'yinbao',
+    'zhengfa',
+    'huimie',
   ],
 };
 
@@ -338,7 +487,11 @@ const HOLIDAY_PREFIXES: Record<string, string> = {
  */
 let holidayUsed = false;
 
-export function generateOutputFilename(inputName: string, format: ExportFormat = 'png', locale = 'en'): string {
+export function generateOutputFilename(
+  inputName: string,
+  format: ExportFormat = 'png',
+  locale = 'en',
+): string {
   const base = inputName.replace(/\.[^.]+$/, '');
   const now = new Date();
   const monthDay = `${String(now.getMonth() + 1).padStart(2, '0')}-${String(now.getDate()).padStart(2, '0')}`;

--- a/src/workers/cv.worker.ts
+++ b/src/workers/cv.worker.ts
@@ -15,32 +15,34 @@ self.onmessage = (e: MessageEvent<CvWorkerRequest>) => {
     switch (type) {
       case 'detect-bg-colors': {
         const result = detectBgColors(
-          payload.pixels, payload.width, payload.height, payload.sampleSize
+          payload.pixels,
+          payload.width,
+          payload.height,
+          payload.sampleSize,
         );
         self.postMessage({ id, type, result });
         break;
       }
       case 'watermark-detect': {
         const result = watermarkDetect(
-          payload.pixels, payload.width, payload.height,
-          payload.colorA, payload.colorB
+          payload.pixels,
+          payload.width,
+          payload.height,
+          payload.colorA,
+          payload.colorB,
         );
         const transferables: Transferable[] = result.mask ? [result.mask.buffer] : [];
         self.postMessage({ id, type, result }, transferables);
         break;
       }
       case 'watermark-detect-dalle': {
-        const result = watermarkDetectDalle(
-          payload.pixels, payload.width, payload.height
-        );
+        const result = watermarkDetectDalle(payload.pixels, payload.width, payload.height);
         const transferables: Transferable[] = result.mask ? [result.mask.buffer] : [];
         self.postMessage({ id, type, result }, transferables);
         break;
       }
       case 'sparkle-detect': {
-        const result = sparkleDetect(
-          payload.pixels, payload.width, payload.height
-        );
+        const result = sparkleDetect(payload.pixels, payload.width, payload.height);
         const transferables: Transferable[] = result.mask ? [result.mask.buffer] : [];
         self.postMessage({ id, type, result }, transferables);
         break;
@@ -63,7 +65,10 @@ self.onmessage = (e: MessageEvent<CvWorkerRequest>) => {
       }
       case 'foreground-estimate': {
         const result = estimateForeground(
-          payload.pixels, payload.alpha, payload.width, payload.height,
+          payload.pixels,
+          payload.alpha,
+          payload.width,
+          payload.height,
           { iterationsPerLevel: payload.iterationsPerLevel, lambda: payload.lambda },
         );
         self.postMessage({ id, type, result }, [result.buffer]);

--- a/src/workers/cv/alpha-matting.ts
+++ b/src/workers/cv/alpha-matting.ts
@@ -10,12 +10,7 @@
  * Compute box mean via separable sliding window - O(1) per pixel.
  * Two passes: horizontal then vertical, each using a running sum.
  */
-function boxMean(
-  src: Float32Array,
-  w: number,
-  h: number,
-  radius: number,
-): Float32Array {
+function boxMean(src: Float32Array, w: number, h: number, radius: number): Float32Array {
   const n = w * h;
   const tmp = new Float32Array(n);
   const out = new Float32Array(n);
@@ -138,4 +133,3 @@ export function guidedFilter(
 
   return result;
 }
-

--- a/src/workers/cv/alpha-refine.ts
+++ b/src/workers/cv/alpha-refine.ts
@@ -4,11 +4,7 @@ import { ALPHA_PARAMS } from '../../pipeline/constants';
  * Refine alpha channel: median filter + gaussian blur + threshold.
  * Port of Python alpha refinement steps.
  */
-export function alphaRefine(
-  mask: Uint8Array,
-  width: number,
-  height: number
-): Uint8Array {
+export function alphaRefine(mask: Uint8Array, width: number, height: number): Uint8Array {
   // Convert mask (1=bg, 0=fg) to alpha (0=bg, 255=fg)
   const alpha = new Uint8Array(width * height);
   for (let i = 0; i < mask.length; i++) {

--- a/src/workers/cv/classify-image.ts
+++ b/src/workers/cv/classify-image.ts
@@ -29,7 +29,8 @@ export function extractImageFeatures(
   const P = IMAGE_CLASSIFY_PARAMS;
 
   // Sample pixels for unique color counting (full scan is too slow for large images)
-  const sampleStep = totalPixels > P.SAMPLE_THRESHOLD ? Math.ceil(totalPixels / P.SAMPLE_THRESHOLD) : 1;
+  const sampleStep =
+    totalPixels > P.SAMPLE_THRESHOLD ? Math.ceil(totalPixels / P.SAMPLE_THRESHOLD) : 1;
 
   let brightnessSum = 0;
   let brightnessSqSum = 0;

--- a/src/workers/cv/detect-bg-colors.ts
+++ b/src/workers/cv/detect-bg-colors.ts
@@ -10,7 +10,7 @@ export function detectBgColors(
   pixels: Uint8ClampedArray,
   width: number,
   height: number,
-  sampleSize: number = CV_PARAMS.CORNER_SAMPLE_SIZE
+  sampleSize: number = CV_PARAMS.CORNER_SAMPLE_SIZE,
 ): BgColorResult {
   const s = Math.min(sampleSize, Math.floor(height / 4), Math.floor(width / 4));
 

--- a/src/workers/cv/detect-checker-grid.ts
+++ b/src/workers/cv/detect-checker-grid.ts
@@ -11,11 +11,12 @@ export function detectCheckerGrid(
   width: number,
   height: number,
   colorDark: number[],
-  colorLight: number[]
+  colorLight: number[],
 ): GridResult {
   const midBrightness =
     ((colorDark[0] + colorDark[1] + colorDark[2]) / 3 +
-      (colorLight[0] + colorLight[1] + colorLight[2]) / 3) / 2;
+      (colorLight[0] + colorLight[1] + colorLight[2]) / 3) /
+    2;
 
   const gridSizes: number[] = [];
 

--- a/src/workers/cv/foreground-estimation.ts
+++ b/src/workers/cv/foreground-estimation.ts
@@ -107,13 +107,13 @@ export function estimateForeground(
     const a = alpha[i];
     out[i * 4 + 3] = a;
     if (a >= 254) {
-      out[i * 4]     = observed[i * 4];
+      out[i * 4] = observed[i * 4];
       out[i * 4 + 1] = observed[i * 4 + 1];
       out[i * 4 + 2] = observed[i * 4 + 2];
     } else if (a <= 1) {
       // Invisible — leave RGB at zero.
     } else {
-      out[i * 4]     = Math.max(0, Math.min(255, Math.round(F[i * 3])));
+      out[i * 4] = Math.max(0, Math.min(255, Math.round(F[i * 3])));
       out[i * 4 + 1] = Math.max(0, Math.min(255, Math.round(F[i * 3 + 1])));
       out[i * 4 + 2] = Math.max(0, Math.min(255, Math.round(F[i * 3 + 2])));
     }
@@ -153,7 +153,7 @@ function buildPyramid(
 function initializeFromImage(image: Uint8ClampedArray, out: Float32Array): void {
   const n = out.length / 3;
   for (let i = 0; i < n; i++) {
-    out[i * 3]     = image[i * 4];
+    out[i * 3] = image[i * 4];
     out[i * 3 + 1] = image[i * 4 + 1];
     out[i * 3 + 2] = image[i * 4 + 2];
   }
@@ -214,7 +214,9 @@ function weightedBoxBlur3(
   for (let y = 0; y < height; y++) {
     for (let x = 0; x < width; x++) {
       let wsum = 0;
-      let sr = 0, sg = 0, sb = 0;
+      let sr = 0,
+        sg = 0,
+        sb = 0;
       for (let dy = -r; dy <= r; dy++) {
         const yi = Math.min(Math.max(y + dy, 0), height - 1);
         for (let dx = -r; dx <= r; dx++) {
@@ -230,11 +232,11 @@ function weightedBoxBlur3(
       }
       const oi = y * width + x;
       if (wsum > 1e-6) {
-        out[oi * 3]     = sr / wsum;
+        out[oi * 3] = sr / wsum;
         out[oi * 3 + 1] = sg / wsum;
         out[oi * 3 + 2] = sb / wsum;
       } else {
-        out[oi * 3]     = src[oi * 3];
+        out[oi * 3] = src[oi * 3];
         out[oi * 3 + 1] = src[oi * 3 + 1];
         out[oi * 3 + 2] = src[oi * 3 + 2];
       }
@@ -244,7 +246,13 @@ function weightedBoxBlur3(
 }
 
 /** Bilinear upsample of a 3-channel interleaved Float32 buffer. */
-function upsample3(src: Float32Array, srcW: number, srcH: number, dstW: number, dstH: number): Float32Array {
+function upsample3(
+  src: Float32Array,
+  srcW: number,
+  srcH: number,
+  dstW: number,
+  dstH: number,
+): Float32Array {
   const dst = new Float32Array(dstW * dstH * 3);
   const xRatio = srcW > 1 ? (srcW - 1) / (dstW - 1 || 1) : 0;
   const yRatio = srcH > 1 ? (srcH - 1) / (dstH - 1 || 1) : 0;
@@ -278,8 +286,11 @@ function upsample3(src: Float32Array, srcW: number, srcH: number, dstW: number, 
 
 /** 2× downsample of an RGBA buffer into (dstW × dstH) using 2×2 averaging. */
 function downsample2xRGBA(
-  src: Uint8ClampedArray, srcW: number, srcH: number,
-  dstW: number, dstH: number,
+  src: Uint8ClampedArray,
+  srcW: number,
+  srcH: number,
+  dstW: number,
+  dstH: number,
 ): Uint8ClampedArray {
   const dst = new Uint8ClampedArray(dstW * dstH * 4);
   for (let y = 0; y < dstH; y++) {
@@ -289,8 +300,11 @@ function downsample2xRGBA(
       const x0 = Math.min(x * 2, srcW - 1);
       const x1 = Math.min(x0 + 1, srcW - 1);
       for (let ch = 0; ch < 3; ch++) {
-        const s = src[(y0 * srcW + x0) * 4 + ch] + src[(y0 * srcW + x1) * 4 + ch]
-                + src[(y1 * srcW + x0) * 4 + ch] + src[(y1 * srcW + x1) * 4 + ch];
+        const s =
+          src[(y0 * srcW + x0) * 4 + ch] +
+          src[(y0 * srcW + x1) * 4 + ch] +
+          src[(y1 * srcW + x0) * 4 + ch] +
+          src[(y1 * srcW + x1) * 4 + ch];
         dst[(y * dstW + x) * 4 + ch] = (s + 2) >> 2;
       }
       dst[(y * dstW + x) * 4 + 3] = 255;
@@ -301,8 +315,11 @@ function downsample2xRGBA(
 
 /** 2× downsample of a Uint8 buffer using 2×2 averaging. */
 function downsample2xU8(
-  src: Uint8Array, srcW: number, srcH: number,
-  dstW: number, dstH: number,
+  src: Uint8Array,
+  srcW: number,
+  srcH: number,
+  dstW: number,
+  dstH: number,
 ): Uint8Array {
   const dst = new Uint8Array(dstW * dstH);
   for (let y = 0; y < dstH; y++) {
@@ -311,8 +328,8 @@ function downsample2xU8(
     for (let x = 0; x < dstW; x++) {
       const x0 = Math.min(x * 2, srcW - 1);
       const x1 = Math.min(x0 + 1, srcW - 1);
-      const s = src[y0 * srcW + x0] + src[y0 * srcW + x1]
-              + src[y1 * srcW + x0] + src[y1 * srcW + x1];
+      const s =
+        src[y0 * srcW + x0] + src[y0 * srcW + x1] + src[y1 * srcW + x0] + src[y1 * srcW + x1];
       dst[y * dstW + x] = (s + 2) >> 2;
     }
   }

--- a/src/workers/cv/grid-flood-fill.ts
+++ b/src/workers/cv/grid-flood-fill.ts
@@ -13,7 +13,7 @@ export function gridFloodFill(
   colorLight: number[],
   gridSize: number,
   phase: number,
-  tolerance: number = CV_PARAMS.COLOR_TOLERANCE
+  tolerance: number = CV_PARAMS.COLOR_TOLERANCE,
 ): Uint8Array {
   const totalPixels = width * height;
   const potentialBg = new Uint8Array(totalPixels);
@@ -33,9 +33,7 @@ export function gridFloodFill(
       const diffLight = maxChannelDiff(pixels, idx, colorLight);
 
       // Grid-aware match: pixel matches expected color for its cell
-      const gridMatch = parity === 0
-        ? diffDark <= tolerance
-        : diffLight <= tolerance;
+      const gridMatch = parity === 0 ? diffDark <= tolerance : diffLight <= tolerance;
 
       // Near boundary: accept either color for connectivity
       const distBx = Math.min(x % gridSize, gridSize - 1 - (x % gridSize));

--- a/src/workers/cv/inpaint-telea.ts
+++ b/src/workers/cv/inpaint-telea.ts
@@ -147,7 +147,7 @@ export function inpaintTelea(
   for (let i = 0; i < size; i++) {
     const inMask = mask[i] ? 1 : 0;
     const inDilated = dilated[i] ? 1 : 0;
-    flag[i] = (inDilated * 2) - (inMask ^ inDilated);
+    flag[i] = inDilated * 2 - (inMask ^ inDilated);
     if (flag[i] === UNKNOWN) {
       u[i] = LARGE_VALUE;
     }

--- a/src/workers/cv/lama-crop.ts
+++ b/src/workers/cv/lama-crop.ts
@@ -19,7 +19,10 @@ export function computeLamaCropRect(
   width: number,
   height: number,
 ): LamaCropRect | null {
-  let minX = width, minY = height, maxX = -1, maxY = -1;
+  let minX = width,
+    minY = height,
+    maxX = -1,
+    maxY = -1;
   for (let y = 0; y < height; y++) {
     const row = y * width;
     for (let x = 0; x < width; x++) {
@@ -118,7 +121,10 @@ export function nearestResizeMask(
   for (let ty = 0; ty < targetSize; ty++) {
     const srcY = Math.min(rect.y + rect.h - 1, Math.max(rect.y, Math.round(rect.y + ty * scaleY)));
     for (let tx = 0; tx < targetSize; tx++) {
-      const srcX = Math.min(rect.x + rect.w - 1, Math.max(rect.x, Math.round(rect.x + tx * scaleX)));
+      const srcX = Math.min(
+        rect.x + rect.w - 1,
+        Math.max(rect.x, Math.round(rect.x + tx * scaleX)),
+      );
       dst[ty * targetSize + tx] = src[srcY * srcWidth + srcX] ? 1 : 0;
     }
   }

--- a/src/workers/cv/lama-router.ts
+++ b/src/workers/cv/lama-router.ts
@@ -58,7 +58,10 @@ function expandedMaskBbox(
   height: number,
   margin: number,
 ): { x: number; y: number; w: number; h: number } | null {
-  let minX = width, minY = height, maxX = -1, maxY = -1;
+  let minX = width,
+    minY = height,
+    maxX = -1,
+    maxY = -1;
   for (let y = 0; y < height; y++) {
     const row = y * width;
     for (let x = 0; x < width; x++) {
@@ -87,7 +90,9 @@ function luminanceVariance(
   width: number,
   bbox: { x: number; y: number; w: number; h: number },
 ): number {
-  let sum = 0, sumSq = 0, n = 0;
+  let sum = 0,
+    sumSq = 0,
+    n = 0;
   for (let y = bbox.y; y < bbox.y + bbox.h; y++) {
     const row = y * width * 4;
     for (let x = bbox.x; x < bbox.x + bbox.w; x++) {
@@ -108,18 +113,25 @@ function sobelMeanMagnitude(
   bbox: { x: number; y: number; w: number; h: number },
 ): number {
   if (bbox.w < 3 || bbox.h < 3) return 0;
-  let sum = 0, n = 0;
+  let sum = 0,
+    n = 0;
   for (let y = bbox.y + 1; y < bbox.y + bbox.h - 1; y++) {
     for (let x = bbox.x + 1; x < bbox.x + bbox.w - 1; x++) {
-      const p = (ix: number, iy: number): number =>
-        luminance(pixels, (iy * width + ix) * 4);
+      const p = (ix: number, iy: number): number => luminance(pixels, (iy * width + ix) * 4);
       const gx =
-        -p(x - 1, y - 1) + p(x + 1, y - 1) +
-        -2 * p(x - 1, y) + 2 * p(x + 1, y) +
-        -p(x - 1, y + 1) + p(x + 1, y + 1);
+        -p(x - 1, y - 1) +
+        p(x + 1, y - 1) +
+        -2 * p(x - 1, y) +
+        2 * p(x + 1, y) +
+        -p(x - 1, y + 1) +
+        p(x + 1, y + 1);
       const gy =
-        -p(x - 1, y - 1) - 2 * p(x, y - 1) - p(x + 1, y - 1) +
-        p(x - 1, y + 1) + 2 * p(x, y + 1) + p(x + 1, y + 1);
+        -p(x - 1, y - 1) -
+        2 * p(x, y - 1) -
+        p(x + 1, y - 1) +
+        p(x - 1, y + 1) +
+        2 * p(x, y + 1) +
+        p(x + 1, y + 1);
       sum += Math.sqrt(gx * gx + gy * gy);
       n++;
     }

--- a/src/workers/cv/patchmatch-inpaint.ts
+++ b/src/workers/cv/patchmatch-inpaint.ts
@@ -55,7 +55,7 @@ function makeRng(seed: number) {
     s ^= s << 13;
     s ^= s >>> 17;
     s ^= s << 5;
-    return ((s >>> 0) / 0xffffffff);
+    return (s >>> 0) / 0xffffffff;
   };
 }
 
@@ -126,7 +126,9 @@ export function initNNF(
         continue;
       }
       // Reject-sample a valid source
-      let sx = 0, sy = 0, tries = 0;
+      let sx = 0,
+        sy = 0,
+        tries = 0;
       do {
         sx = patchRadius + Math.floor(rng() * validSpanX);
         sy = patchRadius + Math.floor(rng() * validSpanY);
@@ -175,8 +177,17 @@ export function patchMatchInpaint(
     // Alternate scan direction between passes for fast propagation.
     const forward = (iter & 1) === 0;
     patchMatchPass(
-      work, width, height, mask, patchRadius, nnf, dist, searchRegion, rng,
-      forward, maxRadius,
+      work,
+      width,
+      height,
+      mask,
+      patchRadius,
+      nnf,
+      dist,
+      searchRegion,
+      rng,
+      forward,
+      maxRadius,
     );
     voteReconstruct(src, work, width, height, mask, patchRadius, nnf);
     // Distances are stale after voting; recompute for masked pixels.
@@ -212,7 +223,10 @@ function seedMaskedWithLocalMean(
   mask: Uint8Array,
 ): void {
   // Find mask bounding box
-  let minX = width, minY = height, maxX = -1, maxY = -1;
+  let minX = width,
+    minY = height,
+    maxX = -1,
+    maxY = -1;
   for (let y = 0; y < height; y++) {
     for (let x = 0; x < width; x++) {
       if (!mask[y * width + x]) continue;
@@ -225,14 +239,21 @@ function seedMaskedWithLocalMean(
   if (maxX < 0) return;
   // Take a ring around the bbox as reference
   const pad = Math.max(8, Math.floor(Math.max(maxX - minX, maxY - minY) * 0.5));
-  const rx0 = Math.max(0, minX - pad), rx1 = Math.min(width - 1, maxX + pad);
-  const ry0 = Math.max(0, minY - pad), ry1 = Math.min(height - 1, maxY + pad);
-  let r = 0, g = 0, b = 0, n = 0;
+  const rx0 = Math.max(0, minX - pad),
+    rx1 = Math.min(width - 1, maxX + pad);
+  const ry0 = Math.max(0, minY - pad),
+    ry1 = Math.min(height - 1, maxY + pad);
+  let r = 0,
+    g = 0,
+    b = 0,
+    n = 0;
   for (let y = ry0; y <= ry1; y++) {
     for (let x = rx0; x <= rx1; x++) {
       if (mask[y * width + x]) continue;
       const i = (y * width + x) * 4;
-      r += img[i]; g += img[i + 1]; b += img[i + 2];
+      r += img[i];
+      g += img[i + 1];
+      b += img[i + 2];
       n++;
     }
   }
@@ -243,7 +264,10 @@ function seedMaskedWithLocalMean(
   for (let i = 0; i < mask.length; i++) {
     if (!mask[i]) continue;
     const p = i * 4;
-    img[p] = r; img[p + 1] = g; img[p + 2] = b; img[p + 3] = 255;
+    img[p] = r;
+    img[p + 1] = g;
+    img[p + 2] = b;
+    img[p + 3] = 255;
   }
 }
 
@@ -259,9 +283,16 @@ function computeInitialDistances(
   for (let y = 0; y < height; y++) {
     for (let x = 0; x < width; x++) {
       const idx = y * width + x;
-      if (!mask[idx]) { dist[idx] = 0; continue; }
-      if (!fits(x, y, width, height, patchRadius)) { dist[idx] = Infinity; continue; }
-      const sx = nnf[idx * 2], sy = nnf[idx * 2 + 1];
+      if (!mask[idx]) {
+        dist[idx] = 0;
+        continue;
+      }
+      if (!fits(x, y, width, height, patchRadius)) {
+        dist[idx] = Infinity;
+        continue;
+      }
+      const sx = nnf[idx * 2],
+        sy = nnf[idx * 2 + 1];
       dist[idx] = patchDistance(work, work, width, height, x, y, sx, sy, patchRadius);
     }
   }
@@ -281,7 +312,8 @@ function recomputeMaskedDistances(
       const idx = y * width + x;
       if (!mask[idx]) continue;
       if (!fits(x, y, width, height, patchRadius)) continue;
-      const sx = nnf[idx * 2], sy = nnf[idx * 2 + 1];
+      const sx = nnf[idx * 2],
+        sy = nnf[idx * 2 + 1];
       dist[idx] = patchDistance(work, work, width, height, x, y, sx, sy, patchRadius);
     }
   }
@@ -336,7 +368,11 @@ function patchMatchPass(
         const candY = nnf[nidx * 2 + 1];
         if (isValidSource(candX, candY, width, height, mask, patchRadius, searchRegion)) {
           const d = patchDistance(work, work, width, height, x, y, candX, candY, patchRadius);
-          if (d < bestD) { bestD = d; bestSx = candX; bestSy = candY; }
+          if (d < bestD) {
+            bestD = d;
+            bestSx = candX;
+            bestSy = candY;
+          }
         }
       }
       // ── Propagation from vertical neighbour ──
@@ -347,7 +383,11 @@ function patchMatchPass(
         const candY = nnf[nidx * 2 + 1] - off;
         if (isValidSource(candX, candY, width, height, mask, patchRadius, searchRegion)) {
           const d = patchDistance(work, work, width, height, x, y, candX, candY, patchRadius);
-          if (d < bestD) { bestD = d; bestSx = candX; bestSy = candY; }
+          if (d < bestD) {
+            bestD = d;
+            bestSx = candX;
+            bestSy = candY;
+          }
         }
       }
 
@@ -358,7 +398,11 @@ function patchMatchPass(
         const candY = Math.round(bestSy + (rng() * 2 - 1) * radius);
         if (isValidSource(candX, candY, width, height, mask, patchRadius, searchRegion)) {
           const d = patchDistance(work, work, width, height, x, y, candX, candY, patchRadius);
-          if (d < bestD) { bestD = d; bestSx = candX; bestSy = candY; }
+          if (d < bestD) {
+            bestD = d;
+            bestSx = candX;
+            bestSy = candY;
+          }
         }
         radius = Math.floor(radius / 2);
       }
@@ -418,7 +462,8 @@ function voteReconstruct(
       // contribution averages over all overlapping source patches.
       for (let dy = -patchRadius; dy <= patchRadius; dy++) {
         for (let dx = -patchRadius; dx <= patchRadius; dx++) {
-          const tx = x + dx, ty = y + dy;
+          const tx = x + dx,
+            ty = y + dy;
           if (tx < 0 || ty < 0 || tx >= width || ty >= height) continue;
           const tIdx = ty * width + tx;
           if (!mask[tIdx]) continue; // only write masked pixels

--- a/src/workers/cv/shadow-cleanup.ts
+++ b/src/workers/cv/shadow-cleanup.ts
@@ -10,7 +10,7 @@ export function shadowCleanup(
   width: number,
   height: number,
   mask: Uint8Array,
-  maxBlobSize: number = SHADOW_PARAMS.MAX_BLOB_SIZE
+  maxBlobSize: number = SHADOW_PARAMS.MAX_BLOB_SIZE,
 ): Uint8Array {
   const result = new Uint8Array(mask);
   const totalPixels = width * height;
@@ -32,9 +32,11 @@ export function shadowCleanup(
       const sat = mx > 0 ? (mx - mn) / mx : 0;
       const brightness = (r + g + b) / 3;
 
-      if (sat < SHADOW_PARAMS.SATURATION_THRESHOLD &&
-          brightness < SHADOW_PARAMS.BRIGHTNESS_MAX &&
-          brightness > SHADOW_PARAMS.BRIGHTNESS_MIN) {
+      if (
+        sat < SHADOW_PARAMS.SATURATION_THRESHOLD &&
+        brightness < SHADOW_PARAMS.BRIGHTNESS_MAX &&
+        brightness > SHADOW_PARAMS.BRIGHTNESS_MIN
+      ) {
         candidate[pos] = 1;
       }
     }

--- a/src/workers/cv/signature-threshold.ts
+++ b/src/workers/cv/signature-threshold.ts
@@ -42,7 +42,7 @@ export function signatureThreshold(
       alpha[i] = 0; // solid background
     } else {
       // Anti-aliased transition: linear interpolation across the band
-      alpha[i] = Math.round(255 * (diff + halfBand) / P.AA_BAND_SIZE);
+      alpha[i] = Math.round((255 * (diff + halfBand)) / P.AA_BAND_SIZE);
     }
   }
 

--- a/src/workers/cv/simple-flood-fill.ts
+++ b/src/workers/cv/simple-flood-fill.ts
@@ -11,7 +11,7 @@ export function simpleFloodFill(
   height: number,
   colorA: number[],
   colorB: number[],
-  tolerance: number = CV_PARAMS.COLOR_TOLERANCE
+  tolerance: number = CV_PARAMS.COLOR_TOLERANCE,
 ): Uint8Array {
   const totalPixels = width * height;
 

--- a/src/workers/cv/sparkle-detect.ts
+++ b/src/workers/cv/sparkle-detect.ts
@@ -86,25 +86,47 @@ export function sparkleDetect(
     const outerC = Math.round(r * 1.5);
     const outerD = Math.round(r * 1.06);
     return {
-      arm: [[-arm, 0], [arm, 0], [0, -arm], [0, arm]],
+      arm: [
+        [-arm, 0],
+        [arm, 0],
+        [0, -arm],
+        [0, arm],
+      ],
       // Two perpendicular samples per arm (8 total) — arms are narrow lines,
       // so perpendicular offsets land in dark gap territory for a real sparkle.
       perp: [
-        [-arm, -perp], [-arm, perp],  // north arm sides
-        [arm, -perp], [arm, perp],    // south arm sides
-        [-perp, arm], [perp, arm],    // east arm sides
-        [-perp, -arm], [perp, -arm],  // west arm sides
+        [-arm, -perp],
+        [-arm, perp], // north arm sides
+        [arm, -perp],
+        [arm, perp], // south arm sides
+        [-perp, arm],
+        [perp, arm], // east arm sides
+        [-perp, -arm],
+        [perp, -arm], // west arm sides
       ],
-      gap: [[-gap, -gap], [-gap, gap], [gap, -gap], [gap, gap]],
+      gap: [
+        [-gap, -gap],
+        [-gap, gap],
+        [gap, -gap],
+        [gap, gap],
+      ],
       outer: [
-        [-outerC, 0], [outerC, 0], [0, -outerC], [0, outerC],
-        [-outerD, -outerD], [-outerD, outerD], [outerD, -outerD], [outerD, outerD],
+        [-outerC, 0],
+        [outerC, 0],
+        [0, -outerC],
+        [0, outerC],
+        [-outerD, -outerD],
+        [-outerD, outerD],
+        [outerD, -outerD],
+        [outerD, outerD],
       ],
     };
   });
 
   let bestScore = 0;
-  let bestY = -1, bestX = -1, bestR = 0;
+  let bestY = -1,
+    bestX = -1,
+    bestR = 0;
   const stride = SPARKLE_PARAMS.CANDIDATE_STRIDE;
 
   for (let cy = yStart; cy < yEnd; cy += stride) {
@@ -140,7 +162,8 @@ export function sparkleDetect(
           ((a0 - meanA) * (a0 - meanA) +
             (a1 - meanA) * (a1 - meanA) +
             (a2 - meanA) * (a2 - meanA) +
-            (a3 - meanA) * (a3 - meanA)) / 4;
+            (a3 - meanA) * (a3 - meanA)) /
+          4;
         const stdA = Math.sqrt(varA);
         if (stdA / meanA > SPARKLE_PARAMS.MAX_ARM_CV) continue;
 

--- a/src/workers/cv/subject-exclusion.ts
+++ b/src/workers/cv/subject-exclusion.ts
@@ -21,7 +21,7 @@ export function subjectExclusion(
   _colorLight: number[],
   _gridSize: number,
   _phase: number,
-  _tolerance: number = CV_PARAMS.COLOR_TOLERANCE
+  _tolerance: number = CV_PARAMS.COLOR_TOLERANCE,
 ): Uint8Array {
   const totalPixels = width * height;
 
@@ -39,7 +39,10 @@ export function subjectExclusion(
       const sat = mx > 0 ? (mx - mn) / mx : 0;
       const brightness = (r + g + b) / 3;
 
-      if (sat > CV_PARAMS.CELL_SATURATION_THRESHOLD && brightness > CV_PARAMS.CELL_BRIGHTNESS_THRESHOLD) {
+      if (
+        sat > CV_PARAMS.CELL_SATURATION_THRESHOLD &&
+        brightness > CV_PARAMS.CELL_BRIGHTNESS_THRESHOLD
+      ) {
         colored[y * width + x] = 1;
       }
     }
@@ -65,7 +68,12 @@ export function subjectExclusion(
           const [cy, cx] = queue.pop();
           count++;
 
-          for (const [dy, dx] of [[-1, 0], [1, 0], [0, -1], [0, 1]] as const) {
+          for (const [dy, dx] of [
+            [-1, 0],
+            [1, 0],
+            [0, -1],
+            [0, 1],
+          ] as const) {
             const ny = cy + dy;
             const nx = cx + dx;
             if (ny >= 0 && ny < height && nx >= 0 && nx < width) {
@@ -132,7 +140,12 @@ export function subjectExclusion(
         if (!mask[y * width + x]) continue;
         // Keep pixel only if ALL 4-connected neighbors are also set
         let allSet = true;
-        for (const [dy, dx] of [[-1, 0], [1, 0], [0, -1], [0, 1]] as const) {
+        for (const [dy, dx] of [
+          [-1, 0],
+          [1, 0],
+          [0, -1],
+          [0, 1],
+        ] as const) {
           const ny = y + dy;
           const nx = x + dx;
           if (ny >= 0 && ny < height && nx >= 0 && nx < width) {

--- a/src/workers/cv/utils.ts
+++ b/src/workers/cv/utils.ts
@@ -64,15 +64,11 @@ export function pixelIndex(x: number, y: number, width: number): number {
 }
 
 /** Max channel difference between pixel at (x,y) and an RGB color */
-export function maxChannelDiff(
-  pixels: Uint8ClampedArray,
-  idx: number,
-  color: number[]
-): number {
+export function maxChannelDiff(pixels: Uint8ClampedArray, idx: number, color: number[]): number {
   return Math.max(
     Math.abs(pixels[idx] - color[0]),
     Math.abs(pixels[idx + 1] - color[1]),
-    Math.abs(pixels[idx + 2] - color[2])
+    Math.abs(pixels[idx + 2] - color[2]),
   );
 }
 
@@ -101,7 +97,5 @@ export function median(arr: number[]): number {
   if (arr.length === 0) return 0;
   const sorted = arr.slice().sort((a, b) => a - b);
   const mid = Math.floor(sorted.length / 2);
-  return sorted.length % 2 !== 0
-    ? sorted[mid]
-    : (sorted[mid - 1] + sorted[mid]) / 2;
+  return sorted.length % 2 !== 0 ? sorted[mid] : (sorted[mid - 1] + sorted[mid]) / 2;
 }

--- a/src/workers/cv/watermark-dalle.ts
+++ b/src/workers/cv/watermark-dalle.ts
@@ -25,7 +25,9 @@ export function watermarkDetectDalle(
   for (let y = height - scanH; y < height; y++) {
     // Recoger colores de la linea en la zona derecha
     const colors = new Set<number>();
-    let sumR = 0, sumG = 0, sumB = 0;
+    let sumR = 0,
+      sumG = 0,
+      sumB = 0;
     let count = 0;
 
     for (let x = width - scanW; x < width; x++) {
@@ -63,17 +65,25 @@ export function watermarkDetectDalle(
     if (colors.size <= refColors.size * contrastThreshold) continue;
 
     // Verify there is real hue variation (not just brightness noise)
-    let minR = 255, maxR = 0, minG = 255, maxG = 0, minB = 255, maxB = 0;
+    let minR = 255,
+      maxR = 0,
+      minG = 255,
+      maxG = 0,
+      minB = 255,
+      maxB = 0;
     for (let x = width - scanW; x < width; x++) {
       const idx = pixelIndex(x, y, width);
       const r = pixels[idx];
       const g = pixels[idx + 1];
       const b = pixels[idx + 2];
-      minR = Math.min(minR, r); maxR = Math.max(maxR, r);
-      minG = Math.min(minG, g); maxG = Math.max(maxG, g);
-      minB = Math.min(minB, b); maxB = Math.max(maxB, b);
+      minR = Math.min(minR, r);
+      maxR = Math.max(maxR, r);
+      minG = Math.min(minG, g);
+      maxG = Math.max(maxG, g);
+      minB = Math.min(minB, b);
+      maxB = Math.max(maxB, b);
     }
-    const channelSpread = (maxR - minR) + (maxG - minG) + (maxB - minB);
+    const channelSpread = maxR - minR + (maxG - minG) + (maxB - minB);
     if (channelSpread < DALLE_WATERMARK_PARAMS.MIN_CHANNEL_SPREAD) continue;
 
     // Esta linea parece parte del watermark

--- a/src/workers/cv/watermark-detect.ts
+++ b/src/workers/cv/watermark-detect.ts
@@ -39,11 +39,11 @@ export function watermarkDetect(
   width: number,
   height: number,
   colorA: number[],
-  colorB: number[]
+  colorB: number[],
 ): WatermarkResult {
   let scanSize = Math.max(
     WATERMARK_PARAMS.MIN_SCAN_SIZE,
-    Math.floor(Math.min(height, width) / WATERMARK_PARAMS.SCAN_FRACTION)
+    Math.floor(Math.min(height, width) / WATERMARK_PARAMS.SCAN_FRACTION),
   );
   scanSize = Math.min(scanSize, Math.floor(Math.min(height, width) / 2));
 
@@ -65,12 +65,12 @@ export function watermarkDetect(
         const diffA = Math.max(
           Math.abs(r - colorA[0]),
           Math.abs(g - colorA[1]),
-          Math.abs(b - colorA[2])
+          Math.abs(b - colorA[2]),
         );
         const diffB = Math.max(
           Math.abs(r - colorB[0]),
           Math.abs(g - colorB[1]),
-          Math.abs(b - colorB[2])
+          Math.abs(b - colorB[2]),
         );
         const deviation = Math.min(diffA, diffB);
 
@@ -96,7 +96,8 @@ export function watermarkDetect(
   }
 
   // Compute center
-  let sumY = 0, sumX = 0;
+  let sumY = 0,
+    sumX = 0;
   for (const [ly, lx] of sparkleCoords) {
     sumY += ly;
     sumX += lx;
@@ -120,7 +121,10 @@ export function watermarkDetect(
   const cxAbs = width - scanSize + cxLocal;
 
   // Compute spread and radius
-  let minY = Infinity, maxY = -Infinity, minX = Infinity, maxX = -Infinity;
+  let minY = Infinity,
+    maxY = -Infinity,
+    minX = Infinity,
+    maxX = -Infinity;
   for (const [ly, lx] of sparkleCoords) {
     minY = Math.min(minY, ly);
     maxY = Math.max(maxY, ly);
@@ -148,12 +152,12 @@ export function watermarkDetect(
         const diffA = Math.max(
           Math.abs(r - colorA[0]),
           Math.abs(g - colorA[1]),
-          Math.abs(b - colorA[2])
+          Math.abs(b - colorA[2]),
         );
         const diffB = Math.max(
           Math.abs(r - colorB[0]),
           Math.abs(g - colorB[1]),
-          Math.abs(b - colorB[2])
+          Math.abs(b - colorB[2]),
         );
         const dev = Math.min(diffA, diffB);
         if (dev > WATERMARK_PARAMS.HALO_DEVIATION_THRESHOLD && isGeminiSparkleColor(r, g, b)) {

--- a/src/workers/inpaint.worker.ts
+++ b/src/workers/inpaint.worker.ts
@@ -17,7 +17,11 @@ async function inpaint(
   height: number,
   mask: Uint8Array,
 ): Promise<void> {
-  self.postMessage({ id, type: 'inpaint-progress', stage: 'processing' } satisfies InpaintWorkerResponse);
+  self.postMessage({
+    id,
+    type: 'inpaint-progress',
+    stage: 'processing',
+  } satisfies InpaintWorkerResponse);
 
   const resultPixels = patchMatchInpaint(pixels, width, height, mask, {
     iterations: PATCHMATCH_PARAMS.ITERATIONS,
@@ -46,6 +50,10 @@ self.onmessage = async (e: MessageEvent<InpaintWorkerRequest>) => {
       }
     }
   } catch (err) {
-    self.postMessage({ id: msg.id, type: 'error', error: String(err) } satisfies InpaintWorkerResponse);
+    self.postMessage({
+      id: msg.id,
+      type: 'error',
+      error: String(err),
+    } satisfies InpaintWorkerResponse);
   }
 };

--- a/src/workers/lama.worker.ts
+++ b/src/workers/lama.worker.ts
@@ -32,8 +32,7 @@ import {
 // script-src and connect-src (transformers.js reaches the same CDN).
 // Bump this version string in lockstep with package.json's onnxruntime-web
 // dependency so the runtime matches the JS API we link against.
-ort.env.wasm.wasmPaths =
-  'https://cdn.jsdelivr.net/npm/onnxruntime-web@1.24.3/dist/';
+ort.env.wasm.wasmPaths = 'https://cdn.jsdelivr.net/npm/onnxruntime-web@1.24.3/dist/';
 
 // The LaMa graph has ~80 unused Conv shape initializers that ORT logs as
 // warnings at session-create time. They're harmless (graph optimiser
@@ -70,9 +69,11 @@ async function loadModel(id: string): Promise<ort.InferenceSession> {
         const pct = Math.floor((received / total) * 100);
         if (pct !== lastReportedPct) {
           lastReportedPct = pct;
-          self.postMessage(
-            { id, type: 'lama-model-progress', progress: pct } satisfies LamaWorkerResponse,
-          );
+          self.postMessage({
+            id,
+            type: 'lama-model-progress',
+            progress: pct,
+          } satisfies LamaWorkerResponse);
         }
       }
     }
@@ -82,14 +83,12 @@ async function loadModel(id: string): Promise<ort.InferenceSession> {
     // with an opaque "failed to load model" — we want a specific,
     // retryable error instead.
     if (total > 0 && received !== total) {
-      throw new Error(
-        `Truncated LaMa model download: got ${received} / ${total} bytes`,
-      );
+      throw new Error(`Truncated LaMa model download: got ${received} / ${total} bytes`);
     }
     if (received !== LAMA_PARAMS.EXPECTED_SIZE) {
       throw new Error(
         `LaMa model size mismatch: got ${received} bytes, expected ` +
-        `${LAMA_PARAMS.EXPECTED_SIZE}. Upstream may have been replaced.`,
+          `${LAMA_PARAMS.EXPECTED_SIZE}. Upstream may have been replaced.`,
       );
     }
 
@@ -110,7 +109,7 @@ async function loadModel(id: string): Promise<ort.InferenceSession> {
     if (digestHex !== LAMA_PARAMS.EXPECTED_SHA256) {
       throw new Error(
         `LaMa model hash mismatch: got ${digestHex}, ` +
-        `expected ${LAMA_PARAMS.EXPECTED_SHA256}. Refusing to load.`,
+          `expected ${LAMA_PARAMS.EXPECTED_SHA256}. Refusing to load.`,
       );
     }
 
@@ -138,9 +137,9 @@ function rgbaToImageTensor(rgba: Uint8ClampedArray, size: number): ort.Tensor {
   const plane = size * size;
   const data = new Float32Array(3 * plane);
   for (let i = 0; i < plane; i++) {
-    data[i] = rgba[i * 4] / 255;                 // R
-    data[plane + i] = rgba[i * 4 + 1] / 255;      // G
-    data[2 * plane + i] = rgba[i * 4 + 2] / 255;  // B
+    data[i] = rgba[i * 4] / 255; // R
+    data[plane + i] = rgba[i * 4 + 1] / 255; // G
+    data[2 * plane + i] = rgba[i * 4 + 2] / 255; // B
   }
   return new ort.Tensor('float32', data, [1, 3, size, size]);
 }
@@ -160,9 +159,9 @@ function imageTensorToRgba(tensor: ort.Tensor, size: number): Uint8ClampedArray 
   const plane = size * size;
   const rgba = new Uint8ClampedArray(size * size * 4);
   for (let i = 0; i < plane; i++) {
-    rgba[i * 4] = data[i];                   // R
-    rgba[i * 4 + 1] = data[plane + i];       // G
-    rgba[i * 4 + 2] = data[2 * plane + i];   // B
+    rgba[i * 4] = data[i]; // R
+    rgba[i * 4 + 1] = data[plane + i]; // G
+    rgba[i * 4 + 2] = data[2 * plane + i]; // B
     rgba[i * 4 + 3] = 255;
   }
   return rgba;
@@ -175,21 +174,27 @@ async function runInpaint(
   height: number,
   mask: Uint8Array,
 ): Promise<void> {
-  self.postMessage(
-    { id, type: 'lama-inpaint-progress', stage: 'loading-model' } satisfies LamaWorkerResponse,
-  );
+  self.postMessage({
+    id,
+    type: 'lama-inpaint-progress',
+    stage: 'loading-model',
+  } satisfies LamaWorkerResponse);
   const sess = await loadModel(id);
 
-  self.postMessage(
-    { id, type: 'lama-inpaint-progress', stage: 'preparing-tensors' } satisfies LamaWorkerResponse,
-  );
+  self.postMessage({
+    id,
+    type: 'lama-inpaint-progress',
+    stage: 'preparing-tensors',
+  } satisfies LamaWorkerResponse);
 
   const rect = computeLamaCropRect(mask, width, height);
   if (!rect) {
     // Empty mask — nothing to reconstruct. Return the input unchanged.
-    self.postMessage(
-      { id, type: 'lama-inpaint-result', result: new Uint8ClampedArray(pixels) } satisfies LamaWorkerResponse,
-    );
+    self.postMessage({
+      id,
+      type: 'lama-inpaint-result',
+      result: new Uint8ClampedArray(pixels),
+    } satisfies LamaWorkerResponse);
     return;
   }
 
@@ -200,9 +205,11 @@ async function runInpaint(
   const imageTensor = rgbaToImageTensor(cropRgba, inputSize);
   const maskTensor = maskToTensor(cropMask, inputSize);
 
-  self.postMessage(
-    { id, type: 'lama-inpaint-progress', stage: 'running-inference' } satisfies LamaWorkerResponse,
-  );
+  self.postMessage({
+    id,
+    type: 'lama-inpaint-progress',
+    stage: 'running-inference',
+  } satisfies LamaWorkerResponse);
 
   const feeds: Record<string, ort.Tensor> = {
     [LAMA_PARAMS.IMAGE_INPUT_NAME]: imageTensor,
@@ -212,17 +219,18 @@ async function runInpaint(
   const outputKey = sess.outputNames[0];
   const outputTensor = results[outputKey];
 
-  self.postMessage(
-    { id, type: 'lama-inpaint-progress', stage: 'compositing' } satisfies LamaWorkerResponse,
-  );
+  self.postMessage({
+    id,
+    type: 'lama-inpaint-progress',
+    stage: 'compositing',
+  } satisfies LamaWorkerResponse);
 
   const inpaintedCropRgba = imageTensorToRgba(outputTensor, inputSize);
   const full = spliceLamaOutput(pixels, width, height, inpaintedCropRgba, inputSize, rect);
 
-  self.postMessage(
-    { id, type: 'lama-inpaint-result', result: full } satisfies LamaWorkerResponse,
-    [full.buffer],
-  );
+  self.postMessage({ id, type: 'lama-inpaint-result', result: full } satisfies LamaWorkerResponse, [
+    full.buffer,
+  ]);
 }
 
 self.onmessage = async (e: MessageEvent<LamaWorkerRequest>) => {
@@ -252,8 +260,10 @@ self.onmessage = async (e: MessageEvent<LamaWorkerRequest>) => {
       }
     }
   } catch (err) {
-    self.postMessage(
-      { id: msg.id, type: 'error', error: String(err) } satisfies LamaWorkerResponse,
-    );
+    self.postMessage({
+      id: msg.id,
+      type: 'error',
+      error: String(err),
+    } satisfies LamaWorkerResponse);
   }
 };

--- a/src/workers/ml.worker.ts
+++ b/src/workers/ml.worker.ts
@@ -4,7 +4,12 @@
  * Transformers.js handles ONNX Runtime, WebGPU/WASM detection,
  * model download, caching - all internally.
  */
-import type { MlWorkerRequest, MlRefineOptions, ModelId, WarmupDiagnostic } from '../types/worker-messages';
+import type {
+  MlWorkerRequest,
+  MlRefineOptions,
+  ModelId,
+  WarmupDiagnostic,
+} from '../types/worker-messages';
 import { REFINE_PARAMS } from '../pipeline/constants';
 
 const DEFAULT_MODEL: ModelId = 'briaai/RMBG-1.4';
@@ -19,14 +24,22 @@ const MODEL_REVISIONS: Record<ModelId, string> = {
 
 /** Transformers.js pipeline entry - shape is dynamic from the library */
 interface SegmenterEntry {
-  pipeline: { dispose?: () => void; (image: unknown, opts: unknown): Promise<Array<{ mask?: { data: Uint8Array; width: number; height: number } }>>; };
+  pipeline: {
+    dispose?: () => void;
+    (
+      image: unknown,
+      opts: unknown,
+    ): Promise<Array<{ mask?: { data: Uint8Array; width: number; height: number } }>>;
+  };
   type: string;
 }
 
 /** Cache segmenters by model ID so switching is instant after first load */
 const segmenters = new Map<string, SegmenterEntry>();
 let currentModelId: ModelId = DEFAULT_MODEL;
-let RawImageClass: (new (data: Uint8ClampedArray, w: number, h: number, channels: number) => unknown) | null = null;
+let RawImageClass:
+  | (new (data: Uint8ClampedArray, w: number, h: number, channels: number) => unknown)
+  | null = null;
 
 /** Detect compute device - currently forced to WASM */
 async function detectDevice(): Promise<'webgpu' | 'wasm'> {
@@ -131,13 +144,18 @@ function morphOpen(alpha: Uint8Array, w: number, h: number, radius: number): Uin
     for (let x = 0; x < w; x++) {
       if (alpha[y * w + x] < threshold) continue;
       let allOpaque = true;
-      outer:
-      for (let dy = -radius; dy <= radius; dy++) {
+      outer: for (let dy = -radius; dy <= radius; dy++) {
         for (let dx = -radius; dx <= radius; dx++) {
           const ny = y + dy;
           const nx = x + dx;
-          if (ny < 0 || ny >= h || nx < 0 || nx >= w) { allOpaque = false; break outer; }
-          if (alpha[ny * w + nx] < threshold) { allOpaque = false; break outer; }
+          if (ny < 0 || ny >= h || nx < 0 || nx >= w) {
+            allOpaque = false;
+            break outer;
+          }
+          if (alpha[ny * w + nx] < threshold) {
+            allOpaque = false;
+            break outer;
+          }
         }
       }
       if (allOpaque) eroded[y * w + x] = alpha[y * w + x];
@@ -172,7 +190,13 @@ function morphOpen(alpha: Uint8Array, w: number, h: number, radius: number): Uin
 }
 
 /** Remove small opaque clusters not connected to the main subject */
-function removeSmallClusters(alpha: Uint8Array, w: number, h: number, minSize: number, clusterRatio?: number): Uint8Array {
+function removeSmallClusters(
+  alpha: Uint8Array,
+  w: number,
+  h: number,
+  minSize: number,
+  clusterRatio?: number,
+): Uint8Array {
   const result = new Uint8Array(alpha);
   const visited = new Uint8Array(w * h);
 
@@ -194,7 +218,12 @@ function removeSmallClusters(alpha: Uint8Array, w: number, h: number, minSize: n
       const cx = idx % w;
       const cy = (idx - cx) / w;
 
-      for (const [dx, dy] of [[-1,0],[1,0],[0,-1],[0,1]]) {
+      for (const [dx, dy] of [
+        [-1, 0],
+        [1, 0],
+        [0, -1],
+        [0, 1],
+      ]) {
         const nx = cx + dx;
         const ny = cy + dy;
         if (nx < 0 || nx >= w || ny < 0 || ny >= h) continue;
@@ -211,7 +240,7 @@ function removeSmallClusters(alpha: Uint8Array, w: number, h: number, minSize: n
 
   // Find the largest component (= the subject)
   if (components.length === 0) return result;
-  const maxSize = Math.max(...components.map(c => c.size));
+  const maxSize = Math.max(...components.map((c) => c.size));
 
   // Remove components smaller than CLUSTER_RATIO of the main subject OR below absolute minSize
   const ratio = clusterRatio ?? REFINE_PARAMS.CLUSTER_RATIO;
@@ -228,7 +257,11 @@ function removeSmallClusters(alpha: Uint8Array, w: number, h: number, minSize: n
 }
 
 const progressCb = (id: string) => (progress: { status: string; progress?: number }) => {
-  if (progress.status === 'progress' && progress.progress !== null && progress.progress !== undefined) {
+  if (
+    progress.status === 'progress' &&
+    progress.progress !== null &&
+    progress.progress !== undefined
+  ) {
     const pct = 10 + Math.round(progress.progress * 0.8);
     self.postMessage({ id, type: 'model-progress', progress: pct });
   }
@@ -237,7 +270,11 @@ const progressCb = (id: string) => (progress: { status: string; progress?: numbe
   }
 };
 
-async function loadModel(id: string, modelId: ModelId = DEFAULT_MODEL, emitReady = true): Promise<void> {
+async function loadModel(
+  id: string,
+  modelId: ModelId = DEFAULT_MODEL,
+  emitReady = true,
+): Promise<void> {
   const device = await detectDevice();
 
   if (segmenters.has(modelId)) {
@@ -255,7 +292,9 @@ async function loadModel(id: string, modelId: ModelId = DEFAULT_MODEL, emitReady
       // Free previous model to avoid OOM
       try {
         if (entry.pipeline?.dispose) entry.pipeline.dispose();
-      } catch { /* ignore dispose errors */ }
+      } catch {
+        /* ignore dispose errors */
+      }
       segmenters.delete(key);
     }
   }
@@ -275,7 +314,10 @@ async function loadModel(id: string, modelId: ModelId = DEFAULT_MODEL, emitReady
     revision: MODEL_REVISIONS[modelId],
     progress_callback: progressCb(id),
   });
-  segmenters.set(modelId, { pipeline: seg as unknown as SegmenterEntry['pipeline'], type: 'pipeline' });
+  segmenters.set(modelId, {
+    pipeline: seg as unknown as SegmenterEntry['pipeline'],
+    type: 'pipeline',
+  });
 
   // Warmup: run a tiny inference to force WASM full compilation.
   // This ensures consistent results from the very first real image.
@@ -292,14 +334,20 @@ async function loadModel(id: string, modelId: ModelId = DEFAULT_MODEL, emitReady
     elapsedMs: 0,
     device,
     userAgent: typeof self !== 'undefined' && self.navigator ? self.navigator.userAgent : undefined,
-    hardwareConcurrency: typeof self !== 'undefined' && self.navigator ? self.navigator.hardwareConcurrency : undefined,
+    hardwareConcurrency:
+      typeof self !== 'undefined' && self.navigator
+        ? self.navigator.hardwareConcurrency
+        : undefined,
   };
   try {
     if (RawImageClass) {
       const warmupSize = 256;
       const warmupPixels = new Uint8ClampedArray(warmupSize * warmupSize * 4);
       const warmupImg = new RawImageClass(warmupPixels, warmupSize, warmupSize, 4);
-      const warmupPromise = (seg as unknown as SegmenterEntry['pipeline'])(warmupImg, { threshold: 0.5, return_mask: true });
+      const warmupPromise = (seg as unknown as SegmenterEntry['pipeline'])(warmupImg, {
+        threshold: 0.5,
+        return_mask: true,
+      });
       const timeoutPromise = new Promise<never>((_, reject) => {
         setTimeout(() => reject(new Error(`warmup_timeout_${warmupTimeoutMs}ms`)), warmupTimeoutMs);
       });
@@ -356,10 +404,7 @@ async function segment(
     return_mask: true,
   });
   const segmentTimeout = new Promise<never>((_, reject) => {
-    setTimeout(
-      () => reject(new Error(`segment_timeout_${segmentTimeoutMs}ms`)),
-      segmentTimeoutMs,
-    );
+    setTimeout(() => reject(new Error(`segment_timeout_${segmentTimeoutMs}ms`)), segmentTimeoutMs);
   });
   const results = await Promise.race([segmentPromise, segmentTimeout]);
 
@@ -416,11 +461,11 @@ async function segment(
   }
 
   const totalPx = rawAlpha.length;
-  const allSameRange = (rawMax - rawMin) < 5;
+  const allSameRange = rawMax - rawMin < 5;
   if (allSameRange && totalPx > 100) {
     console.warn(
       `[NukeBG ML] Suspicious mask: min=${rawMin} max=${rawMax} range=${rawMax - rawMin} - ` +
-      `model may have returned uniform output.`
+        `model may have returned uniform output.`,
     );
   }
 
@@ -430,10 +475,7 @@ async function segment(
   // Light edge cleanup: remove isolated residue pixels only.
   const alphaMask = refineEdges(rawAlpha, pixels, width, height, refineOpts);
 
-  self.postMessage(
-    { id, type: 'segment-result', result: alphaMask },
-    [alphaMask.buffer],
-  );
+  self.postMessage({ id, type: 'segment-result', result: alphaMask }, [alphaMask.buffer]);
 }
 
 self.onmessage = async (e: MessageEvent<MlWorkerRequest>) => {
@@ -448,7 +490,15 @@ self.onmessage = async (e: MessageEvent<MlWorkerRequest>) => {
         const { payload } = msg;
         const modelId = msg.modelId || currentModelId;
         const threshold = msg.threshold ?? 0.5;
-        await segment(msg.id, payload.pixels, payload.width, payload.height, modelId, threshold, msg.refine);
+        await segment(
+          msg.id,
+          payload.pixels,
+          payload.width,
+          payload.height,
+          modelId,
+          threshold,
+          msg.refine,
+        );
         break;
       }
     }

--- a/src/workers/sam.worker.ts
+++ b/src/workers/sam.worker.ts
@@ -14,17 +14,14 @@
 import * as ort from 'onnxruntime-web';
 import type { SamWorkerRequest, SamWorkerResponse } from '../types/worker-messages';
 const SAM_PARAMS = {
-  ENCODER_URL:
-    'https://huggingface.co/Acly/MobileSAM/resolve/main/mobile_sam_image_encoder.onnx',
-  DECODER_URL:
-    'https://huggingface.co/Acly/MobileSAM/resolve/main/sam_mask_decoder_single.onnx',
+  ENCODER_URL: 'https://huggingface.co/Acly/MobileSAM/resolve/main/mobile_sam_image_encoder.onnx',
+  DECODER_URL: 'https://huggingface.co/Acly/MobileSAM/resolve/main/sam_mask_decoder_single.onnx',
   INPUT_SIZE: 1024,
   MASK_SIZE: 256,
   MASK_THRESHOLD: 0.0,
 } as const;
 
-ort.env.wasm.wasmPaths =
-  'https://cdn.jsdelivr.net/npm/onnxruntime-web@1.24.3/dist/';
+ort.env.wasm.wasmPaths = 'https://cdn.jsdelivr.net/npm/onnxruntime-web@1.24.3/dist/';
 ort.env.logLevel = 'error';
 
 let encoderSession: ort.InferenceSession | null = null;
@@ -60,15 +57,21 @@ async function fetchModel(
       const pct = Math.floor((received / total) * 100);
       if (pct !== lastPct) {
         lastPct = pct;
-        self.postMessage(
-          { id, type: 'sam-load-progress', progress: pct, stage } satisfies SamWorkerResponse,
-        );
+        self.postMessage({
+          id,
+          type: 'sam-load-progress',
+          progress: pct,
+          stage,
+        } satisfies SamWorkerResponse);
       }
     }
   }
   const buffer = new Uint8Array(received);
   let offset = 0;
-  for (const c of chunks) { buffer.set(c, offset); offset += c.byteLength; }
+  for (const c of chunks) {
+    buffer.set(c, offset);
+    offset += c.byteLength;
+  }
   return buffer;
 }
 
@@ -155,9 +158,9 @@ function bilinearResize(
       for (let c = 0; c < 4; c++) {
         out[idx + c] = Math.round(
           src[i00 + c] * (1 - fx) * (1 - fy) +
-          src[i10 + c] * fx * (1 - fy) +
-          src[i01 + c] * (1 - fx) * fy +
-          src[i11 + c] * fx * fy,
+            src[i10 + c] * fx * (1 - fy) +
+            src[i01 + c] * (1 - fx) * fy +
+            src[i11 + c] * fx * fy,
         );
       }
     }
@@ -165,12 +168,7 @@ function bilinearResize(
   return out;
 }
 
-async function encode(
-  id: string,
-  pixels: Uint8ClampedArray,
-  w: number,
-  h: number,
-): Promise<void> {
+async function encode(id: string, pixels: Uint8ClampedArray, w: number, h: number): Promise<void> {
   await loadModels(id);
   if (!encoderSession) throw new Error('Encoder not loaded');
 
@@ -261,9 +259,13 @@ async function decode(
     }
   }
 
-  self.postMessage(
-    { id, type: 'sam-mask', mask: binary, width: w, height: h } satisfies SamWorkerResponse,
-  );
+  self.postMessage({
+    id,
+    type: 'sam-mask',
+    mask: binary,
+    width: w,
+    height: h,
+  } satisfies SamWorkerResponse);
 }
 
 // ────────────────────────────── Dispose ─────────────────────────────────────
@@ -291,7 +293,13 @@ self.addEventListener('message', async (e: MessageEvent<SamWorkerRequest>) => {
         await encode(msg.id, msg.payload.pixels, msg.payload.width, msg.payload.height);
         break;
       case 'sam-decode':
-        await decode(msg.id, msg.payload.points, msg.payload.labels, msg.payload.width, msg.payload.height);
+        await decode(
+          msg.id,
+          msg.payload.points,
+          msg.payload.labels,
+          msg.payload.width,
+          msg.payload.height,
+        );
         break;
       case 'sam-dispose':
         dispose();

--- a/tests/changelog.test.ts
+++ b/tests/changelog.test.ts
@@ -45,6 +45,8 @@ describe('CHANGELOG.md', () => {
 
   it('ships a release-checklist template and compare link at the bottom', () => {
     expect(CHANGELOG).toMatch(/## Release checklist template/);
-    expect(CHANGELOG).toMatch(/\[Unreleased\]: https:\/\/github\.com\/yocreoquesi\/nukebg\/compare\//);
+    expect(CHANGELOG).toMatch(
+      /\[Unreleased\]: https:\/\/github\.com\/yocreoquesi\/nukebg\/compare\//,
+    );
   });
 });

--- a/tests/color-consistency.test.ts
+++ b/tests/color-consistency.test.ts
@@ -23,8 +23,8 @@ const read = (rel: string) => readFileSync(resolve(root, rel), 'utf8');
 function readComponentFiles(dir: string): { name: string; content: string }[] {
   const absDir = resolve(root, dir);
   return readdirSync(absDir)
-    .filter(f => f.endsWith('.ts'))
-    .map(f => ({ name: join(dir, f), content: readFileSync(resolve(absDir, f), 'utf8') }));
+    .filter((f) => f.endsWith('.ts'))
+    .map((f) => ({ name: join(dir, f), content: readFileSync(resolve(absDir, f), 'utf8') }));
 }
 
 /** Extract CSS template strings from a component file (inside backtick <style>...</style>) */
@@ -40,12 +40,12 @@ function extractCssBlocks(source: string): string[] {
 
 // Theme green hex values that MUST go through CSS variables
 const FORBIDDEN_HEX = [
-  '#00ff41',  // --color-accent-primary / --color-text-primary
-  '#00dd44',  // --color-text-secondary
-  '#00b34a',  // --color-text-tertiary (WCAG AA bump from #008830)
-  '#008830',  // previous tertiary — keep blocked so it can't regress
-  '#1a3a1a',  // --color-surface-border
-  '#ffd700',  // old --color-accent (no longer exists)
+  '#00ff41', // --color-accent-primary / --color-text-primary
+  '#00dd44', // --color-text-secondary
+  '#00b34a', // --color-text-tertiary (WCAG AA bump from #008830)
+  '#008830', // previous tertiary — keep blocked so it can't regress
+  '#1a3a1a', // --color-surface-border
+  '#ffd700', // old --color-accent (no longer exists)
 ];
 
 // Allowed contexts where these hex values appear as CSS variable FALLBACKS
@@ -90,10 +90,7 @@ describe('color consistency — no hardcoded theme colors in components', () => 
           const stripped = stripVarFallbacks(css);
           const regex = /rgba\(\s*0\s*,\s*255\s*,\s*65/gi;
           const matches = stripped.match(regex) || [];
-          expect(
-            matches,
-            `Found hardcoded rgba(0,255,65,...) in ${name} CSS`,
-          ).toHaveLength(0);
+          expect(matches, `Found hardcoded rgba(0,255,65,...) in ${name} CSS`).toHaveLength(0);
         }
       });
 
@@ -101,13 +98,12 @@ describe('color consistency — no hardcoded theme colors in components', () => 
         for (const css of cssBlocks) {
           const regex = /rgba\(\s*255\s*,\s*215\s*,\s*0/gi;
           const matches = stripped(css).match(regex) || [];
-          expect(
-            matches,
-            `Found hardcoded rgba(255,215,0,...) in ${name} CSS`,
-          ).toHaveLength(0);
+          expect(matches, `Found hardcoded rgba(255,215,0,...) in ${name} CSS`).toHaveLength(0);
         }
 
-        function stripped(css: string) { return stripVarFallbacks(css); }
+        function stripped(css: string) {
+          return stripVarFallbacks(css);
+        }
       });
     });
   }
@@ -137,7 +133,7 @@ describe('color consistency — no non-existent CSS variables', () => {
   const components = readComponentFiles('src/components');
   // var(--color-accent, ...) was a common mistake — this variable doesn't exist
   const GHOST_VARS = [
-    '--color-accent,',  // trailing comma = used as var(--color-accent, fallback)
+    '--color-accent,', // trailing comma = used as var(--color-accent, fallback)
   ];
 
   for (const { name, content } of components) {
@@ -156,10 +152,7 @@ describe('color consistency — :host must not shadow theme variables', () => {
   // document.documentElement, breaking the power mode cascade.
   // Only non-theme variables may be declared on :host.
   const CUSTOM_PROP_DECL = /--[\w-]+\s*:/g;
-  const THEME_VAR_PREFIXES = [
-    '--color-',
-    '--terminal-color-',
-  ];
+  const THEME_VAR_PREFIXES = ['--color-', '--terminal-color-'];
 
   for (const { name, content } of components) {
     const cssBlocks = extractCssBlocks(content);
@@ -174,7 +167,7 @@ describe('color consistency — :host must not shadow theme variables', () => {
           const propMatches = hostBody.match(CUSTOM_PROP_DECL) || [];
           for (const prop of propMatches) {
             const propName = prop.replace(/\s*:$/, '');
-            const isThemeVar = THEME_VAR_PREFIXES.some(prefix => propName.startsWith(prefix));
+            const isThemeVar = THEME_VAR_PREFIXES.some((prefix) => propName.startsWith(prefix));
             expect(
               isThemeVar,
               `${name} :host declares theme variable "${propName}" which shadows document-level power mode values`,

--- a/tests/components/a11y-canvas-slider.test.ts
+++ b/tests/components/a11y-canvas-slider.test.ts
@@ -30,8 +30,12 @@ describe('editor canvas — focusable + described (#35)', () => {
 
 describe('viewer slider — WAI-ARIA keyboard steps (#35)', () => {
   it('handle is a role=slider with valuemin/valuemax/valuenow', () => {
-    expect(VIEWER).toMatch(/role="slider"[\s\S]*?aria-valuenow=[\s\S]*?aria-valuemin="0"[\s\S]*?aria-valuemax="100"/);
-    expect(VIEWER).toMatch(/aria-label="\$\{t\(['"]viewer\.original['"]\)\} \/ \$\{t\(['"]viewer\.result['"]\)\}"/);
+    expect(VIEWER).toMatch(
+      /role="slider"[\s\S]*?aria-valuenow=[\s\S]*?aria-valuemin="0"[\s\S]*?aria-valuemax="100"/,
+    );
+    expect(VIEWER).toMatch(
+      /aria-label="\$\{t\(['"]viewer\.original['"]\)\} \/ \$\{t\(['"]viewer\.result['"]\)\}"/,
+    );
   });
 
   it('supports ±2 / ±10 / Home / End / PageUp / PageDown per WAI-ARIA slider spec', () => {
@@ -39,7 +43,16 @@ describe('viewer slider — WAI-ARIA keyboard steps (#35)', () => {
     expect(keymap, 'slider key handler not found').not.toBeNull();
     const block = keymap![0];
     expect(block).toMatch(/e\.shiftKey \? 10 : 2/);
-    for (const key of ['ArrowLeft', 'ArrowRight', 'ArrowUp', 'ArrowDown', 'PageUp', 'PageDown', 'Home', 'End']) {
+    for (const key of [
+      'ArrowLeft',
+      'ArrowRight',
+      'ArrowUp',
+      'ArrowDown',
+      'PageUp',
+      'PageDown',
+      'Home',
+      'End',
+    ]) {
       expect(block).toContain(`case '${key}':`);
     }
   });

--- a/tests/components/ar-advanced-toolbar.test.ts
+++ b/tests/components/ar-advanced-toolbar.test.ts
@@ -16,7 +16,9 @@ describe('ar-editor-advanced — toolbar split into two rows (#77)', () => {
   });
 
   it('primary row carries tools + size + zoom; contextual row carries lasso/preview', () => {
-    const primary = ED.match(/class="toolbar-row toolbar-row-primary"[\s\S]*?<\/div>\s*<\/div>\s*<\/div>/);
+    const primary = ED.match(
+      /class="toolbar-row toolbar-row-primary"[\s\S]*?<\/div>\s*<\/div>\s*<\/div>/,
+    );
     expect(primary).not.toBeNull();
     expect(primary![0]).toMatch(/class="tool-group"/);
     expect(primary![0]).toMatch(/id="size-row"/);
@@ -35,6 +37,8 @@ describe('ar-editor-advanced — toolbar split into two rows (#77)', () => {
   });
 
   it('contextual row hides when none of its children carry .visible', () => {
-    expect(ED).toMatch(/\.toolbar-row-contextual:not\(:has\(> \.visible\)\) \{[\s\S]*?display: none/);
+    expect(ED).toMatch(
+      /\.toolbar-row-contextual:not\(:has\(> \.visible\)\) \{[\s\S]*?display: none/,
+    );
   });
 });

--- a/tests/components/ar-command-bar.test.ts
+++ b/tests/components/ar-command-bar.test.ts
@@ -25,10 +25,12 @@ describe('Command bar — ar-app.ts invariants', () => {
   it('renders <div class="command-bar"> inside the single-file workspace', () => {
     expect(APP).toMatch(/<div class="command-bar"[^>]*id="command-bar"/);
     // Situated inside #single-file-workspace and BEFORE ar-viewer.
-    const ws = APP.match(/<div class="single-file-workspace"[\s\S]*?<\/div>\s*<\/div>\s*<\/section>/);
+    const ws = APP.match(
+      /<div class="single-file-workspace"[\s\S]*?<\/div>\s*<\/div>\s*<\/section>/,
+    );
     expect(ws).not.toBeNull();
-    const idx = (ws![0].indexOf('<div class="command-bar"'));
-    const viewerIdx = (ws![0].indexOf('<ar-viewer>'));
+    const idx = ws![0].indexOf('<div class="command-bar"');
+    const viewerIdx = ws![0].indexOf('<ar-viewer>');
     expect(idx).toBeGreaterThan(-1);
     expect(viewerIdx).toBeGreaterThan(idx);
   });
@@ -54,8 +56,12 @@ describe('Command bar — ar-app.ts invariants', () => {
   });
 
   it('updateCommandBar + updateCommandBarState methods exist with the documented signature', () => {
-    expect(APP).toMatch(/private updateCommandBar\(payload:[\s\S]*?filename:[\s\S]*?sizeBytes:[\s\S]*?state:[\s\S]*?\}\): void/);
-    expect(APP).toMatch(/private updateCommandBarState\(state: ['"]running['"] \| ['"]ready['"] \| ['"]failed['"]\): void/);
+    expect(APP).toMatch(
+      /private updateCommandBar\(payload:[\s\S]*?filename:[\s\S]*?sizeBytes:[\s\S]*?state:[\s\S]*?\}\): void/,
+    );
+    expect(APP).toMatch(
+      /private updateCommandBarState\(state: ['"]running['"] \| ['"]ready['"] \| ['"]failed['"]\): void/,
+    );
   });
 
   it('updateTexts re-translates the surviving cmdbar labels on locale change', () => {

--- a/tests/components/ar-download-cta.test.ts
+++ b/tests/components/ar-download-cta.test.ts
@@ -33,7 +33,9 @@ describe('Download CTA — ar-download.ts invariants', () => {
     expect(DL).toMatch(/private async prepareWebp\(imageData: ImageData\): Promise<void>/);
     expect(DL).toMatch(/void this\.prepareWebp\(imageData\);/);
     // PNG blob URL is set before prepareWebp fires.
-    expect(DL).toMatch(/this\.pngBlobUrl = URL\.createObjectURL\(blob\);[\s\S]*?this\.updateCtaAnchors\(['"]png-only['"]\)/);
+    expect(DL).toMatch(
+      /this\.pngBlobUrl = URL\.createObjectURL\(blob\);[\s\S]*?this\.updateCtaAnchors\(['"]png-only['"]\)/,
+    );
   });
 
   it('updateCtaAnchors fills href + download filename + meta line for each anchor', () => {
@@ -57,7 +59,9 @@ describe('Download CTA — ar-download.ts invariants', () => {
   });
 
   it('reset() clears both blob URLs and hides both anchors', () => {
-    expect(DL).toMatch(/reset\(\): void \{[\s\S]*?pngBlobUrl[\s\S]*?webpBlobUrl[\s\S]*?png\.hidden = true[\s\S]*?webp\.hidden = true/);
+    expect(DL).toMatch(
+      /reset\(\): void \{[\s\S]*?pngBlobUrl[\s\S]*?webpBlobUrl[\s\S]*?png\.hidden = true[\s\S]*?webp\.hidden = true/,
+    );
   });
 });
 

--- a/tests/components/ar-editor-cmd-bar.test.ts
+++ b/tests/components/ar-editor-cmd-bar.test.ts
@@ -43,13 +43,13 @@ describe('ar-editor — mini command bar (#76-C)', () => {
     expect(ED).toMatch(/private syncCmdBarMeta\(\): void/);
     // Tool select + size slider + keyboard shortcuts all route through it.
     expect(ED).toMatch(/#brush-tool[\s\S]*?this\.syncCmdBarMeta\(\)/);
-    expect(ED).toMatch(/sizeInput\.addEventListener\(['"]input['"],[\s\S]*?this\.syncCmdBarMeta\(\)/);
+    expect(ED).toMatch(
+      /sizeInput\.addEventListener\(\s*['"]input['"][\s\S]*?this\.syncCmdBarMeta\(\)/,
+    );
     expect(ED).toMatch(/updateSizeUI\(\)[\s\S]*?this\.syncCmdBarMeta\(\)/);
   });
 
   it('CSS styles command bar buttons with ≥ 44 px min-height on coarse pointers', () => {
-    expect(ED).toMatch(
-      /@media \(pointer: coarse\) \{[\s\S]*?\.editor-cmd-btn \{ min-height: 44px/,
-    );
+    expect(ED).toMatch(/@media \(pointer: coarse\) \{[\s\S]*?\.editor-cmd-btn \{ min-height: 44px/);
   });
 });

--- a/tests/components/ar-editor-sidebar.test.ts
+++ b/tests/components/ar-editor-sidebar.test.ts
@@ -43,9 +43,7 @@ describe('ar-editor — permanent shortcuts sidebar (#76-B)', () => {
   });
 
   it('CSS hides .help-wrap popover at ≥ 900 px (sidebar owns shortcuts)', () => {
-    expect(ED).toMatch(
-      /@media \(min-width: 900px\) \{[\s\S]*?\.help-wrap \{ display: none; \}/,
-    );
+    expect(ED).toMatch(/@media \(min-width: 900px\) \{[\s\S]*?\.help-wrap \{ display: none; \}/);
   });
 
   it('.editor-body becomes a multi-col grid at ≥ 900 px', () => {

--- a/tests/components/ar-editor.test.ts
+++ b/tests/components/ar-editor.test.ts
@@ -16,11 +16,15 @@ if (typeof globalThis.ImageData === 'undefined') {
     data: Uint8ClampedArray;
     width: number;
     height: number;
-    constructor(dataOrWidth: Uint8ClampedArray | number, widthOrHeight: number, maybeHeight?: number) {
+    constructor(
+      dataOrWidth: Uint8ClampedArray | number,
+      widthOrHeight: number,
+      maybeHeight?: number,
+    ) {
       if (dataOrWidth instanceof Uint8ClampedArray) {
         this.data = dataOrWidth;
         this.width = widthOrHeight;
-        this.height = maybeHeight ?? (dataOrWidth.length / (widthOrHeight * 4));
+        this.height = maybeHeight ?? dataOrWidth.length / (widthOrHeight * 4);
       } else {
         this.width = dataOrWidth;
         this.height = widthOrHeight;
@@ -54,12 +58,20 @@ vi.spyOn(document, 'createElement').mockImplementation((tag: string, options?: a
 });
 
 // Tambien patchear OffscreenCanvas (usado en redraw)
-vi.stubGlobal('OffscreenCanvas', class {
-  width: number;
-  height: number;
-  constructor(w: number, h: number) { this.width = w; this.height = h; }
-  getContext() { return mockCtx; }
-});
+vi.stubGlobal(
+  'OffscreenCanvas',
+  class {
+    width: number;
+    height: number;
+    constructor(w: number, h: number) {
+      this.width = w;
+      this.height = h;
+    }
+    getContext() {
+      return mockCtx;
+    }
+  },
+);
 
 // Register the component
 import '../../src/components/ar-editor';
@@ -113,7 +125,7 @@ describe('ArEditor component', () => {
   describe('setImage', () => {
     it('establece la imagen y se puede recuperar con getResultImageData', () => {
       const img = makeTestImageData();
-      setImg(editor,img);
+      setImg(editor, img);
 
       const result = editor.getResultImageData();
       expect(result).not.toBeNull();
@@ -123,7 +135,7 @@ describe('ArEditor component', () => {
 
     it('crea una copia independiente de los datos', () => {
       const img = makeTestImageData();
-      setImg(editor,img);
+      setImg(editor, img);
 
       // Modify the original
       img.data[0] = 0;
@@ -140,7 +152,7 @@ describe('ArEditor component', () => {
       img.data[2] = 30;
       img.data[3] = 128;
 
-      setImg(editor,img);
+      setImg(editor, img);
 
       const result = editor.getResultImageData();
       expect(result.data[0]).toBe(10);
@@ -150,7 +162,7 @@ describe('ArEditor component', () => {
     });
 
     it('resetea las pilas de undo/redo al cargar nueva imagen', () => {
-      setImg(editor,makeTestImageData());
+      setImg(editor, makeTestImageData());
 
       const undoBtn = editor.shadowRoot!.querySelector('#undo-btn') as HTMLButtonElement;
       const redoBtn = editor.shadowRoot!.querySelector('#redo-btn') as HTMLButtonElement;
@@ -162,7 +174,7 @@ describe('ArEditor component', () => {
   describe('getResultImageData', () => {
     it('devuelve el ImageData actual del editor', () => {
       const img = makeTestImageData(8, 8);
-      setImg(editor,img);
+      setImg(editor, img);
 
       const result = editor.getResultImageData();
       expect(result).toBeInstanceOf(ImageData);
@@ -172,7 +184,7 @@ describe('ArEditor component', () => {
 
   describe('reset', () => {
     it('limpia el estado interno', () => {
-      setImg(editor,makeTestImageData());
+      setImg(editor, makeTestImageData());
       editor.reset();
 
       const result = editor.getResultImageData();
@@ -182,13 +194,13 @@ describe('ArEditor component', () => {
 
   describe('undo/redo', () => {
     it('undo esta deshabilitado antes de editar', () => {
-      setImg(editor,makeTestImageData(4, 4));
+      setImg(editor, makeTestImageData(4, 4));
       const undoBtn = editor.shadowRoot!.querySelector('#undo-btn') as HTMLButtonElement;
       expect(undoBtn.disabled).toBe(true);
     });
 
     it('redo esta deshabilitado antes de editar', () => {
-      setImg(editor,makeTestImageData(4, 4));
+      setImg(editor, makeTestImageData(4, 4));
       const redoBtn = editor.shadowRoot!.querySelector('#redo-btn') as HTMLButtonElement;
       expect(redoBtn.disabled).toBe(true);
     });
@@ -196,7 +208,7 @@ describe('ArEditor component', () => {
 
   describe('eventos', () => {
     it('emite ar:editor-done con imageData al hacer click en Done', async () => {
-      setImg(editor,makeTestImageData(4, 4));
+      setImg(editor, makeTestImageData(4, 4));
 
       const donePromise = new Promise<CustomEvent>((resolve) => {
         editor.addEventListener('ar:editor-done', (e) => resolve(e as CustomEvent), { once: true });
@@ -210,7 +222,7 @@ describe('ArEditor component', () => {
     });
 
     it('emite ar:editor-cancel al hacer click en Cancel', async () => {
-      setImg(editor,makeTestImageData());
+      setImg(editor, makeTestImageData());
 
       const cancelPromise = new Promise<Event>((resolve) => {
         editor.addEventListener('ar:editor-cancel', (e) => resolve(e), { once: true });
@@ -273,7 +285,7 @@ describe('ArEditor component', () => {
       const select = editor.shadowRoot!.querySelector('#brush-tool') as HTMLSelectElement;
       expect(select).not.toBeNull();
       expect(select.value).toBe('erase');
-      const values = Array.from(select.options).map(o => o.value);
+      const values = Array.from(select.options).map((o) => o.value);
       expect(values).toEqual(['erase', 'restore']);
     });
 

--- a/tests/components/ar-first-run.test.ts
+++ b/tests/components/ar-first-run.test.ts
@@ -24,19 +24,25 @@ describe('first-run explainer (#78)', () => {
   });
 
   it('exposes a public setLoadingState({ visible, pct, label, ready }) API', () => {
-    expect(DZ).toMatch(/setLoadingState\(state: \{ visible: boolean; pct\?: number; label\?: string; ready\?: boolean \}\): void/);
+    expect(DZ).toMatch(
+      /setLoadingState\(state: \{[\s\S]*?visible: boolean;[\s\S]*?pct\?: number;[\s\S]*?label\?: string;[\s\S]*?ready\?: boolean;?\s*\}\): void/,
+    );
     expect(DZ).toMatch(/this\.dropArea\?\.classList\.add\(['"]is-loading['"]\)/);
     expect(DZ).toMatch(/this\.dropArea\?\.classList\.remove\(['"]is-loading['"]\)/);
     expect(DZ).toMatch(/label\.textContent = t\(['"]firstRun\.ready['"]\)/);
   });
 
   it('ar-app reveals the slot after 400 ms of sustained loading (cold-cache heuristic)', () => {
-    expect(APP).toMatch(/window\.setTimeout\([\s\S]*?this\.dropzone\.setLoadingState\(\{ visible: true \}\)[\s\S]*?\}, 400\)/);
+    expect(APP).toMatch(
+      /window\.setTimeout\([\s\S]*?this\.dropzone\.setLoadingState\(\{ visible: true \}\)[\s\S]*?\}, 400\)/,
+    );
   });
 
   it('ar-app forwards "N%" worker messages into the dropzone bar', () => {
     expect(APP).toMatch(/match\(\/\(\\d\+\)\\s\*%\//);
-    expect(APP).toMatch(/this\.dropzone\.setLoadingState\(\{ visible: true, pct, label: message \}\)/);
+    expect(APP).toMatch(
+      /this\.dropzone\.setLoadingState\(\{ visible: true, pct, label: message \}\)/,
+    );
   });
 
   it('ar-app finishes with ready=true on resolve, ready=false on reject', () => {
@@ -50,14 +56,20 @@ describe('first-run explainer (#78)', () => {
   });
 
   it('respects prefers-reduced-motion for the progress bar transition', () => {
-    expect(DZ).toMatch(/@media \(prefers-reduced-motion: reduce\) \{[\s\S]*?\.dz-loading-bar \{ transition: none/);
+    expect(DZ).toMatch(
+      /@media \(prefers-reduced-motion: reduce\) \{[\s\S]*?\.dz-loading-bar \{ transition: none/,
+    );
   });
 });
 
 describe('status line — reactor offline → active flip', () => {
   it('initial render writes data-state="offline" + status.reactor.offline', () => {
-    expect(APP).toMatch(/<span class="status-reactor"[^>]*data-state="offline">\$\{t\(['"]status\.reactor\.offline['"]\)\}/);
-    expect(APP).toMatch(/<span class="status-model"[^>]*data-state="loading">\$\{t\(['"]status\.model\.loading['"]\)\}/);
+    expect(APP).toMatch(
+      /<span class="status-reactor"[^>]*data-state="offline">\$\{t\(['"]status\.reactor\.offline['"]\)\}/,
+    );
+    expect(APP).toMatch(
+      /<span class="status-model"[^>]*data-state="loading">\$\{t\(['"]status\.model\.loading['"]\)\}/,
+    );
   });
 
   it('preload success flips status-reactor data-state to "online" and status-model to "ready"', () => {
@@ -67,8 +79,12 @@ describe('status line — reactor offline → active flip', () => {
   });
 
   it('CSS dims dot + reactor word while offline', () => {
-    expect(APP).toMatch(/\.status-reactor\[data-state="offline"\] \{[\s\S]*?color: var\(--color-text-tertiary/);
-    expect(APP).toMatch(/\.status-line:has\(\.status-reactor\[data-state="offline"\]\) \.status-dot \{[\s\S]*?opacity: 0\.55/);
+    expect(APP).toMatch(
+      /\.status-reactor\[data-state="offline"\] \{[\s\S]*?color: var\(--color-text-tertiary/,
+    );
+    expect(APP).toMatch(
+      /\.status-line:has\(\.status-reactor\[data-state="offline"\]\) \.status-dot \{[\s\S]*?opacity: 0\.55/,
+    );
   });
 
   it('status.reactor.offline is shipped in all six locales', () => {
@@ -78,11 +94,15 @@ describe('status line — reactor offline → active flip', () => {
 
 describe('hero disclaimer + support pitch (recovered from reactor copy)', () => {
   it('hero renders <p id="hero-disclaimer"> using features.disclaimer', () => {
-    expect(APP).toMatch(/<p class="hero-disclaimer" id="hero-disclaimer">\$\{t\(['"]features\.disclaimer['"]\)\}/);
+    expect(APP).toMatch(
+      /<p class="hero-disclaimer" id="hero-disclaimer">\$\{t\(['"]features\.disclaimer['"]\)\}/,
+    );
   });
 
   it('hero renders <p id="hero-support"> using support.kofi', () => {
-    expect(APP).toMatch(/<p class="hero-support" id="hero-support">\$\{t\(['"]support\.kofi['"]\)\}/);
+    expect(APP).toMatch(
+      /<p class="hero-support" id="hero-support">\$\{t\(['"]support\.kofi['"]\)\}/,
+    );
   });
 
   it('updateTexts re-localizes both paragraphs on locale change', () => {

--- a/tests/components/ar-landing-redesign.test.ts
+++ b/tests/components/ar-landing-redesign.test.ts
@@ -92,7 +92,9 @@ describe('Landing redesign — ar-dropzone.ts invariants', () => {
 
   it('outer dropzone border uses accent-primary (not surface-border) + glow shadow', () => {
     expect(DZ).toMatch(/border:\s*1px solid var\(--color-accent-primary/);
-    expect(DZ).toMatch(/box-shadow:\s*\n?\s*0 0 14px rgba\(var\(--color-accent-rgb[^)]+\),\s*0\.08\)/);
+    expect(DZ).toMatch(
+      /box-shadow:\s*\n?\s*0 0 14px rgba\(var\(--color-accent-rgb[^)]+\),\s*0\.08\)/,
+    );
   });
 
   it('mobile dropzone gets min-height: 44vh so it occupies most of the viewport', () => {
@@ -101,7 +103,12 @@ describe('Landing redesign — ar-dropzone.ts invariants', () => {
 });
 
 describe('Landing redesign — i18n invariants', () => {
-  const keys = ['status.reactor.online', 'status.model.cached', 'status.limitations', 'dropzone.hint'];
+  const keys = [
+    'status.reactor.online',
+    'status.model.cached',
+    'status.limitations',
+    'dropzone.hint',
+  ];
   for (const key of keys) {
     it(`has '${key}' in all six locales`, () => {
       const matches = I18N.match(new RegExp(`'${key.replace(/\./g, '\\.')}'\\s*:`, 'g')) ?? [];

--- a/tests/components/ar-mobile-hero.test.ts
+++ b/tests/components/ar-mobile-hero.test.ts
@@ -23,7 +23,9 @@ describe('Mobile hero — short-form copy swap (#73)', () => {
 
   it('CSS swaps which variant renders at ≤ 480 px', () => {
     expect(APP).toMatch(/\.hero-title-short, \.subline-short \{ display: none; \}/);
-    expect(APP).toMatch(/@media \(max-width: 480px\)\s*\{[\s\S]*?\.hero-title-long, \.subline-long \{ display: none/);
+    expect(APP).toMatch(
+      /@media \(max-width: 480px\)\s*\{[\s\S]*?\.hero-title-long, \.subline-long \{ display: none/,
+    );
   });
 
   it('updateTexts renders both spans so locale-change keeps the swap working', () => {

--- a/tests/components/ar-progress.test.ts
+++ b/tests/components/ar-progress.test.ts
@@ -104,7 +104,7 @@ describe('ar-progress — replay after reset', () => {
     ];
     replay(el, history);
     const stages = stageEls(el);
-    const errorStage = stages.find(s => s.className.includes('error'));
+    const errorStage = stages.find((s) => s.className.includes('error'));
     expect(errorStage).toBeDefined();
     // Error icon draws two crossing <line> elements
     expect(iconHtml(errorStage!)).toContain('<line');

--- a/tests/components/ar-stage-actions.test.ts
+++ b/tests/components/ar-stage-actions.test.ts
@@ -34,7 +34,9 @@ describe('inline error-stage actions (#78)', () => {
 
   it('ar-app wires ar:stage-retry -> retryFromError and ar:stage-report -> GitHub issue URL', () => {
     expect(APP).toMatch(/ar:stage-retry[\s\S]*?retryFromError\(\)/);
-    expect(APP).toMatch(/ar:stage-report[\s\S]*?github\.com\/yocreoquesi\/nukebg\/issues\/new\?title=/);
+    expect(APP).toMatch(
+      /ar:stage-report[\s\S]*?github\.com\/yocreoquesi\/nukebg\/issues\/new\?title=/,
+    );
     // Body embeds UA + locale for debugging
     expect(APP).toMatch(/encodeURIComponent\(navigator\.userAgent\)/);
   });

--- a/tests/components/kbd-shortcuts.test.ts
+++ b/tests/components/kbd-shortcuts.test.ts
@@ -63,9 +63,9 @@ describe('global keyboard shortcuts (src/main.ts)', () => {
   });
 
   it('main.css defines .kbd-overlay with a high z-index so it sits over every shadow tree', () => {
-    expect(CSS).toMatch(/\.kbd-overlay \{[\s\S]*?position: fixed;[\s\S]*?z-index:\s*10000;/);
-    expect(CSS).toMatch(/\.kbd-overlay\[hidden\] \{ display: none; \}/);
-    expect(CSS).toMatch(/\.kbd-overlay-card \{/);
-    expect(CSS).toMatch(/\.kbd-overlay-close \{/);
+    expect(CSS).toMatch(/\.kbd-overlay\s*\{[\s\S]*?position: fixed;[\s\S]*?z-index:\s*10000;/);
+    expect(CSS).toMatch(/\.kbd-overlay\[hidden\]\s*\{\s*display:\s*none;?\s*\}/);
+    expect(CSS).toMatch(/\.kbd-overlay-card\s*\{/);
+    expect(CSS).toMatch(/\.kbd-overlay-close\s*\{/);
   });
 });

--- a/tests/cv/alpha-matting.test.ts
+++ b/tests/cv/alpha-matting.test.ts
@@ -16,7 +16,8 @@ function makePixels(w: number, h: number, gray: number): Uint8ClampedArray {
 
 describe('guidedFilter (alpha matting)', () => {
   it('binary mask: smooths borders without destroying core regions', () => {
-    const w = 64, h = 64;
+    const w = 64,
+      h = 64;
     const alpha = new Uint8Array(w * h);
     const pixels = new Uint8ClampedArray(w * h * 4);
 
@@ -42,19 +43,20 @@ describe('guidedFilter (alpha matting)', () => {
     const result = guidedFilter(alpha, pixels, w, h, 5, 1e-4);
 
     // Deep subject pixels should remain mostly opaque
-    expect(result[h / 2 * w + 5]).toBeGreaterThan(200);
+    expect(result[(h / 2) * w + 5]).toBeGreaterThan(200);
 
     // Deep background pixels should remain mostly transparent
-    expect(result[h / 2 * w + (w - 5)]).toBeLessThan(55);
+    expect(result[(h / 2) * w + (w - 5)]).toBeLessThan(55);
 
     // Border region (around x=32) should contain intermediate values
-    const borderVal = result[h / 2 * w + w / 2];
+    const borderVal = result[(h / 2) * w + w / 2];
     expect(borderVal).toBeGreaterThanOrEqual(0);
     expect(borderVal).toBeLessThanOrEqual(255);
   });
 
   it('already-smooth mask: does not degrade quality', () => {
-    const w = 32, h = 32;
+    const w = 32,
+      h = 32;
     // Create a smooth gradient mask
     const alpha = new Uint8Array(w * h);
     for (let y = 0; y < h; y++) {
@@ -67,8 +69,13 @@ describe('guidedFilter (alpha matting)', () => {
     const result = guidedFilter(alpha, pixels, w, h, 3, 1e-4);
 
     // Should still be a gradient (left should be darker, right brighter)
-    const leftAvg = (result[h / 2 * w + 0] + result[h / 2 * w + 1] + result[h / 2 * w + 2]) / 3;
-    const rightAvg = (result[h / 2 * w + (w - 1)] + result[h / 2 * w + (w - 2)] + result[h / 2 * w + (w - 3)]) / 3;
+    const leftAvg =
+      (result[(h / 2) * w + 0] + result[(h / 2) * w + 1] + result[(h / 2) * w + 2]) / 3;
+    const rightAvg =
+      (result[(h / 2) * w + (w - 1)] +
+        result[(h / 2) * w + (w - 2)] +
+        result[(h / 2) * w + (w - 3)]) /
+      3;
     expect(rightAvg).toBeGreaterThan(leftAvg);
 
     // All values in valid range
@@ -79,7 +86,8 @@ describe('guidedFilter (alpha matting)', () => {
   });
 
   it('all-opaque mask stays opaque', () => {
-    const w = 16, h = 16;
+    const w = 16,
+      h = 16;
     const alpha = new Uint8Array(w * h).fill(255);
     const pixels = makePixels(w, h, 180);
 
@@ -91,7 +99,8 @@ describe('guidedFilter (alpha matting)', () => {
   });
 
   it('all-transparent mask stays transparent', () => {
-    const w = 16, h = 16;
+    const w = 16,
+      h = 16;
     const alpha = new Uint8Array(w * h).fill(0);
     const pixels = makePixels(w, h, 100);
 
@@ -113,10 +122,13 @@ describe('guidedFilter (alpha matting)', () => {
   });
 
   it('performance: 1024x1024 completes in <500ms', () => {
-    const w = 1024, h = 1024;
+    const w = 1024,
+      h = 1024;
     const alpha = new Uint8Array(w * h);
     // Create a circle mask
-    const cx = w / 2, cy = h / 2, r = w / 3;
+    const cx = w / 2,
+      cy = h / 2,
+      r = w / 3;
     for (let y = 0; y < h; y++) {
       for (let x = 0; x < w; x++) {
         const dist = Math.sqrt((x - cx) ** 2 + (y - cy) ** 2);
@@ -134,7 +146,8 @@ describe('guidedFilter (alpha matting)', () => {
   });
 
   it('produces values strictly within [0, 255]', () => {
-    const w = 50, h = 50;
+    const w = 50,
+      h = 50;
     const alpha = new Uint8Array(w * h);
     const pixels = new Uint8ClampedArray(w * h * 4);
 
@@ -156,4 +169,3 @@ describe('guidedFilter (alpha matting)', () => {
     }
   });
 });
-

--- a/tests/cv/alpha-refine.test.ts
+++ b/tests/cv/alpha-refine.test.ts
@@ -3,7 +3,8 @@ import { alphaRefine } from '../../src/workers/cv/alpha-refine';
 
 describe('alphaRefine', () => {
   it('convierte mascara binaria a alpha: bg=0, fg=255', () => {
-    const w = 10, h = 10;
+    const w = 10,
+      h = 10;
     const mask = new Uint8Array(w * h);
     // Mitad superior: fondo (1), mitad inferior: sujeto (0)
     for (let y = 0; y < 5; y++) {
@@ -15,7 +16,8 @@ describe('alphaRefine', () => {
     const alpha = alphaRefine(mask, w, h);
 
     // Los pixeles de fondo deben tener alpha = 0
-    for (let y = 0; y < 3; y++) { // margenes internos por blur
+    for (let y = 0; y < 3; y++) {
+      // margenes internos por blur
       for (let x = 1; x < w - 1; x++) {
         expect(alpha[y * w + x]).toBe(0);
       }
@@ -30,7 +32,8 @@ describe('alphaRefine', () => {
   });
 
   it('todo fondo produce todo alpha 0', () => {
-    const w = 16, h = 16;
+    const w = 16,
+      h = 16;
     const mask = new Uint8Array(w * h).fill(1); // todo bg
 
     const alpha = alphaRefine(mask, w, h);
@@ -41,7 +44,8 @@ describe('alphaRefine', () => {
   });
 
   it('todo sujeto produce todo alpha 255', () => {
-    const w = 16, h = 16;
+    const w = 16,
+      h = 16;
     const mask = new Uint8Array(w * h); // todo fg (0)
 
     const alpha = alphaRefine(mask, w, h);
@@ -52,7 +56,8 @@ describe('alphaRefine', () => {
   });
 
   it('el borde entre fg y bg tiene transicion suave', () => {
-    const w = 20, h = 20;
+    const w = 20,
+      h = 20;
     const mask = new Uint8Array(w * h);
     // Izquierda: fondo, derecha: sujeto
     for (let y = 0; y < h; y++) {
@@ -66,7 +71,7 @@ describe('alphaRefine', () => {
     // In the transition zone (x=9-10) there may be intermediate values
     // o un salto brusco post-threshold. El punto es que no crashee
     // y los extremos sean correctos
-    expect(alpha[10 * w + 0]).toBe(0);   // bg lejano
+    expect(alpha[10 * w + 0]).toBe(0); // bg lejano
     expect(alpha[10 * w + 19]).toBe(255); // fg lejano
   });
 
@@ -83,7 +88,8 @@ describe('alphaRefine', () => {
   });
 
   it('produce valores dentro de [0, 255]', () => {
-    const w = 50, h = 50;
+    const w = 50,
+      h = 50;
     const mask = new Uint8Array(w * h);
     // Patron aleatorio-ish
     for (let i = 0; i < mask.length; i++) {

--- a/tests/cv/classify-image.test.ts
+++ b/tests/cv/classify-image.test.ts
@@ -17,7 +17,8 @@ describe('extractImageFeatures', () => {
   });
 
   it('extracts correct features from a colorful image', () => {
-    const w = 200, h = 200;
+    const w = 200,
+      h = 200;
     const pixels = new Uint8ClampedArray(w * h * 4);
     // Fill with varied colors (gradient)
     for (let y = 0; y < h; y++) {
@@ -39,7 +40,8 @@ describe('extractImageFeatures', () => {
 
 describe('classifyImage', () => {
   it('classifies mostly white image with dark strokes as SIGNATURE', () => {
-    const w = 300, h = 150;
+    const w = 300,
+      h = 150;
     // White background
     const pixels = solidImage(w, h, 255, 255, 255);
     // Draw a thin dark "signature" line across the middle
@@ -60,13 +62,14 @@ describe('classifyImage', () => {
     expect(result).toBe('SIGNATURE');
     expect(features.brightnessMean).toBeGreaterThan(150);
     expect(features.saturationMean).toBeLessThan(0.08);
-    expect(features.nearWhiteRatio).toBeGreaterThan(0.50);
+    expect(features.nearWhiteRatio).toBeGreaterThan(0.5);
     expect(features.darkPixelRatio).toBeGreaterThan(0.01);
-    expect(features.darkPixelRatio).toBeLessThan(0.40);
+    expect(features.darkPixelRatio).toBeLessThan(0.4);
   });
 
   it('classifies colorful varied image as PHOTO', () => {
-    const w = 400, h = 300;
+    const w = 400,
+      h = 300;
     const pixels = new Uint8ClampedArray(w * h * 4);
     // Rich photo-like content with many colors
     for (let y = 0; y < h; y++) {
@@ -87,7 +90,8 @@ describe('classifyImage', () => {
   });
 
   it('classifies small low-color square image as ICON', () => {
-    const w = 64, h = 64;
+    const w = 64,
+      h = 64;
     // Flat color icon with few colors
     const pixels = solidImage(w, h, 50, 120, 200);
     // Add a second color region
@@ -104,7 +108,8 @@ describe('classifyImage', () => {
   });
 
   it('classifies medium-color low-variance image as ILLUSTRATION', () => {
-    const w = 600, h = 400;
+    const w = 600,
+      h = 400;
     const pixels = new Uint8ClampedArray(w * h * 4);
     // Flat shaded regions with per-pixel variation (illustration-like):
     // many bands with x-based and y-based subtle gradients to produce 50-800 unique quantized colors
@@ -146,7 +151,8 @@ describe('classifyImage', () => {
   });
 
   it('defaults to PHOTO for ambiguous images', () => {
-    const w = 800, h = 600;
+    const w = 800,
+      h = 600;
     const pixels = new Uint8ClampedArray(w * h * 4);
     // High variation, many colors, large size
     for (let y = 0; y < h; y++) {

--- a/tests/cv/foreground-estimation.test.ts
+++ b/tests/cv/foreground-estimation.test.ts
@@ -45,7 +45,8 @@ function makeScene(
 
 describe('estimateForeground', () => {
   it('fully opaque pixels are copied verbatim (no round-trip error)', () => {
-    const w = 16, h = 16;
+    const w = 16,
+      h = 16;
     const { observed, alpha } = makeScene(w, h, [200, 50, 50], [30, 30, 30], () => 255);
     const out = estimateForeground(observed, alpha, w, h);
     for (let i = 0; i < w * h; i++) {
@@ -57,7 +58,8 @@ describe('estimateForeground', () => {
   });
 
   it('fully transparent pixels output alpha=0', () => {
-    const w = 16, h = 16;
+    const w = 16,
+      h = 16;
     const { observed, alpha } = makeScene(w, h, [200, 50, 50], [30, 30, 30], () => 0);
     const out = estimateForeground(observed, alpha, w, h);
     for (let i = 0; i < w * h; i++) {
@@ -69,7 +71,8 @@ describe('estimateForeground', () => {
     // Horizontal stripes: α=255 (0..20), α=128 (20..40), α=0 (40..60).
     // The opaque and transparent stripes anchor F and B respectively, and
     // the solver propagates them into the middle band.
-    const w = 60, h = 60;
+    const w = 60,
+      h = 60;
     const FG: [number, number, number] = [230, 0, 0];
     const BG: [number, number, number] = [0, 230, 0];
     const { observed, alpha } = makeScene(w, h, FG, BG, (x) => {
@@ -80,7 +83,10 @@ describe('estimateForeground', () => {
     const out = estimateForeground(observed, alpha, w, h, { iterationsPerLevel: 12 });
 
     // Sample middle band far from boundaries.
-    let dr = 0, dg = 0, db = 0, n = 0;
+    let dr = 0,
+      dg = 0,
+      db = 0,
+      n = 0;
     for (let y = 10; y < h - 10; y++) {
       for (let x = 25; x < 35; x++) {
         const i = y * w + x;
@@ -102,8 +108,10 @@ describe('estimateForeground', () => {
     // Center disc α=255 (pure FG), ring of α=128 around it, bg α=0 outside.
     // The solver has strong anchoring from the opaque core — edge pixels
     // should come out very close to FG color.
-    const w = 64, h = 64;
-    const cx = w / 2, cy = h / 2;
+    const w = 64,
+      h = 64;
+    const cx = w / 2,
+      cy = h / 2;
     const FG: [number, number, number] = [255, 0, 0];
     const BG: [number, number, number] = [0, 255, 0];
     const { observed, alpha } = makeScene(w, h, FG, BG, (x, y) => {
@@ -122,13 +130,20 @@ describe('estimateForeground', () => {
     expect(alpha[i]).toBe(128);
     // With anchoring, recovered FG on the ring should be much redder than
     // the observed green ghost (128,128,0 would be the naive composite).
-    expect(out[i * 4]).toBeGreaterThan(150);     // red dominant
-    expect(out[i * 4 + 1]).toBeLessThan(100);    // green stripped
+    expect(out[i * 4]).toBeGreaterThan(150); // red dominant
+    expect(out[i * 4 + 1]).toBeLessThan(100); // green stripped
   });
 
   it('does not touch alpha channel', () => {
-    const w = 32, h = 32;
-    const { observed, alpha } = makeScene(w, h, [128, 64, 32], [200, 200, 200], (x, y) => (x + y) % 256);
+    const w = 32,
+      h = 32;
+    const { observed, alpha } = makeScene(
+      w,
+      h,
+      [128, 64, 32],
+      [200, 200, 200],
+      (x, y) => (x + y) % 256,
+    );
     const out = estimateForeground(observed, alpha, w, h);
     for (let i = 0; i < w * h; i++) {
       expect(out[i * 4 + 3]).toBe(alpha[i]);
@@ -136,13 +151,15 @@ describe('estimateForeground', () => {
   });
 
   it('handles degenerate tiny inputs without throwing', () => {
-    const w = 4, h = 4;
+    const w = 4,
+      h = 4;
     const { observed, alpha } = makeScene(w, h, [100, 100, 100], [0, 0, 0], () => 128);
     expect(() => estimateForeground(observed, alpha, w, h)).not.toThrow();
   });
 
   it('output array length is 4 × width × height', () => {
-    const w = 10, h = 7;
+    const w = 10,
+      h = 7;
     const { observed, alpha } = makeScene(w, h, [100, 100, 100], [50, 50, 50], () => 200);
     const out = estimateForeground(observed, alpha, w, h);
     expect(out.length).toBe(w * h * 4);

--- a/tests/cv/grid-flood-fill.test.ts
+++ b/tests/cv/grid-flood-fill.test.ts
@@ -7,7 +7,9 @@ describe('gridFloodFill', () => {
   const light: [number, number, number] = [255, 255, 255];
 
   it('marca todo como fondo en checkerboard puro (sin sujeto)', () => {
-    const w = 128, h = 128, gs = 16;
+    const w = 128,
+      h = 128,
+      gs = 16;
     const pixels = checkerboardImage(w, h, gs, dark, light);
 
     const mask = gridFloodFill(pixels, w, h, dark, light, gs, 0);
@@ -18,7 +20,9 @@ describe('gridFloodFill', () => {
   });
 
   it('preserva un sujeto central opaco', () => {
-    const w = 128, h = 128, gs = 16;
+    const w = 128,
+      h = 128,
+      gs = 16;
     const pixels = checkerboardImage(w, h, gs, dark, light);
 
     // Paint a 40x40 red subject in the center
@@ -38,7 +42,9 @@ describe('gridFloodFill', () => {
   });
 
   it('funciona con grid de 32px', () => {
-    const w = 256, h = 256, gs = 32;
+    const w = 256,
+      h = 256,
+      gs = 32;
     const pixels = checkerboardImage(w, h, gs, dark, light);
 
     const mask = gridFloodFill(pixels, w, h, dark, light, gs, 0);
@@ -48,7 +54,9 @@ describe('gridFloodFill', () => {
   });
 
   it('respeta el parametro de tolerancia', () => {
-    const w = 128, h = 128, gs = 16;
+    const w = 128,
+      h = 128,
+      gs = 16;
     const pixels = checkerboardImage(w, h, gs, dark, light);
 
     // Con tolerancia 0, deberia ser mas estricto

--- a/tests/cv/inpaint-blend.test.ts
+++ b/tests/cv/inpaint-blend.test.ts
@@ -1,17 +1,8 @@
 import { describe, it, expect } from 'vitest';
-import {
-  compositeWithFeather,
-  dilateMask,
-} from '../../src/workers/cv/inpaint-blend';
+import { compositeWithFeather, dilateMask } from '../../src/workers/cv/inpaint-blend';
 
 /** RGBA image filled with a solid color. */
-function solid(
-  w: number,
-  h: number,
-  r: number,
-  g: number,
-  b: number,
-): Uint8ClampedArray {
+function solid(w: number, h: number, r: number, g: number, b: number): Uint8ClampedArray {
   const out = new Uint8ClampedArray(w * h * 4);
   for (let i = 0; i < out.length; i += 4) {
     out[i] = r;
@@ -60,7 +51,8 @@ describe('dilateMask', () => {
 
 describe('compositeWithFeather', () => {
   it('leaves pixels outside the dilated mask untouched', () => {
-    const w = 40, h = 40;
+    const w = 40,
+      h = 40;
     const original = solid(w, h, 100, 150, 200);
     // Paint a different solid color into "inpainted"
     const inpainted = solid(w, h, 255, 0, 0);
@@ -79,7 +71,8 @@ describe('compositeWithFeather', () => {
   });
 
   it('replaces pixels at the core of the mask with inpainted values', () => {
-    const w = 40, h = 40;
+    const w = 40,
+      h = 40;
     const original = solid(w, h, 100, 150, 200);
     const inpainted = solid(w, h, 255, 0, 0);
     const mask = circleMask(w, h, 20, 20, 6);
@@ -97,7 +90,8 @@ describe('compositeWithFeather', () => {
   });
 
   it('produces intermediate blend values in the feather ring', () => {
-    const w = 60, h = 60;
+    const w = 60,
+      h = 60;
     const original = solid(w, h, 0, 0, 0);
     const inpainted = solid(w, h, 200, 200, 200);
     const mask = circleMask(w, h, 30, 30, 8);
@@ -114,7 +108,8 @@ describe('compositeWithFeather', () => {
   });
 
   it('preserves alpha channel at 255 everywhere', () => {
-    const w = 30, h = 30;
+    const w = 30,
+      h = 30;
     const original = solid(w, h, 50, 50, 50);
     const inpainted = solid(w, h, 150, 150, 150);
     const mask = circleMask(w, h, 15, 15, 4);
@@ -130,7 +125,8 @@ describe('compositeWithFeather', () => {
   });
 
   it('injects noise inside the mask when noiseSigma > 0', () => {
-    const w = 40, h = 40;
+    const w = 40,
+      h = 40;
     const original = solid(w, h, 100, 100, 100);
     const inpainted = solid(w, h, 100, 100, 100); // identical to original
     const mask = circleMask(w, h, 20, 20, 6);
@@ -145,7 +141,8 @@ describe('compositeWithFeather', () => {
     const r2 = 4 * 4; // sample near core
     for (let y = 16; y <= 24; y++) {
       for (let x = 16; x <= 24; x++) {
-        const dx = x - 20, dy = y - 20;
+        const dx = x - 20,
+          dy = y - 20;
         if (dx * dx + dy * dy > r2) continue;
         const i = (y * w + x) * 4;
         if (result[i] !== 100) varied++;
@@ -155,7 +152,8 @@ describe('compositeWithFeather', () => {
   });
 
   it('does not add noise outside the mask', () => {
-    const w = 40, h = 40;
+    const w = 40,
+      h = 40;
     const original = solid(w, h, 100, 100, 100);
     const inpainted = solid(w, h, 100, 100, 100);
     const mask = circleMask(w, h, 20, 20, 4);

--- a/tests/cv/lama-crop.test.ts
+++ b/tests/cv/lama-crop.test.ts
@@ -7,7 +7,14 @@ import {
 } from '../../src/workers/cv/lama-crop';
 import { LAMA_PARAMS } from '../../src/pipeline/constants';
 
-function makeMask(w: number, h: number, rx: number, ry: number, rw: number, rh: number): Uint8Array {
+function makeMask(
+  w: number,
+  h: number,
+  rx: number,
+  ry: number,
+  rw: number,
+  rh: number,
+): Uint8Array {
   const m = new Uint8Array(w * h);
   for (let y = ry; y < ry + rh; y++) {
     for (let x = rx; x < rx + rw; x++) {
@@ -35,7 +42,8 @@ describe('computeLamaCropRect', () => {
   });
 
   it('produces a square crop (w === h)', () => {
-    const w = 400, h = 300;
+    const w = 400,
+      h = 300;
     const mask = makeMask(w, h, 50, 40, 30, 60); // non-square bbox
     const rect = computeLamaCropRect(mask, w, h)!;
     expect(rect).not.toBeNull();
@@ -43,14 +51,16 @@ describe('computeLamaCropRect', () => {
   });
 
   it('enforces MIN_CROP_SIDE when the mask bbox is tiny', () => {
-    const w = 512, h = 512;
+    const w = 512,
+      h = 512;
     const mask = makeMask(w, h, 100, 100, 4, 4);
     const rect = computeLamaCropRect(mask, w, h)!;
     expect(rect.w).toBeGreaterThanOrEqual(LAMA_PARAMS.MIN_CROP_SIDE);
   });
 
   it('clamps the crop inside the image bounds', () => {
-    const w = 200, h = 200;
+    const w = 200,
+      h = 200;
     // Mask at the bottom-right corner — crop must not overflow.
     const mask = makeMask(w, h, 180, 180, 10, 10);
     const rect = computeLamaCropRect(mask, w, h)!;
@@ -61,7 +71,8 @@ describe('computeLamaCropRect', () => {
   });
 
   it('never returns a crop bigger than min(width, height)', () => {
-    const w = 80, h = 600;
+    const w = 80,
+      h = 600;
     const mask = makeMask(w, h, 10, 100, 60, 400); // very tall bbox
     const rect = computeLamaCropRect(mask, w, h)!;
     expect(rect.w).toBeLessThanOrEqual(Math.min(w, h));
@@ -69,7 +80,8 @@ describe('computeLamaCropRect', () => {
   });
 
   it('centres the square on the mask bbox midpoint when there is room', () => {
-    const w = 1000, h = 1000;
+    const w = 1000,
+      h = 1000;
     const mask = makeMask(w, h, 450, 450, 100, 100); // centred mask
     const rect = computeLamaCropRect(mask, w, h)!;
     const cx = rect.x + rect.w / 2;
@@ -81,13 +93,18 @@ describe('computeLamaCropRect', () => {
 
 describe('bilinearResizeRGBA', () => {
   it('resizing a solid colour preserves that colour exactly', () => {
-    const w = 200, h = 200;
+    const w = 200,
+      h = 200;
     const src = solidRgba(w, h, 120, 80, 200);
     const rect = { x: 50, y: 50, w: 100, h: 100 };
     const out = bilinearResizeRGBA(src, w, rect, 64);
     expect(out.length).toBe(64 * 64 * 4);
     // Sample a few interior pixels.
-    for (const [ox, oy] of [[0, 0], [32, 32], [63, 63]]) {
+    for (const [ox, oy] of [
+      [0, 0],
+      [32, 32],
+      [63, 63],
+    ]) {
       const i = (oy * 64 + ox) * 4;
       expect(out[i]).toBe(120);
       expect(out[i + 1]).toBe(80);
@@ -99,7 +116,8 @@ describe('bilinearResizeRGBA', () => {
 
 describe('nearestResizeMask', () => {
   it('output is strictly binary {0,1}', () => {
-    const w = 50, h = 50;
+    const w = 50,
+      h = 50;
     const mask = makeMask(w, h, 10, 10, 30, 30);
     const rect = { x: 0, y: 0, w, h };
     const out = nearestResizeMask(mask, w, rect, 32);
@@ -109,7 +127,8 @@ describe('nearestResizeMask', () => {
   });
 
   it('a fully-covered mask resizes to a fully-covered mask', () => {
-    const w = 32, h = 32;
+    const w = 32,
+      h = 32;
     const mask = new Uint8Array(w * h).fill(1);
     const rect = { x: 0, y: 0, w, h };
     const out = nearestResizeMask(mask, w, rect, 64);
@@ -119,7 +138,8 @@ describe('nearestResizeMask', () => {
 
 describe('spliceLamaOutput', () => {
   it('overwrites only the crop rectangle and leaves the rest untouched', () => {
-    const baseW = 100, baseH = 100;
+    const baseW = 100,
+      baseH = 100;
     const base = solidRgba(baseW, baseH, 10, 20, 30);
     // LaMa output: solid red at model resolution.
     const lamaSize = 64;

--- a/tests/cv/lama-router.test.ts
+++ b/tests/cv/lama-router.test.ts
@@ -32,7 +32,14 @@ function checker(w: number, h: number, cell: number): Uint8ClampedArray {
 }
 
 /** Binary mask with a filled rectangle. */
-function rectMask(w: number, h: number, rx: number, ry: number, rw: number, rh: number): Uint8Array {
+function rectMask(
+  w: number,
+  h: number,
+  rx: number,
+  ry: number,
+  rw: number,
+  rh: number,
+): Uint8Array {
   const m = new Uint8Array(w * h);
   for (let y = ry; y < ry + rh; y++) {
     for (let x = rx; x < rx + rw; x++) {
@@ -44,7 +51,8 @@ function rectMask(w: number, h: number, rx: number, ry: number, rw: number, rh: 
 
 describe('shouldUseLama', () => {
   it('returns useLama=false on a uniform sky (no structure to reconstruct)', () => {
-    const w = 64, h = 64;
+    const w = 64,
+      h = 64;
     const pixels = solid(w, h, 180);
     const mask = rectMask(w, h, 20, 20, 16, 16);
 
@@ -56,7 +64,8 @@ describe('shouldUseLama', () => {
   });
 
   it('returns useLama=true on a high-contrast checker (edges + variance present)', () => {
-    const w = 64, h = 64;
+    const w = 64,
+      h = 64;
     const pixels = checker(w, h, 4);
     const mask = rectMask(w, h, 20, 20, 16, 16);
 
@@ -67,12 +76,13 @@ describe('shouldUseLama', () => {
     // for this aggressive pattern.
     expect(
       decision.variance > LAMA_ROUTER_PARAMS.VARIANCE_THRESHOLD ||
-      decision.edgeDensity > LAMA_ROUTER_PARAMS.EDGE_DENSITY_THRESHOLD,
+        decision.edgeDensity > LAMA_ROUTER_PARAMS.EDGE_DENSITY_THRESHOLD,
     ).toBe(true);
   });
 
   it('returns useLama=false on an empty mask with an all-zero bbox', () => {
-    const w = 32, h = 32;
+    const w = 32,
+      h = 32;
     const pixels = checker(w, h, 4);
     const mask = new Uint8Array(w * h); // all zeros
 
@@ -83,7 +93,8 @@ describe('shouldUseLama', () => {
   });
 
   it('expands the sample bbox by SAMPLE_BBOX_MARGIN, clamped to image bounds', () => {
-    const w = 32, h = 32;
+    const w = 32,
+      h = 32;
     const pixels = solid(w, h, 128);
     // Mask at top-left corner — expanded bbox must not go negative.
     const mask = rectMask(w, h, 0, 0, 4, 4);

--- a/tests/cv/patchmatch-inpaint.test.ts
+++ b/tests/cv/patchmatch-inpaint.test.ts
@@ -1,9 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import {
-  patchDistance,
-  initNNF,
-  patchMatchInpaint,
-} from '../../src/workers/cv/patchmatch-inpaint';
+import { patchDistance, initNNF, patchMatchInpaint } from '../../src/workers/cv/patchmatch-inpaint';
 
 /** RGBA image filled with a solid color. */
 function solid(w: number, h: number, r: number, g: number, b: number): Uint8ClampedArray {
@@ -67,7 +63,8 @@ describe('patchDistance', () => {
 
 describe('initNNF', () => {
   it('produces valid source coordinates for each target pixel', () => {
-    const w = 20, h = 20;
+    const w = 20,
+      h = 20;
     const mask = circleMask(w, h, 10, 10, 3);
     const nnf = initNNF(w, h, mask, 3);
     expect(nnf.length).toBe(w * h * 2);
@@ -91,7 +88,8 @@ describe('initNNF', () => {
 
 describe('patchMatchInpaint', () => {
   it('does not modify pixels outside the mask', () => {
-    const w = 32, h = 32;
+    const w = 32,
+      h = 32;
     const src = stripes(w, h, 4);
     const mask = circleMask(w, h, 16, 16, 3);
     const out = patchMatchInpaint(src, w, h, mask, { iterations: 2, patchRadius: 3 });
@@ -107,7 +105,8 @@ describe('patchMatchInpaint', () => {
   });
 
   it('fills a uniform-color mask with the same color', () => {
-    const w = 40, h = 40;
+    const w = 40,
+      h = 40;
     const src = solid(w, h, 140, 80, 40);
     const mask = circleMask(w, h, 20, 20, 5);
     const out = patchMatchInpaint(src, w, h, mask, { iterations: 2, patchRadius: 3 });
@@ -124,7 +123,8 @@ describe('patchMatchInpaint', () => {
   });
 
   it('reconstructs a striped pattern consistently (structure + texture)', () => {
-    const w = 48, h = 48;
+    const w = 48,
+      h = 48;
     const period = 4;
     const src = stripes(w, h, period);
     // Small square mask in the middle
@@ -147,11 +147,12 @@ describe('patchMatchInpaint', () => {
       }
     }
     // At least 70% of reconstructed pixels should be crisp (not midtone mush)
-    expect(crisp / total).toBeGreaterThan(0.70);
+    expect(crisp / total).toBeGreaterThan(0.7);
   });
 
   it('preserves the alpha channel at 255 in the mask region', () => {
-    const w = 30, h = 30;
+    const w = 30,
+      h = 30;
     const src = solid(w, h, 100, 100, 100);
     const mask = circleMask(w, h, 15, 15, 4);
     const out = patchMatchInpaint(src, w, h, mask, { iterations: 2, patchRadius: 3 });
@@ -161,7 +162,8 @@ describe('patchMatchInpaint', () => {
   });
 
   it('respects a search region restriction (no source patches from forbidden zone)', () => {
-    const w = 60, h = 60;
+    const w = 60,
+      h = 60;
     // Left half is red, right half is blue. Mask is in the center column.
     const pixels = new Uint8ClampedArray(w * h * 4);
     for (let y = 0; y < h; y++) {

--- a/tests/cv/shadow-cleanup.test.ts
+++ b/tests/cv/shadow-cleanup.test.ts
@@ -4,7 +4,8 @@ import { solidImage, paintRect, countBg } from '../helpers';
 
 describe('shadowCleanup', () => {
   it('no modifica la mascara si no hay sombras', () => {
-    const w = 64, h = 64;
+    const w = 64,
+      h = 64;
     const pixels = solidImage(w, h, 255, 0, 0); // sujeto rojo saturado
     // Mascara donde todo el borde es fondo
     const mask = new Uint8Array(w * h);
@@ -25,7 +26,8 @@ describe('shadowCleanup', () => {
   });
 
   it('marca sombras pequenas como fondo', () => {
-    const w = 128, h = 128;
+    const w = 128,
+      h = 128;
     // Fondo blanco con un sujeto colorido
     const pixels = solidImage(w, h, 255, 255, 255);
     // Sujeto rojo en el centro
@@ -57,7 +59,8 @@ describe('shadowCleanup', () => {
   });
 
   it('no marca blobs grandes como fondo (limite maxBlobSize)', () => {
-    const w = 200, h = 200;
+    const w = 200,
+      h = 200;
     const pixels = solidImage(w, h, 255, 255, 255);
     // Blob gris grande (mayor que maxBlobSize=100 para este test)
     paintRect(pixels, w, 50, 50, 60, 60, 80, 80, 80);
@@ -83,7 +86,8 @@ describe('shadowCleanup', () => {
   });
 
   it('no toca pixeles saturados (sujeto colorido)', () => {
-    const w = 64, h = 64;
+    const w = 64,
+      h = 64;
     // Sujeto rojo intenso (saturacion alta)
     const pixels = solidImage(w, h, 255, 0, 0);
     const mask = new Uint8Array(w * h); // todo foreground
@@ -95,7 +99,8 @@ describe('shadowCleanup', () => {
   });
 
   it('maneja mascara vacia (todo foreground)', () => {
-    const w = 32, h = 32;
+    const w = 32,
+      h = 32;
     const pixels = solidImage(w, h, 100, 100, 100);
     const mask = new Uint8Array(w * h);
 
@@ -105,7 +110,8 @@ describe('shadowCleanup', () => {
   });
 
   it('maneja mascara llena (todo background)', () => {
-    const w = 32, h = 32;
+    const w = 32,
+      h = 32;
     const pixels = solidImage(w, h, 100, 100, 100);
     const mask = new Uint8Array(w * h).fill(1);
 

--- a/tests/cv/signature-threshold.test.ts
+++ b/tests/cv/signature-threshold.test.ts
@@ -1,10 +1,15 @@
 import { describe, it, expect } from 'vitest';
-import { signatureThreshold, computeOtsu, morphologicalClose } from '../../src/workers/cv/signature-threshold';
+import {
+  signatureThreshold,
+  computeOtsu,
+  morphologicalClose,
+} from '../../src/workers/cv/signature-threshold';
 import { solidImage } from '../helpers';
 
 describe('signatureThreshold', () => {
   it('extracts dark strokes on white background', () => {
-    const w = 100, h = 100;
+    const w = 100,
+      h = 100;
     // White background
     const pixels = solidImage(w, h, 255, 255, 255);
     // Draw a black horizontal stripe at y=50
@@ -30,7 +35,8 @@ describe('signatureThreshold', () => {
   });
 
   it('handles gray background with dark strokes via Sauvola', () => {
-    const w = 300, h = 300;
+    const w = 300,
+      h = 300;
     // Gray background (not white)
     const pixels = solidImage(w, h, 180, 180, 180);
     // Draw black strokes
@@ -54,7 +60,8 @@ describe('signatureThreshold', () => {
   });
 
   it('returns all transparent for all-white image', () => {
-    const w = 100, h = 100;
+    const w = 100,
+      h = 100;
     const pixels = solidImage(w, h, 255, 255, 255);
 
     const alpha = signatureThreshold(pixels, w, h);
@@ -68,7 +75,8 @@ describe('signatureThreshold', () => {
   });
 
   it('returns uniform alpha for all-black image (no contrast to detect)', () => {
-    const w = 100, h = 100;
+    const w = 100,
+      h = 100;
     const pixels = solidImage(w, h, 0, 0, 0);
 
     const alpha = signatureThreshold(pixels, w, h);
@@ -79,7 +87,10 @@ describe('signatureThreshold', () => {
     const first = alpha[0];
     let allEqual = true;
     for (let i = 1; i < alpha.length; i++) {
-      if (alpha[i] !== first) { allEqual = false; break; }
+      if (alpha[i] !== first) {
+        allEqual = false;
+        break;
+      }
     }
     expect(allEqual).toBe(true);
     // Value should be at the midpoint of the anti-aliasing band
@@ -88,7 +99,8 @@ describe('signatureThreshold', () => {
   });
 
   it('falls back to Otsu for small images', () => {
-    const w = 50, h = 50;
+    const w = 50,
+      h = 50;
     // Small image: should use Otsu, not Sauvola
     const pixels = solidImage(w, h, 255, 255, 255);
     // Add a dark spot
@@ -141,7 +153,8 @@ describe('computeOtsu', () => {
 
 describe('morphologicalClose', () => {
   it('fills single-pixel gap in a horizontal line', () => {
-    const w = 10, h = 5;
+    const w = 10,
+      h = 5;
     const alpha = new Uint8Array(w * h);
 
     // Horizontal line at y=2 with a 1px gap at x=5
@@ -156,7 +169,8 @@ describe('morphologicalClose', () => {
   });
 
   it('does not expand isolated pixels beyond close radius', () => {
-    const w = 20, h = 20;
+    const w = 20,
+      h = 20;
     const alpha = new Uint8Array(w * h);
 
     // Single isolated pixel at center

--- a/tests/cv/simple-flood-fill.test.ts
+++ b/tests/cv/simple-flood-fill.test.ts
@@ -4,7 +4,8 @@ import { solidImage, paintRect, countBg } from '../helpers';
 
 describe('simpleFloodFill', () => {
   it('marca todo como fondo en imagen solida', () => {
-    const w = 64, h = 64;
+    const w = 64,
+      h = 64;
     const pixels = solidImage(w, h, 255, 255, 255);
     const colorA = [255, 255, 255];
     const colorB = [255, 255, 255];
@@ -15,7 +16,8 @@ describe('simpleFloodFill', () => {
   });
 
   it('no marca pixeles de un color distinto al fondo', () => {
-    const w = 64, h = 64;
+    const w = 64,
+      h = 64;
     const pixels = solidImage(w, h, 255, 255, 255);
     // Paint a red subject in the center that doesn't touch edges
     paintRect(pixels, w, 20, 20, 24, 24, 255, 0, 0);
@@ -39,7 +41,8 @@ describe('simpleFloodFill', () => {
   });
 
   it('funciona con fondo negro', () => {
-    const w = 64, h = 64;
+    const w = 64,
+      h = 64;
     const pixels = solidImage(w, h, 0, 0, 0);
     paintRect(pixels, w, 20, 20, 10, 10, 200, 100, 50);
 
@@ -56,7 +59,8 @@ describe('simpleFloodFill', () => {
   });
 
   it('no invade sujeto que toca el borde si color difiere', () => {
-    const w = 64, h = 64;
+    const w = 64,
+      h = 64;
     const pixels = solidImage(w, h, 255, 255, 255);
     // Sujeto azul tocando borde izquierdo
     paintRect(pixels, w, 0, 20, 10, 24, 0, 0, 255);
@@ -73,7 +77,8 @@ describe('simpleFloodFill', () => {
   });
 
   it('acepta dos colores de fondo distintos (colorA y colorB)', () => {
-    const w = 64, h = 64;
+    const w = 64,
+      h = 64;
     const pixels = solidImage(w, h, 200, 200, 200);
     // Mitad izquierda con un color, derecha con otro
     for (let y = 0; y < h; y++) {

--- a/tests/cv/sparkle-detect.test.ts
+++ b/tests/cv/sparkle-detect.test.ts
@@ -69,7 +69,7 @@ describe('sparkleDetect', () => {
     expect(result.mask).not.toBeNull();
     // Sparkle sits in the bottom-right quadrant of the downscaled selfie
     expect(result.centerX).toBeGreaterThan(width * 0.75);
-    expect(result.centerY).toBeGreaterThan(height * 0.70);
+    expect(result.centerY).toBeGreaterThan(height * 0.7);
     // Radius should be within the relative band (1.5%-5.5% of min dim)
     const minDim = Math.min(width, height);
     expect(result.radius).toBeGreaterThanOrEqual(Math.floor(minDim * 0.015));
@@ -86,11 +86,7 @@ describe('sparkleDetect', () => {
   });
 
   // Real-world negatives — production false positives we must reject.
-  const cleanFixtures = [
-    'motorcycles-clean.png',
-    'fiat-clean.png',
-    'trump-clean.png',
-  ] as const;
+  const cleanFixtures = ['motorcycles-clean.png', 'fiat-clean.png', 'trump-clean.png'] as const;
   for (const name of cleanFixtures) {
     it(`does not detect on clean real photo: ${name}`, async () => {
       const { pixels, width, height } = await loadFixture(name);
@@ -100,7 +96,8 @@ describe('sparkleDetect', () => {
   }
 
   it('does not detect on a solid color image', () => {
-    const w = 512, h = 512;
+    const w = 512,
+      h = 512;
     const pixels = solidImage(w, h, 180, 140, 100);
 
     const result = sparkleDetect(pixels, w, h);
@@ -109,7 +106,8 @@ describe('sparkleDetect', () => {
   });
 
   it('detects a synthetic 4-pointed sparkle painted on a uniform bg', () => {
-    const w = 500, h = 500;
+    const w = 500,
+      h = 500;
     const pixels = solidImage(w, h, 90, 70, 60);
     // Paint a sparkle in the bottom-right area. Radius 20 sits inside the
     // detector's 1.5-5.5% band (500 * 0.055 = 27.5).
@@ -125,7 +123,8 @@ describe('sparkleDetect', () => {
   });
 
   it('returns a non-empty circular mask when detected', () => {
-    const w = 500, h = 500;
+    const w = 500,
+      h = 500;
     const pixels = solidImage(w, h, 80, 80, 80);
     paintSparkle(pixels, w, 430, 430, 18, [240, 240, 240]);
 
@@ -141,7 +140,8 @@ describe('sparkleDetect', () => {
   });
 
   it('handles small images without crashing', () => {
-    const w = 80, h = 80;
+    const w = 80,
+      h = 80;
     const pixels = solidImage(w, h, 200, 200, 200);
 
     const result = sparkleDetect(pixels, w, h);

--- a/tests/cv/spatial-refinement.test.ts
+++ b/tests/cv/spatial-refinement.test.ts
@@ -11,7 +11,8 @@ import { solidImage, paintRect } from '../helpers';
 
 describe('shadowCleanup (spatial refinement / removeSmallClusters)', () => {
   it('removes a small gray blob disconnected from the subject', () => {
-    const w = 64, h = 64;
+    const w = 64,
+      h = 64;
     const pixels = solidImage(w, h, 255, 255, 255);
 
     // Large colorful subject (will not be removed)
@@ -46,7 +47,8 @@ describe('shadowCleanup (spatial refinement / removeSmallClusters)', () => {
   });
 
   it('does not remove a large blob (exceeds maxBlobSize)', () => {
-    const w = 128, h = 128;
+    const w = 128,
+      h = 128;
     const pixels = solidImage(w, h, 255, 255, 255);
 
     // Large gray blob (>maxBlobSize by default)
@@ -69,7 +71,8 @@ describe('shadowCleanup (spatial refinement / removeSmallClusters)', () => {
   });
 
   it('does not touch pixels that are already background', () => {
-    const w = 16, h = 16;
+    const w = 16,
+      h = 16;
     const pixels = solidImage(w, h, 255, 255, 255);
 
     const mask = new Uint8Array(w * h);
@@ -84,7 +87,8 @@ describe('shadowCleanup (spatial refinement / removeSmallClusters)', () => {
   });
 
   it('does not remove foreground with high saturation (real color, not shadow)', () => {
-    const w = 32, h = 32;
+    const w = 32,
+      h = 32;
     const pixels = solidImage(w, h, 255, 255, 255);
 
     // Highly colorful blob (high saturation)
@@ -106,7 +110,8 @@ describe('shadowCleanup (spatial refinement / removeSmallClusters)', () => {
   });
 
   it('removes multiple small independent shadow blobs', () => {
-    const w = 64, h = 64;
+    const w = 64,
+      h = 64;
     const pixels = solidImage(w, h, 255, 255, 255);
 
     // Real subject
@@ -149,7 +154,8 @@ describe('shadowCleanup (spatial refinement / removeSmallClusters)', () => {
   });
 
   it('handles image with no foreground (all background)', () => {
-    const w = 16, h = 16;
+    const w = 16,
+      h = 16;
     const pixels = solidImage(w, h, 128, 128, 128);
     const mask = new Uint8Array(w * h).fill(1);
 
@@ -159,7 +165,8 @@ describe('shadowCleanup (spatial refinement / removeSmallClusters)', () => {
   });
 
   it('handles image with all foreground (no background)', () => {
-    const w = 16, h = 16;
+    const w = 16,
+      h = 16;
     const pixels = solidImage(w, h, 200, 50, 50);
     const mask = new Uint8Array(w * h); // all foreground
 
@@ -168,7 +175,8 @@ describe('shadowCleanup (spatial refinement / removeSmallClusters)', () => {
   });
 
   it('respects custom maxBlobSize parameter', () => {
-    const w = 32, h = 32;
+    const w = 32,
+      h = 32;
     const pixels = solidImage(w, h, 255, 255, 255);
 
     // Gray blob of 5x5 = 25 pixels
@@ -192,7 +200,8 @@ describe('shadowCleanup (spatial refinement / removeSmallClusters)', () => {
   });
 
   it('does not remove bright pixels (brightness > MAX) or dark pixels (brightness < MIN)', () => {
-    const w = 32, h = 32;
+    const w = 32,
+      h = 32;
     const pixels = solidImage(w, h, 200, 200, 200);
 
     // Near-white blob (brightness > BRIGHTNESS_MAX=220)

--- a/tests/cv/subject-exclusion.test.ts
+++ b/tests/cv/subject-exclusion.test.ts
@@ -7,7 +7,9 @@ describe('subjectExclusion', () => {
   const light: [number, number, number] = [255, 255, 255];
 
   it('marca todo como fondo en checkerboard puro', () => {
-    const w = 128, h = 128, gs = 16;
+    const w = 128,
+      h = 128,
+      gs = 16;
     const pixels = checkerboardImage(w, h, gs, dark, light);
 
     const mask = subjectExclusion(pixels, w, h, dark, light, gs, 0);
@@ -18,7 +20,9 @@ describe('subjectExclusion', () => {
   });
 
   it('identifica sujeto colorido central', () => {
-    const w = 128, h = 128, gs = 16;
+    const w = 128,
+      h = 128,
+      gs = 16;
     const pixels = checkerboardImage(w, h, gs, dark, light);
 
     // Sujeto rojo brillante de 48x48 en el centro
@@ -39,7 +43,9 @@ describe('subjectExclusion', () => {
   });
 
   it('el fondo checkerboard alrededor del sujeto se marca como bg', () => {
-    const w = 128, h = 128, gs = 16;
+    const w = 128,
+      h = 128,
+      gs = 16;
     const pixels = checkerboardImage(w, h, gs, dark, light);
     paintRect(pixels, w, 40, 40, 48, 48, 0, 200, 0);
 
@@ -58,7 +64,9 @@ describe('subjectExclusion', () => {
   });
 
   it('devuelve todo fondo si no hay sujeto detectable (baja saturacion)', () => {
-    const w = 64, h = 64, gs = 16;
+    const w = 64,
+      h = 64,
+      gs = 16;
     const pixels = checkerboardImage(w, h, gs, dark, light);
 
     const mask = subjectExclusion(pixels, w, h, dark, light, gs, 0);
@@ -69,7 +77,9 @@ describe('subjectExclusion', () => {
   });
 
   it('maneja imagen pequena sin crash', () => {
-    const w = 16, h = 16, gs = 8;
+    const w = 16,
+      h = 16,
+      gs = 8;
     const pixels = checkerboardImage(w, h, gs, dark, light);
 
     const mask = subjectExclusion(pixels, w, h, dark, light, gs, 0);

--- a/tests/cv/utils.test.ts
+++ b/tests/cv/utils.test.ts
@@ -1,5 +1,12 @@
 import { describe, it, expect } from 'vitest';
-import { RingBuffer, pixelIndex, maxChannelDiff, mean, std, median } from '../../src/workers/cv/utils';
+import {
+  RingBuffer,
+  pixelIndex,
+  maxChannelDiff,
+  mean,
+  std,
+  median,
+} from '../../src/workers/cv/utils';
 
 describe('pixelIndex', () => {
   it('calcula el indice RGBA correcto', () => {

--- a/tests/cv/watermark-detect.test.ts
+++ b/tests/cv/watermark-detect.test.ts
@@ -4,7 +4,8 @@ import { solidImage, paintRect } from '../helpers';
 
 describe('watermarkDetect', () => {
   it('no detecta watermark en imagen limpia con fondo solido', () => {
-    const w = 512, h = 512;
+    const w = 512,
+      h = 512;
     const pixels = solidImage(w, h, 255, 255, 255);
 
     const result = watermarkDetect(pixels, w, h, [255, 255, 255], [255, 255, 255]);
@@ -14,7 +15,8 @@ describe('watermarkDetect', () => {
   });
 
   it('no detecta watermark en imagen con sujeto pero sin sparkle', () => {
-    const w = 512, h = 512;
+    const w = 512,
+      h = 512;
     const pixels = solidImage(w, h, 255, 255, 255);
     // Subject in the center
     paintRect(pixels, w, 200, 200, 112, 112, 100, 50, 150);
@@ -25,7 +27,8 @@ describe('watermarkDetect', () => {
   });
 
   it('detecta sparkle simulado en esquina inferior derecha', () => {
-    const w = 512, h = 512;
+    const w = 512,
+      h = 512;
     const pixels = solidImage(w, h, 200, 200, 200);
 
     // Simulate a cluster of bright pixels (sparkle) in bottom-right
@@ -41,7 +44,7 @@ describe('watermarkDetect', () => {
           const x = cx + dx;
           if (y >= 0 && y < h && x >= 0 && x < w) {
             const i = (y * w + x) * 4;
-            pixels[i] = 255;     // r - muy diferente a 200
+            pixels[i] = 255; // r - muy diferente a 200
             pixels[i + 1] = 255; // g
             pixels[i + 2] = 255; // b
           }
@@ -59,7 +62,8 @@ describe('watermarkDetect', () => {
   });
 
   it('no detecta ruido disperso como watermark (filtro de mediana de distancia)', () => {
-    const w = 512, h = 512;
+    const w = 512,
+      h = 512;
     const pixels = solidImage(w, h, 200, 200, 200);
 
     // Pintar pixeles brillantes dispersos (no clustered) en bottom-right
@@ -88,7 +92,8 @@ describe('watermarkDetect', () => {
   });
 
   it('genera mascara circular con radio razonable', () => {
-    const w = 512, h = 512;
+    const w = 512,
+      h = 512;
     const pixels = solidImage(w, h, 100, 100, 100);
 
     // Sparkle concentrado
@@ -122,7 +127,8 @@ describe('watermarkDetect', () => {
   });
 
   it('rechaza cluster rojo brillante en esquina (no es color Gemini) — issue #152', () => {
-    const w = 512, h = 512;
+    const w = 512,
+      h = 512;
     const pixels = solidImage(w, h, 200, 200, 200);
 
     // Cluster denso de pixeles ROJOS en bottom-right — antes del fix
@@ -138,9 +144,9 @@ describe('watermarkDetect', () => {
           const x = cx + dx;
           if (y >= 0 && y < h && x >= 0 && x < w) {
             const i = (y * w + x) * 4;
-            pixels[i] = 220;     // r — rojo brillante (flor, logo, reflejo)
-            pixels[i + 1] = 30;  // g
-            pixels[i + 2] = 30;  // b
+            pixels[i] = 220; // r — rojo brillante (flor, logo, reflejo)
+            pixels[i + 1] = 30; // g
+            pixels[i + 2] = 30; // b
           }
         }
       }
@@ -151,7 +157,8 @@ describe('watermarkDetect', () => {
   });
 
   it('rechaza cluster amarillo brillante en esquina (no es color Gemini) — issue #152', () => {
-    const w = 512, h = 512;
+    const w = 512,
+      h = 512;
     const pixels = solidImage(w, h, 100, 100, 100);
 
     const cy = h - 50;
@@ -164,7 +171,7 @@ describe('watermarkDetect', () => {
           const i = (y * w + x) * 4;
           pixels[i] = 255;
           pixels[i + 1] = 255;
-          pixels[i + 2] = 0;     // amarillo puro — saturación alta, no Gemini
+          pixels[i + 2] = 0; // amarillo puro — saturación alta, no Gemini
         }
       }
     }
@@ -174,7 +181,8 @@ describe('watermarkDetect', () => {
   });
 
   it('detecta sparkle blanco-azulado simulado (color Gemini válido) — issue #152', () => {
-    const w = 512, h = 512;
+    const w = 512,
+      h = 512;
     const pixels = solidImage(w, h, 100, 150, 80); // fondo verde
 
     const scanSize = Math.max(200, Math.floor(Math.min(h, w) / 5));
@@ -201,7 +209,8 @@ describe('watermarkDetect', () => {
   });
 
   it('maneja imagen pequena sin crash', () => {
-    const w = 100, h = 100;
+    const w = 100,
+      h = 100;
     const pixels = solidImage(w, h, 200, 200, 200);
 
     // No debe lanzar excepcion

--- a/tests/helpers.ts
+++ b/tests/helpers.ts
@@ -11,7 +11,7 @@ export function solidImage(
   r: number,
   g: number,
   b: number,
-  a = 255
+  a = 255,
 ): Uint8ClampedArray {
   const data = new Uint8ClampedArray(width * height * 4);
   for (let i = 0; i < width * height; i++) {
@@ -33,7 +33,7 @@ export function checkerboardImage(
   gridSize: number,
   colorDark: [number, number, number],
   colorLight: [number, number, number],
-  phase = 0
+  phase = 0,
 ): Uint8ClampedArray {
   const data = new Uint8ClampedArray(width * height * 4);
   for (let y = 0; y < height; y++) {
@@ -64,7 +64,7 @@ export function paintRect(
   h: number,
   r: number,
   g: number,
-  b: number
+  b: number,
 ): void {
   for (let y = y0; y < y0 + h; y++) {
     for (let x = x0; x < x0 + w; x++) {

--- a/tests/i18n-parity.test.ts
+++ b/tests/i18n-parity.test.ts
@@ -30,7 +30,7 @@ const EXPECTED_LOCALES = ['en', 'es', 'fr', 'de', 'pt', 'zh'] as const;
  * fact that each locale block sits at two-space indentation followed by
  * `<code>: {` and closes at a sibling `},` at the same indent.
  */
-function extractLocaleBlock(code: typeof EXPECTED_LOCALES[number]): string {
+function extractLocaleBlock(code: (typeof EXPECTED_LOCALES)[number]): string {
   const openRe = new RegExp(`^  ${code}:\\s*\\{`, 'm');
   const openMatch = openRe.exec(SOURCE);
   if (!openMatch) throw new Error(`locale "${code}" block not found in i18n/index.ts`);
@@ -75,12 +75,12 @@ describe('i18n key parity across locales', () => {
     it(`${code} declares exactly the same keys as en`, () => {
       const block = extractLocaleBlock(code);
       const keys = extractKeys(block);
-      const missing = enKeys.filter(k => !keys.includes(k));
-      const extra = keys.filter(k => !enKeys.includes(k));
-      expect(
-        { missing, extra },
-        `locale "${code}" key drift vs en`,
-      ).toEqual({ missing: [], extra: [] });
+      const missing = enKeys.filter((k) => !keys.includes(k));
+      const extra = keys.filter((k) => !enKeys.includes(k));
+      expect({ missing, extra }, `locale "${code}" key drift vs en`).toEqual({
+        missing: [],
+        extra: [],
+      });
     });
   }
 });

--- a/tests/i18n/rtl-scaffold.test.ts
+++ b/tests/i18n/rtl-scaffold.test.ts
@@ -42,7 +42,9 @@ describe('i18n — getDirection', () => {
 describe('setLocale wires document.documentElement.dir (#38)', () => {
   it('i18n module ships RTL_LOCALES + getDirection + dir assignment in setLocale', () => {
     expect(I18N).toMatch(/RTL_LOCALES = new Set\(\[/);
-    expect(I18N).toMatch(/export function getDirection\(locale: string\): ['"]rtl['"] \| ['"]ltr['"]/);
+    expect(I18N).toMatch(
+      /export function getDirection\(locale: string\): ['"]rtl['"] \| ['"]ltr['"]/,
+    );
     expect(I18N).toMatch(/document\.documentElement\.dir = getDirection\(locale\)/);
   });
 

--- a/tests/integration.test.ts
+++ b/tests/integration.test.ts
@@ -21,7 +21,7 @@ import { solidImage, checkerboardImage, paintRect } from './helpers';
 function runCvPipeline(
   pixels: Uint8ClampedArray,
   width: number,
-  height: number
+  height: number,
 ): { alpha: Uint8Array; bgType: string; watermarkRemoved: boolean } {
   // 1. Detect background
   const bgInfo = detectBgColors(pixels, width, height);
@@ -35,9 +35,13 @@ function runCvPipeline(
 
     if (grid.gridSize > 0) {
       bgMask = gridFloodFill(
-        pixels, width, height,
-        bgInfo.colorA, bgInfo.colorB,
-        grid.gridSize, grid.phase
+        pixels,
+        width,
+        height,
+        bgInfo.colorA,
+        bgInfo.colorB,
+        grid.gridSize,
+        grid.phase,
       );
 
       let bgCount = 0;
@@ -46,31 +50,26 @@ function runCvPipeline(
 
       if (coverage < CV_PARAMS.LOW_COVERAGE_THRESHOLD) {
         const exclMask = subjectExclusion(
-          pixels, width, height,
-          bgInfo.colorA, bgInfo.colorB,
-          grid.gridSize, grid.phase
+          pixels,
+          width,
+          height,
+          bgInfo.colorA,
+          bgInfo.colorB,
+          grid.gridSize,
+          grid.phase,
         );
-        const floodMask = simpleFloodFill(
-          pixels, width, height,
-          bgInfo.colorA, bgInfo.colorB
-        );
+        const floodMask = simpleFloodFill(pixels, width, height, bgInfo.colorA, bgInfo.colorB);
         bgMask = new Uint8Array(width * height);
         for (let i = 0; i < bgMask.length; i++) {
           bgMask[i] = exclMask[i] || floodMask[i] ? 1 : 0;
         }
       }
     } else {
-      bgMask = simpleFloodFill(
-        pixels, width, height,
-        bgInfo.colorA, bgInfo.colorB
-      );
+      bgMask = simpleFloodFill(pixels, width, height, bgInfo.colorA, bgInfo.colorB);
     }
   } else if (bgInfo.cornerVariance < CV_PARAMS.SOLID_BG_VARIANCE) {
     bgType = 'solid';
-    bgMask = simpleFloodFill(
-      pixels, width, height,
-      bgInfo.colorA, bgInfo.colorB
-    );
+    bgMask = simpleFloodFill(pixels, width, height, bgInfo.colorA, bgInfo.colorB);
   } else {
     bgType = 'complex';
     // In test, without ML worker, return empty mask
@@ -100,7 +99,9 @@ function runCvPipeline(
 
 describe('Integration: T1 - Gemini icon with checkerboard', () => {
   it('removes checkerboard and preserves subject', () => {
-    const w = 256, h = 256, gs = 16;
+    const w = 256,
+      h = 256,
+      gs = 16;
     const dark: [number, number, number] = [191, 191, 191];
     const light: [number, number, number] = [255, 255, 255];
     const pixels = checkerboardImage(w, h, gs, dark, light);
@@ -124,7 +125,8 @@ describe('Integration: T1 - Gemini icon with checkerboard', () => {
 
 describe('Integration: T2 - Illustration on white background', () => {
   it('removes solid white background and preserves subject', () => {
-    const w = 256, h = 256;
+    const w = 256,
+      h = 256;
     const pixels = solidImage(w, h, 255, 255, 255);
     paintRect(pixels, w, 60, 60, 136, 136, 100, 150, 80);
 
@@ -143,7 +145,8 @@ describe('Integration: T2 - Illustration on white background', () => {
 
 describe('Integration: T3 - Illustration on black background', () => {
   it('removes solid black background and preserves subject', () => {
-    const w = 256, h = 256;
+    const w = 256,
+      h = 256;
     const pixels = solidImage(w, h, 0, 0, 0);
     paintRect(pixels, w, 60, 60, 136, 136, 200, 100, 50);
 
@@ -159,7 +162,8 @@ describe('Integration: T5 - Already transparent PNG (passthrough)', () => {
   it('image with alpha 0 in corners is detected as solid and processed', () => {
     // Simulate an image with a uniform background color
     // (in the real world it would be alpha=0, but our pipeline operates on RGB)
-    const w = 128, h = 128;
+    const w = 128,
+      h = 128;
     const pixels = solidImage(w, h, 0, 0, 0);
     paintRect(pixels, w, 30, 30, 68, 68, 150, 200, 100);
 
@@ -171,7 +175,9 @@ describe('Integration: T5 - Already transparent PNG (passthrough)', () => {
 
 describe('Integration: performance', () => {
   it('processes 512x512 in less than 2 seconds (no ML)', () => {
-    const w = 512, h = 512, gs = 16;
+    const w = 512,
+      h = 512,
+      gs = 16;
     const dark: [number, number, number] = [191, 191, 191];
     const light: [number, number, number] = [255, 255, 255];
     const pixels = checkerboardImage(w, h, gs, dark, light);
@@ -186,7 +192,8 @@ describe('Integration: performance', () => {
   });
 
   it('processes 256x256 solid in less than 500ms', () => {
-    const w = 256, h = 256;
+    const w = 256,
+      h = 256;
     const pixels = solidImage(w, h, 255, 255, 255);
     paintRect(pixels, w, 60, 60, 136, 136, 100, 50, 200);
 
@@ -201,7 +208,8 @@ describe('Integration: performance', () => {
 
 describe('Integration: subject with shadows', () => {
   it('cleans gray shadows around the subject', () => {
-    const w = 256, h = 256;
+    const w = 256,
+      h = 256;
     const pixels = solidImage(w, h, 255, 255, 255);
 
     // Colorful subject

--- a/tests/ml/ml-pipeline.integration.test.ts
+++ b/tests/ml/ml-pipeline.integration.test.ts
@@ -40,7 +40,8 @@ function gradientImage(w: number, h: number): Uint8ClampedArray {
 
 describe('Inpaint Telea FMM', () => {
   it('no modifica pixeles fuera de la mascara', () => {
-    const w = 64, h = 64;
+    const w = 64,
+      h = 64;
     const pixels = solidImage(w, h, 128, 64, 32);
     const mask = new Uint8Array(w * h); // Mascara vacia: nada que reconstruir
 
@@ -53,11 +54,13 @@ describe('Inpaint Telea FMM', () => {
   });
 
   it('reconstruye una zona pequena en imagen solida', () => {
-    const w = 64, h = 64;
+    const w = 64,
+      h = 64;
     const pixels = solidImage(w, h, 200, 100, 50);
 
     // Corrupt a 4x4 block in the center
-    const cx = 32, cy = 32;
+    const cx = 32,
+      cy = 32;
     for (let dy = -2; dy <= 2; dy++) {
       for (let dx = -2; dx <= 2; dx++) {
         const i = (cy + dy) * w + (cx + dx);
@@ -81,19 +84,20 @@ describe('Inpaint Telea FMM', () => {
     for (let dy = -2; dy <= 2; dy++) {
       for (let dx = -2; dx <= 2; dx++) {
         const i = (cy + dy) * w + (cx + dx);
-        expect(result[i * 4]).toBeGreaterThan(150);     // R ~200
+        expect(result[i * 4]).toBeGreaterThan(150); // R ~200
         expect(result[i * 4]).toBeLessThan(255);
-        expect(result[i * 4 + 1]).toBeGreaterThan(50);  // G ~100
+        expect(result[i * 4 + 1]).toBeGreaterThan(50); // G ~100
         expect(result[i * 4 + 1]).toBeLessThan(150);
-        expect(result[i * 4 + 2]).toBeGreaterThan(10);  // B ~50
+        expect(result[i * 4 + 2]).toBeGreaterThan(10); // B ~50
         expect(result[i * 4 + 2]).toBeLessThan(100);
-        expect(result[i * 4 + 3]).toBe(255);            // Alpha opaco
+        expect(result[i * 4 + 3]).toBe(255); // Alpha opaco
       }
     }
   });
 
   it('produce valores RGBA en rango [0, 255]', () => {
-    const w = 64, h = 64;
+    const w = 64,
+      h = 64;
     const pixels = gradientImage(w, h);
 
     // Mascara diagonal
@@ -112,7 +116,8 @@ describe('Inpaint Telea FMM', () => {
   });
 
   it('funciona con mascara en esquina inferior derecha (watermark tipico)', () => {
-    const w = 128, h = 128;
+    const w = 128,
+      h = 128;
     const pixels = solidImage(w, h, 180, 180, 180);
 
     // Simular watermark en esquina inferior derecha: bloque de 20x20
@@ -146,7 +151,8 @@ describe('Inpaint Telea FMM', () => {
   });
 
   it('devuelve una nueva copia (no muta el input)', () => {
-    const w = 32, h = 32;
+    const w = 32,
+      h = 32;
     const pixels = solidImage(w, h, 100, 100, 100);
     const originalCopy = new Uint8ClampedArray(pixels);
     const mask = new Uint8Array(w * h);
@@ -163,12 +169,15 @@ describe('Inpaint Telea FMM', () => {
   });
 
   it('es rapido para mascaras de watermark tipicas', () => {
-    const w = 512, h = 512;
+    const w = 512,
+      h = 512;
     const pixels = gradientImage(w, h);
 
     // Mascara circular de radio ~30px en esquina (simula sparkle de Gemini)
     const mask = new Uint8Array(w * h);
-    const cx = w - 60, cy = h - 60, r = 30;
+    const cx = w - 60,
+      cy = h - 60,
+      r = 30;
     for (let y = 0; y < h; y++) {
       for (let x = 0; x < w; x++) {
         if ((x - cx) ** 2 + (y - cy) ** 2 <= r * r) {

--- a/tests/pipeline/extractTransferables.test.ts
+++ b/tests/pipeline/extractTransferables.test.ts
@@ -76,7 +76,8 @@ describe('originalPixels no se corrompe al usar extractTransferables', () => {
     // Simula lo que hace PipelineOrchestrator.process():
     // const originalPixels = new Uint8ClampedArray(imageData.data);
     // luego cada cvCall usa: new Uint8ClampedArray(imageData.data) como copia
-    const width = 16, height = 16;
+    const width = 16,
+      height = 16;
     const originalData = new Uint8ClampedArray(width * height * 4);
     for (let i = 0; i < originalData.length; i++) {
       originalData[i] = i % 256;
@@ -104,7 +105,8 @@ describe('originalPixels no se corrompe al usar extractTransferables', () => {
   });
 
   it('multiples copias son independientes del original', () => {
-    const width = 8, height = 8;
+    const width = 8,
+      height = 8;
     const source = new Uint8ClampedArray(width * height * 4);
     for (let i = 0; i < source.length; i++) {
       source[i] = 200;
@@ -129,11 +131,12 @@ describe('originalPixels no se corrompe al usar extractTransferables', () => {
   });
 
   it('la composicion final usa originalPixels sin corrupcion', () => {
-    const width = 4, height = 4;
+    const width = 4,
+      height = 4;
     const imagePixels = new Uint8ClampedArray(width * height * 4);
     // Fill with known colors
     for (let i = 0; i < width * height; i++) {
-      imagePixels[i * 4] = 100;     // R
+      imagePixels[i * 4] = 100; // R
       imagePixels[i * 4 + 1] = 150; // G
       imagePixels[i * 4 + 2] = 200; // B
       imagePixels[i * 4 + 3] = 255; // A

--- a/tests/pipeline/finalize-chain.test.ts
+++ b/tests/pipeline/finalize-chain.test.ts
@@ -11,11 +11,15 @@ if (typeof globalThis.ImageData === 'undefined') {
     data: Uint8ClampedArray;
     width: number;
     height: number;
-    constructor(dataOrWidth: Uint8ClampedArray | number, widthOrHeight: number, maybeHeight?: number) {
+    constructor(
+      dataOrWidth: Uint8ClampedArray | number,
+      widthOrHeight: number,
+      maybeHeight?: number,
+    ) {
       if (dataOrWidth instanceof Uint8ClampedArray) {
         this.data = dataOrWidth;
         this.width = widthOrHeight;
-        this.height = maybeHeight ?? (dataOrWidth.length / (widthOrHeight * 4));
+        this.height = maybeHeight ?? dataOrWidth.length / (widthOrHeight * 4);
       } else {
         this.width = dataOrWidth;
         this.height = widthOrHeight;
@@ -34,7 +38,8 @@ const runChain = (img: ImageData): ImageData =>
 
 // Build a synthetic image containing every defect class the chain must cure.
 const makeDefectiveSubject = () => {
-  const w = 40, h = 40;
+  const w = 40,
+    h = 40;
   const data = new Uint8ClampedArray(w * h * 4);
   // Solid body at (5,5)-(34,34): α=255, RGB=(200,100,50).
   for (let y = 5; y <= 34; y++) {
@@ -61,14 +66,32 @@ const countEnclosedHoles = (img: ImageData): number => {
   const n = w * h;
   const queue = new Int32Array(n);
   const bg = new Uint8Array(n);
-  let head = 0, tail = 0;
-  const seed = (i: number) => { if (data[i * 4 + 3] === 0 && !bg[i]) { bg[i] = 1; queue[tail++] = i; } };
-  for (let x = 0; x < w; x++) { seed(x); seed((h - 1) * w + x); }
-  for (let y = 1; y < h - 1; y++) { seed(y * w); seed(y * w + w - 1); }
+  let head = 0,
+    tail = 0;
+  const seed = (i: number) => {
+    if (data[i * 4 + 3] === 0 && !bg[i]) {
+      bg[i] = 1;
+      queue[tail++] = i;
+    }
+  };
+  for (let x = 0; x < w; x++) {
+    seed(x);
+    seed((h - 1) * w + x);
+  }
+  for (let y = 1; y < h - 1; y++) {
+    seed(y * w);
+    seed(y * w + w - 1);
+  }
   while (head < tail) {
     const i = queue[head++];
-    const x = i % w, y = (i - x) / w;
-    const push = (ni: number) => { if (data[ni * 4 + 3] === 0 && !bg[ni]) { bg[ni] = 1; queue[tail++] = ni; } };
+    const x = i % w,
+      y = (i - x) / w;
+    const push = (ni: number) => {
+      if (data[ni * 4 + 3] === 0 && !bg[ni]) {
+        bg[ni] = 1;
+        queue[tail++] = ni;
+      }
+    };
     if (x > 0) push(i - 1);
     if (x < w - 1) push(i + 1);
     if (y > 0) push(i - w);
@@ -79,11 +102,20 @@ const countEnclosedHoles = (img: ImageData): number => {
   for (let i = 0; i < n; i++) {
     if (data[i * 4 + 3] !== 0 || bg[i] || seen[i]) continue;
     holes++;
-    head = 0; tail = 0; queue[tail++] = i; seen[i] = 1;
+    head = 0;
+    tail = 0;
+    queue[tail++] = i;
+    seen[i] = 1;
     while (head < tail) {
       const j = queue[head++];
-      const x = j % w, y = (j - x) / w;
-      const push = (nj: number) => { if (data[nj * 4 + 3] === 0 && !bg[nj] && !seen[nj]) { seen[nj] = 1; queue[tail++] = nj; } };
+      const x = j % w,
+        y = (j - x) / w;
+      const push = (nj: number) => {
+        if (data[nj * 4 + 3] === 0 && !bg[nj] && !seen[nj]) {
+          seen[nj] = 1;
+          queue[tail++] = nj;
+        }
+      };
       if (x > 0) push(j - 1);
       if (x < w - 1) push(j + 1);
       if (y > 0) push(j - w);

--- a/tests/pipeline/finalize.test.ts
+++ b/tests/pipeline/finalize.test.ts
@@ -16,11 +16,15 @@ if (typeof globalThis.ImageData === 'undefined') {
     data: Uint8ClampedArray;
     width: number;
     height: number;
-    constructor(dataOrWidth: Uint8ClampedArray | number, widthOrHeight: number, maybeHeight?: number) {
+    constructor(
+      dataOrWidth: Uint8ClampedArray | number,
+      widthOrHeight: number,
+      maybeHeight?: number,
+    ) {
       if (dataOrWidth instanceof Uint8ClampedArray) {
         this.data = dataOrWidth;
         this.width = widthOrHeight;
-        this.height = maybeHeight ?? (dataOrWidth.length / (widthOrHeight * 4));
+        this.height = maybeHeight ?? dataOrWidth.length / (widthOrHeight * 4);
       } else {
         this.width = dataOrWidth;
         this.height = widthOrHeight;
@@ -85,11 +89,12 @@ describe('sharpenAlpha (smoothstep [80, 180])', () => {
 
 describe('refineEdges', () => {
   it('without pipeline: RGB is untouched, α is sharpened', async () => {
-    const w = 4, h = 1;
+    const w = 4,
+      h = 1;
     const data = new Uint8ClampedArray(w * h * 4);
     // Connected blob on the left (opaque + AA edge), halo tail + transparent on the right.
     // Layout keeps both bin=1 pixels adjacent so the CC keep-largest pass preserves them.
-    data.set([255, 0, 0, 255,   100, 100, 100, 200,   50, 50, 50, 30,   0, 0, 0, 0]);
+    data.set([255, 0, 0, 255, 100, 100, 100, 200, 50, 50, 50, 30, 0, 0, 0, 0]);
     const img = new ImageData(data, w, h);
 
     const out = await refineEdges(null, img);
@@ -102,14 +107,15 @@ describe('refineEdges', () => {
     }
 
     // α=200 ≥ HIGH → 255, α=30 ≤ LOW → 0
-    expect(out.data[3]).toBe(255);                // opaque endpoint
-    expect(out.data[7]).toBeGreaterThan(215);     // was 200, sharpened to 255
-    expect(out.data[11]).toBeLessThan(5);         // was 30, killed to 0
-    expect(out.data[15]).toBe(0);                 // transparent endpoint
+    expect(out.data[3]).toBe(255); // opaque endpoint
+    expect(out.data[7]).toBeGreaterThan(215); // was 200, sharpened to 255
+    expect(out.data[11]).toBeLessThan(5); // was 30, killed to 0
+    expect(out.data[15]).toBe(0); // transparent endpoint
   });
 
   it('with pipeline: delegates decontamination to estimateForeground', async () => {
-    const w = 2, h = 1;
+    const w = 2,
+      h = 1;
     const data = new Uint8ClampedArray([10, 20, 30, 128, 40, 50, 60, 200]);
     const img = new ImageData(data, w, h);
 
@@ -150,7 +156,8 @@ describe('refineEdges', () => {
   });
 
   it('returns a fresh ImageData (does not mutate input)', async () => {
-    const w = 2, h = 1;
+    const w = 2,
+      h = 1;
     const data = new Uint8ClampedArray([10, 20, 30, 50, 40, 50, 60, 150]);
     const img = new ImageData(data, w, h);
     const snapshot = Array.from(data);
@@ -163,11 +170,15 @@ describe('refineEdges', () => {
   it('removes isolated opaque blobs disconnected from the main subject', async () => {
     // 5x5: a 3x3 opaque block in the middle (main subject) plus one
     // opaque pixel in the bottom-right corner (stray RMBG artifact).
-    const w = 5, h = 5;
+    const w = 5,
+      h = 5;
     const data = new Uint8ClampedArray(w * h * 4);
     const setPixel = (x: number, y: number, a: number) => {
       const i = (y * w + x) * 4;
-      data[i] = 200; data[i + 1] = 100; data[i + 2] = 50; data[i + 3] = a;
+      data[i] = 200;
+      data[i + 1] = 100;
+      data[i + 2] = 50;
+      data[i + 3] = a;
     };
     // Main 2x2 blob at (0,0)-(1,1), fully opaque
     for (let y = 0; y <= 1; y++) for (let x = 0; x <= 1; x++) setPixel(x, y, 255);
@@ -265,11 +276,15 @@ describe('tailLuminanceVariance / hasHaloRisk', () => {
 describe('dropOrphanBlobs', () => {
   it('zeros α on disconnected blobs and preserves the main body verbatim', () => {
     // 5x5 canvas. Main 3x3 opaque block top-left, stray opaque pixel at (4,4).
-    const w = 5, h = 5;
+    const w = 5,
+      h = 5;
     const data = new Uint8ClampedArray(w * h * 4);
     const paint = (x: number, y: number, r: number, g: number, b: number, a: number) => {
       const i = (y * w + x) * 4;
-      data[i] = r; data[i + 1] = g; data[i + 2] = b; data[i + 3] = a;
+      data[i] = r;
+      data[i + 1] = g;
+      data[i + 2] = b;
+      data[i + 3] = a;
     };
     for (let y = 0; y < 3; y++) for (let x = 0; x < 3; x++) paint(x, y, 200, 100, 50, 255);
     paint(4, 4, 50, 50, 50, 128);
@@ -287,7 +302,8 @@ describe('dropOrphanBlobs', () => {
   });
 
   it('does not mutate RGB on any pixel', () => {
-    const w = 4, h = 4;
+    const w = 4,
+      h = 4;
     const data = new Uint8ClampedArray(w * h * 4);
     for (let i = 0; i < w * h; i++) {
       data[i * 4] = (i * 7) % 256;
@@ -310,15 +326,19 @@ describe('dropOrphanBlobs', () => {
     // 7x7 canvas: 3x3 block at (1..3,1..3) with opaque center + AA ring,
     // and a stray α=200 at (6,6) — Chebyshev distance 3 from the block,
     // far enough to survive 8-connectivity's diagonal reach.
-    const w = 7, h = 7;
+    const w = 7,
+      h = 7;
     const data = new Uint8ClampedArray(w * h * 4);
     const paint = (x: number, y: number, a: number) => {
       const i = (y * w + x) * 4;
-      data[i] = 120; data[i + 1] = 120; data[i + 2] = 120; data[i + 3] = a;
+      data[i] = 120;
+      data[i + 1] = 120;
+      data[i + 2] = 120;
+      data[i + 3] = a;
     };
     for (let y = 1; y <= 3; y++) {
       for (let x = 1; x <= 3; x++) {
-        paint(x, y, (x === 2 && y === 2) ? 255 : 64);
+        paint(x, y, x === 2 && y === 2 ? 255 : 64);
       }
     }
     paint(6, 6, 200); // disconnected
@@ -333,7 +353,8 @@ describe('dropOrphanBlobs', () => {
   });
 
   it('returns a fresh ImageData (does not mutate input)', () => {
-    const w = 3, h = 3;
+    const w = 3,
+      h = 3;
     const data = new Uint8ClampedArray(w * h * 4);
     for (let i = 0; i < w * h; i++) data[i * 4 + 3] = 255;
     const snapshot = Array.from(data);
@@ -346,7 +367,8 @@ describe('fillSubjectHoles', () => {
   // Helper: 7x7 solid subject with a single α=0 speck at an interior pixel.
   // Border pixels remain α=255, so the speck is topologically enclosed.
   const makeBodyWithHole = (holeX: number, holeY: number) => {
-    const w = 7, h = 7;
+    const w = 7,
+      h = 7;
     const data = new Uint8ClampedArray(w * h * 4);
     for (let i = 0; i < w * h; i++) {
       data[i * 4 + 0] = 200;
@@ -374,7 +396,8 @@ describe('fillSubjectHoles', () => {
   });
 
   it('leaves a large hole alone when it exceeds maxHoleSize', () => {
-    const w = 10, h = 10;
+    const w = 10,
+      h = 10;
     const data = new Uint8ClampedArray(w * h * 4);
     for (let i = 0; i < w * h; i++) data[i * 4 + 3] = 255;
     // Carve a 4x4 interior hole (16 px) at (3,3)-(6,6), border stays opaque.
@@ -388,7 +411,8 @@ describe('fillSubjectHoles', () => {
   });
 
   it('never fills α=0 regions that connect to the image border', () => {
-    const w = 5, h = 5;
+    const w = 5,
+      h = 5;
     const data = new Uint8ClampedArray(w * h * 4);
     // Opaque 3x3 block at (1,1)-(3,3); everything else α=0 (connected to border).
     for (let y = 1; y <= 3; y++) {
@@ -424,7 +448,8 @@ describe('promoteSpeckleAlpha', () => {
   // holding α=alphaVal and full RGB. A 5x5 window around (cx, cy) is all α=255,
   // so opaque_neighbors = 24/24 which clears the 75% ratio.
   const makeBodyWithSpeck = (cx: number, cy: number, alphaVal: number) => {
-    const w = 9, h = 9;
+    const w = 9,
+      h = 9;
     const data = new Uint8ClampedArray(w * h * 4);
     for (let i = 0; i < w * h; i++) {
       data[i * 4 + 0] = 200;
@@ -455,7 +480,8 @@ describe('promoteSpeckleAlpha', () => {
   });
 
   it('does not promote AA edge pixels (neighborhood not opaque enough)', () => {
-    const w = 9, h = 9;
+    const w = 9,
+      h = 9;
     const data = new Uint8ClampedArray(w * h * 4);
     // Half-plane opaque: left 5 columns α=255, right 4 columns α=0.
     for (let y = 0; y < h; y++) {
@@ -493,7 +519,8 @@ describe('promoteSpeckleAlpha', () => {
     // Two adjacent specks at (4,4) and (5,4). Without snapshotting, the first
     // promotion would feed into the second's neighborhood count — we want the
     // decision based on the ORIGINAL α only.
-    const w = 9, h = 9;
+    const w = 9,
+      h = 9;
     const data = new Uint8ClampedArray(w * h * 4);
     for (let i = 0; i < w * h; i++) data[i * 4 + 3] = 255;
     data[(4 * w + 4) * 4 + 3] = 100;
@@ -508,11 +535,7 @@ describe('promoteSpeckleAlpha', () => {
 
 describe('keepLargestComponent', () => {
   it('leaves a single component untouched', () => {
-    const bin = new Uint8Array([
-      0, 1, 1, 0,
-      0, 1, 1, 0,
-      0, 0, 0, 0,
-    ]);
+    const bin = new Uint8Array([0, 1, 1, 0, 0, 1, 1, 0, 0, 0, 0, 0]);
     const snapshot = Array.from(bin);
     keepLargestComponent(bin, 4, 3);
     expect(Array.from(bin)).toEqual(snapshot);
@@ -520,26 +543,14 @@ describe('keepLargestComponent', () => {
 
   it('drops smaller components, keeps the largest', () => {
     // Left 2x2 block (4 pixels) and right isolated pixel (1 pixel)
-    const bin = new Uint8Array([
-      1, 1, 0, 0, 1,
-      1, 1, 0, 0, 0,
-      0, 0, 0, 0, 0,
-    ]);
+    const bin = new Uint8Array([1, 1, 0, 0, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0]);
     keepLargestComponent(bin, 5, 3);
-    expect(Array.from(bin)).toEqual([
-      1, 1, 0, 0, 0,
-      1, 1, 0, 0, 0,
-      0, 0, 0, 0, 0,
-    ]);
+    expect(Array.from(bin)).toEqual([1, 1, 0, 0, 0, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0]);
   });
 
   it('uses 8-connectivity (diagonal neighbors count as connected)', () => {
     // Two pixels touching only diagonally — one component under 8-connectivity
-    const bin = new Uint8Array([
-      1, 0, 0,
-      0, 1, 0,
-      0, 0, 0,
-    ]);
+    const bin = new Uint8Array([1, 0, 0, 0, 1, 0, 0, 0, 0]);
     const snapshot = Array.from(bin);
     keepLargestComponent(bin, 3, 3);
     expect(Array.from(bin)).toEqual(snapshot);

--- a/tests/pipeline/modelId.test.ts
+++ b/tests/pipeline/modelId.test.ts
@@ -27,7 +27,7 @@ describe('ModelId parameter', () => {
   });
 
   it('MODEL_OPTIONS incluye RMBG-1.4', () => {
-    const rmbg = MODEL_OPTIONS.find(o => o.id === 'briaai/RMBG-1.4');
+    const rmbg = MODEL_OPTIONS.find((o) => o.id === 'briaai/RMBG-1.4');
     expect(rmbg).toBeDefined();
     expect(rmbg!.label).toBe('RMBG 1.4');
   });

--- a/tests/pipeline/orchestrator.test.ts
+++ b/tests/pipeline/orchestrator.test.ts
@@ -35,7 +35,7 @@ function simulateMlSoftAlpha(
   w: number,
   h: number,
   bgColorA: number[],
-  bgColorB: number[]
+  bgColorB: number[],
 ): Uint8Array {
   const alpha = new Uint8Array(w * h);
   for (let i = 0; i < w * h; i++) {
@@ -52,9 +52,9 @@ function simulateMlSoftAlpha(
 }
 
 describe('Pipeline - flujo de decision (nuevo: ML soft alpha)', () => {
-
   it('clasifica fondo solido correctamente', () => {
-    const w = 128, h = 128;
+    const w = 128,
+      h = 128;
     const pixels = solidImage(w, h, 255, 255, 255);
     paintRect(pixels, w, 40, 40, 48, 48, 200, 50, 50);
 
@@ -77,7 +77,9 @@ describe('Pipeline - flujo de decision (nuevo: ML soft alpha)', () => {
   });
 
   it('clasifica checkerboard y ejecuta grid flood fill para deteccion', () => {
-    const w = 256, h = 256, gs = 16;
+    const w = 256,
+      h = 256,
+      gs = 16;
     const dark: [number, number, number] = [191, 191, 191];
     const light: [number, number, number] = [255, 255, 255];
     const pixels = checkerboardImage(w, h, gs, dark, light);
@@ -101,7 +103,8 @@ describe('Pipeline - flujo de decision (nuevo: ML soft alpha)', () => {
   });
 
   it('clasifica background complejo (alta varianza, no checker)', () => {
-    const w = 128, h = 128;
+    const w = 128,
+      h = 128;
     // Image with gradient (high variance in corners, but not checker)
     const pixels = new Uint8ClampedArray(w * h * 4);
     for (let y = 0; y < h; y++) {
@@ -127,7 +130,9 @@ describe('Pipeline - flujo de decision (nuevo: ML soft alpha)', () => {
   });
 
   it('pipeline completo para checkerboard con coverage bajo ejecuta subject exclusion', () => {
-    const w = 128, h = 128, gs = 16;
+    const w = 128,
+      h = 128,
+      gs = 16;
     const dark: [number, number, number] = [191, 191, 191];
     const light: [number, number, number] = [255, 255, 255];
     const pixels = checkerboardImage(w, h, gs, dark, light);
@@ -143,9 +148,13 @@ describe('Pipeline - flujo de decision (nuevo: ML soft alpha)', () => {
 
       if (grid.gridSize > 0) {
         const bgMask = gridFloodFill(
-          pixels, w, h,
-          bgInfo.colorA, bgInfo.colorB,
-          grid.gridSize, grid.phase
+          pixels,
+          w,
+          h,
+          bgInfo.colorA,
+          bgInfo.colorB,
+          grid.gridSize,
+          grid.phase,
         );
 
         const coverage = countBg(bgMask) / (w * h);
@@ -153,15 +162,16 @@ describe('Pipeline - flujo de decision (nuevo: ML soft alpha)', () => {
         if (coverage < CV_PARAMS.LOW_COVERAGE_THRESHOLD) {
           // Fallback a subject exclusion
           const exclMask = subjectExclusion(
-            pixels, w, h,
-            bgInfo.colorA, bgInfo.colorB,
-            grid.gridSize, grid.phase
+            pixels,
+            w,
+            h,
+            bgInfo.colorA,
+            bgInfo.colorB,
+            grid.gridSize,
+            grid.phase,
           );
 
-          const floodMask = simpleFloodFill(
-            pixels, w, h,
-            bgInfo.colorA, bgInfo.colorB
-          );
+          const floodMask = simpleFloodFill(pixels, w, h, bgInfo.colorA, bgInfo.colorB);
 
           // Union
           const unionMask = new Uint8Array(w * h);
@@ -184,7 +194,8 @@ describe('Pipeline - flujo de decision (nuevo: ML soft alpha)', () => {
 
 describe('Pipeline - composicion final RGBA con soft alpha', () => {
   it('combina pixeles originales con soft alpha del ML model', () => {
-    const w = 16, h = 16;
+    const w = 16,
+      h = 16;
     const pixels = solidImage(w, h, 255, 255, 255);
     paintRect(pixels, w, 4, 4, 8, 8, 100, 150, 200);
 
@@ -217,7 +228,8 @@ describe('Pipeline - composicion final RGBA con soft alpha', () => {
   });
 
   it('soft alpha preserva valores intermedios (semi-transparencia)', () => {
-    const w = 16, h = 16;
+    const w = 16,
+      h = 16;
     const pixels = solidImage(w, h, 255, 255, 255);
     // Pixel ligeramente diferente al fondo (simula borde suave)
     paintRect(pixels, w, 7, 7, 2, 2, 230, 230, 230);
@@ -234,7 +246,8 @@ describe('Pipeline - composicion final RGBA con soft alpha', () => {
 
 describe('Pipeline - watermark zeroes alpha en soft alpha', () => {
   it('watermark mask pone alpha a 0 donde se detecta watermark', () => {
-    const w = 64, h = 64;
+    const w = 64,
+      h = 64;
     const pixels = solidImage(w, h, 200, 200, 200);
     // Sujeto
     paintRect(pixels, w, 20, 20, 24, 24, 100, 50, 50);

--- a/tests/pipeline/precision-profiles.test.ts
+++ b/tests/pipeline/precision-profiles.test.ts
@@ -1,8 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import {
-  PRECISION_PROFILES,
-  REFINE_PARAMS,
-} from '../../src/pipeline/constants';
+import { PRECISION_PROFILES, REFINE_PARAMS } from '../../src/pipeline/constants';
 import type { PrecisionMode, PrecisionProfile } from '../../src/pipeline/constants';
 
 describe('PrecisionProfiles', () => {
@@ -42,38 +39,42 @@ describe('PrecisionProfiles', () => {
   });
 
   it('rmbg threshold decreases as precision increases', () => {
-    const thresholds = modes.map(m => PRECISION_PROFILES[m].rmbgThreshold);
+    const thresholds = modes.map((m) => PRECISION_PROFILES[m].rmbgThreshold);
     // low-power > normal > high-power > full-nuke
     for (let i = 1; i < thresholds.length; i++) {
-      expect(thresholds[i], `${modes[i]} threshold < ${modes[i-1]} threshold`)
-        .toBeLessThan(thresholds[i - 1]);
+      expect(thresholds[i], `${modes[i]} threshold < ${modes[i - 1]} threshold`).toBeLessThan(
+        thresholds[i - 1],
+      );
     }
   });
 
   it('spatial passes increase as precision increases', () => {
-    const passes = modes.map(m => PRECISION_PROFILES[m].spatialPasses);
+    const passes = modes.map((m) => PRECISION_PROFILES[m].spatialPasses);
     // Each mode should have >= the passes of the previous mode
     for (let i = 1; i < passes.length; i++) {
-      expect(passes[i], `${modes[i]} passes >= ${modes[i-1]} passes`)
-        .toBeGreaterThanOrEqual(passes[i - 1]);
+      expect(passes[i], `${modes[i]} passes >= ${modes[i - 1]} passes`).toBeGreaterThanOrEqual(
+        passes[i - 1],
+      );
     }
   });
 
   it('cluster ratio decreases as precision increases (keeps more detail)', () => {
-    const ratios = modes.map(m => PRECISION_PROFILES[m].clusterRatio);
+    const ratios = modes.map((m) => PRECISION_PROFILES[m].clusterRatio);
     // low-power has the most aggressive cleanup (higher ratio)
     // full-nuke keeps the most detail (lower ratio)
     for (let i = 1; i < ratios.length; i++) {
-      expect(ratios[i], `${modes[i]} ratio <= ${modes[i-1]} ratio`)
-        .toBeLessThanOrEqual(ratios[i - 1]);
+      expect(ratios[i], `${modes[i]} ratio <= ${modes[i - 1]} ratio`).toBeLessThanOrEqual(
+        ratios[i - 1],
+      );
     }
   });
 
   it('min cluster size decreases as precision increases (keeps smaller clusters)', () => {
-    const sizes = modes.map(m => PRECISION_PROFILES[m].minClusterSize);
+    const sizes = modes.map((m) => PRECISION_PROFILES[m].minClusterSize);
     for (let i = 1; i < sizes.length; i++) {
-      expect(sizes[i], `${modes[i]} minCluster <= ${modes[i-1]} minCluster`)
-        .toBeLessThanOrEqual(sizes[i - 1]);
+      expect(sizes[i], `${modes[i]} minCluster <= ${modes[i - 1]} minCluster`).toBeLessThanOrEqual(
+        sizes[i - 1],
+      );
     }
   });
 
@@ -90,7 +91,7 @@ describe('PrecisionProfiles', () => {
   });
 
   it('full-nuke has the most aggressive morphological opening', () => {
-    const radii = modes.map(m => PRECISION_PROFILES[m].morphOpenRadius);
+    const radii = modes.map((m) => PRECISION_PROFILES[m].morphOpenRadius);
     expect(radii[3]).toBeGreaterThanOrEqual(radii[0]);
     expect(radii[3]).toBeGreaterThanOrEqual(radii[1]);
     expect(radii[3]).toBeGreaterThanOrEqual(radii[2]);

--- a/tests/pwa-manifest.test.ts
+++ b/tests/pwa-manifest.test.ts
@@ -3,9 +3,7 @@ import { readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
 
 const ROOT = resolve(__dirname, '..');
-const MANIFEST = JSON.parse(
-  readFileSync(resolve(ROOT, 'public/manifest.webmanifest'), 'utf8'),
-);
+const MANIFEST = JSON.parse(readFileSync(resolve(ROOT, 'public/manifest.webmanifest'), 'utf8'));
 const MAIN = readFileSync(resolve(ROOT, 'src/main.ts'), 'utf8');
 
 describe('PWA manifest — install experience', () => {

--- a/tests/theme-switcher.test.ts
+++ b/tests/theme-switcher.test.ts
@@ -33,7 +33,10 @@ describe('theme switcher — DOM', () => {
   });
 
   it('green is the default (aria-checked="true" only on green)', () => {
-    const checkedTrue = HTML.match(/aria-checked="true"[^>]*data-theme="(\w+)"|data-theme="(\w+)"[^>]*aria-checked="true"/g) ?? [];
+    const checkedTrue =
+      HTML.match(
+        /aria-checked="true"[^>]*data-theme="(\w+)"|data-theme="(\w+)"[^>]*aria-checked="true"/g,
+      ) ?? [];
     expect(checkedTrue.length).toBe(1);
     expect(checkedTrue[0]).toMatch(/data-theme="green"/);
   });
@@ -42,13 +45,16 @@ describe('theme switcher — DOM', () => {
 describe('theme switcher — palettes in main.css', () => {
   for (const theme of ['amber', 'cyan', 'magenta']) {
     it(`:root[data-theme="${theme}"] overrides accent + text-* tokens`, () => {
-      const re = new RegExp(`:root\\[data-theme="${theme}"\\]\\s*\\{[\\s\\S]*?--color-accent-primary[\\s\\S]*?--color-text-primary`);
+      // Accept either quote style — prettier may normalize to single quotes.
+      const re = new RegExp(
+        `:root\\[data-theme=['"]${theme}['"]\\]\\s*\\{[\\s\\S]*?--color-accent-primary[\\s\\S]*?--color-text-primary`,
+      );
       expect(CSS).toMatch(re);
     });
   }
 
   it('green has no override block (it is the :root default)', () => {
-    expect(CSS).not.toMatch(/:root\[data-theme="green"\]/);
+    expect(CSS).not.toMatch(/:root\[data-theme=['"]green['"]\]/);
   });
 });
 
@@ -60,7 +66,9 @@ describe('theme switcher — main.ts wiring', () => {
   });
 
   it('applyTheme deletes data-theme for green and sets it for the others', () => {
-    expect(MAIN).toMatch(/if \(theme === ['"]green['"]\)[\s\S]*?delete document\.documentElement\.dataset\.theme/);
+    expect(MAIN).toMatch(
+      /if \(theme === ['"]green['"]\)[\s\S]*?delete document\.documentElement\.dataset\.theme/,
+    );
     expect(MAIN).toMatch(/document\.documentElement\.dataset\.theme = theme/);
   });
 

--- a/tests/utils/batch.test.ts
+++ b/tests/utils/batch.test.ts
@@ -24,7 +24,10 @@ describe('getBatchLimit', () => {
   });
 
   it('uses desktop cap exactly at breakpoint', () => {
-    Object.defineProperty(window, 'innerWidth', { configurable: true, value: BATCH_LIMITS.MOBILE_BREAKPOINT });
+    Object.defineProperty(window, 'innerWidth', {
+      configurable: true,
+      value: BATCH_LIMITS.MOBILE_BREAKPOINT,
+    });
     expect(getBatchLimit()).toBe(BATCH_LIMITS.DESKTOP);
   });
 });

--- a/tests/utils/final-composite.test.ts
+++ b/tests/utils/final-composite.test.ts
@@ -62,8 +62,7 @@ describe('bilinearUpscaleRGB', () => {
   it('preserves corner RGB when upscaling 2x2 to 4x4', () => {
     // Pixel (0,0) red=100, (1,0) green=200, (0,1) blue=50, (1,1) gray=10
     const src = new Uint8ClampedArray([
-      100, 0, 0, 255,    0, 200, 0, 255,
-      0, 0, 50, 255,    10, 10, 10, 255,
+      100, 0, 0, 255, 0, 200, 0, 255, 0, 0, 50, 255, 10, 10, 10, 255,
     ]);
     const out = bilinearUpscaleRGB(src, 2, 2, 4, 4);
     // Top-left: (100, 0, 0)
@@ -77,8 +76,9 @@ describe('bilinearUpscaleRGB', () => {
   });
 
   it('forces alpha=255 in output', () => {
-    const src = new Uint8ClampedArray([255, 255, 255, 0, 255, 255, 255, 0,
-                                        255, 255, 255, 0, 255, 255, 255, 0]);
+    const src = new Uint8ClampedArray([
+      255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0,
+    ]);
     const out = bilinearUpscaleRGB(src, 2, 2, 4, 4);
     for (let i = 0; i < out.length; i += 4) {
       expect(out[i + 3]).toBe(255);
@@ -173,17 +173,21 @@ describe('composeAtOriginal', () => {
     // After bilinear upsample the alpha spreads into a soft ramp across the
     // boundary. refineUpscaledAlpha should push left-column α toward 0 and
     // right-column α toward 255 using the RGB edge as guide.
-    const origW = 8, origH = 8;
+    const origW = 8,
+      origH = 8;
     const original = new Uint8ClampedArray(origW * origH * 4);
     for (let y = 0; y < origH; y++) {
       for (let x = 0; x < origW; x++) {
         const idx = (y * origW + x) * 4;
         const v = x < 4 ? 0 : 255;
-        original[idx] = v; original[idx + 1] = v; original[idx + 2] = v;
+        original[idx] = v;
+        original[idx + 1] = v;
+        original[idx + 2] = v;
         original[idx + 3] = 255;
       }
     }
-    const workW = 4, workH = 4;
+    const workW = 4,
+      workH = 4;
     const working = new Uint8ClampedArray(workW * workH * 4);
     const workAlpha = new Uint8Array(workW * workH);
     for (let i = 0; i < workAlpha.length; i++) {
@@ -226,7 +230,7 @@ describe('composeAtOriginal', () => {
     // Bottom-right of output should still be pristine red (mask=0 there).
     const topLeft = out.data.slice(0, 3);
     expect(topLeft[2]).toBeGreaterThan(topLeft[0]);
-    const bottomRight = out.data.slice((15) * 4, (15) * 4 + 3);
+    const bottomRight = out.data.slice(15 * 4, 15 * 4 + 3);
     expect(bottomRight[0]).toBe(255);
     expect(bottomRight[2]).toBe(0);
   });
@@ -245,7 +249,8 @@ describe('refineUpscaledAlpha', () => {
   };
 
   it('leaves all-zero alpha untouched (BAND_LO gate)', () => {
-    const w = 8, h = 8;
+    const w = 8,
+      h = 8;
     const alpha = new Uint8Array(w * h); // all 0
     const rgba = makeFlatRgba(w, h, 128);
     const out = refineUpscaledAlpha(alpha, rgba, w, h);
@@ -253,7 +258,8 @@ describe('refineUpscaledAlpha', () => {
   });
 
   it('leaves all-255 alpha untouched (BAND_HI gate)', () => {
-    const w = 8, h = 8;
+    const w = 8,
+      h = 8;
     const alpha = new Uint8Array(w * h).fill(255);
     const rgba = makeFlatRgba(w, h, 128);
     const out = refineUpscaledAlpha(alpha, rgba, w, h);
@@ -262,13 +268,17 @@ describe('refineUpscaledAlpha', () => {
 
   it('keeps pixels outside [BAND_LO, BAND_HI] verbatim even when guide has structure', () => {
     // 4x4 with a hard vertical RGB edge in the middle.
-    const w = 4, h = 4;
+    const w = 4,
+      h = 4;
     const rgba = new Uint8ClampedArray(w * h * 4);
     for (let y = 0; y < h; y++) {
       for (let x = 0; x < w; x++) {
         const v = x < 2 ? 0 : 255;
         const idx = (y * w + x) * 4;
-        rgba[idx] = v; rgba[idx + 1] = v; rgba[idx + 2] = v; rgba[idx + 3] = 255;
+        rgba[idx] = v;
+        rgba[idx + 1] = v;
+        rgba[idx + 2] = v;
+        rgba[idx + 3] = 255;
       }
     }
     // Alpha: all extremes (0 on left, 255 on right) — nothing in the trimap band.
@@ -282,7 +292,8 @@ describe('refineUpscaledAlpha', () => {
   });
 
   it('returns the same length as input alpha', () => {
-    const w = 5, h = 7;
+    const w = 5,
+      h = 7;
     const alpha = new Uint8Array(w * h).fill(128);
     const rgba = makeFlatRgba(w, h, 200);
     const out = refineUpscaledAlpha(alpha, rgba, w, h);
@@ -292,12 +303,16 @@ describe('refineUpscaledAlpha', () => {
   it('sharpens a soft alpha ramp when guide has a sharp edge', () => {
     // 8x1 guide: sharp step at x=4 (left=0, right=255).
     // 8x1 alpha: smooth ramp across the whole width (simulates JBU residual).
-    const w = 8, h = 1;
+    const w = 8,
+      h = 1;
     const rgba = new Uint8ClampedArray(w * h * 4);
     for (let x = 0; x < w; x++) {
       const v = x < 4 ? 0 : 255;
       const idx = x * 4;
-      rgba[idx] = v; rgba[idx + 1] = v; rgba[idx + 2] = v; rgba[idx + 3] = 255;
+      rgba[idx] = v;
+      rgba[idx + 1] = v;
+      rgba[idx + 2] = v;
+      rgba[idx + 3] = 255;
     }
     const alpha = new Uint8Array([30, 60, 90, 120, 150, 180, 210, 240]);
     const out = refineUpscaledAlpha(alpha, rgba, w, h);
@@ -314,12 +329,10 @@ describe('refineUpscaledAlpha', () => {
   });
 
   it('does not mutate the input alpha buffer', () => {
-    const w = 4, h = 4;
+    const w = 4,
+      h = 4;
     const alpha = new Uint8Array([
-      0, 0, 128, 255,
-      0, 64, 192, 255,
-      0, 96, 200, 255,
-      0, 128, 220, 255,
+      0, 0, 128, 255, 0, 64, 192, 255, 0, 96, 200, 255, 0, 128, 220, 255,
     ]);
     const snapshot = new Uint8Array(alpha);
     const rgba = makeFlatRgba(w, h, 128);

--- a/tests/utils/image-io.test.ts
+++ b/tests/utils/image-io.test.ts
@@ -4,10 +4,10 @@ import { loadImage } from '../../src/utils/image-io';
 // All headers padded to 12 bytes — sniffImageFormat() refuses anything
 // shorter (covered by its own dedicated test below).
 const PNG_MAGIC = new Uint8Array([
-  0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A, 0x00, 0x00, 0x00, 0x0D,
+  0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0x00, 0x00, 0x00, 0x0d,
 ]);
 const JPEG_MAGIC = new Uint8Array([
-  0xFF, 0xD8, 0xFF, 0xE0, 0x00, 0x10, 0x4A, 0x46, 0x49, 0x46, 0x00, 0x01,
+  0xff, 0xd8, 0xff, 0xe0, 0x00, 0x10, 0x4a, 0x46, 0x49, 0x46, 0x00, 0x01,
 ]);
 const WEBP_MAGIC = new Uint8Array([
   0x52, 0x49, 0x46, 0x46, 0x00, 0x00, 0x00, 0x00, 0x57, 0x45, 0x42, 0x50,
@@ -23,7 +23,7 @@ function fileFrom(bytes: Uint8Array, name: string, type: string): File {
 
 describe('loadImage magic-byte sniffing', () => {
   it('rejects a file whose MIME says PNG but whose bytes do not match', async () => {
-    const fake = fileFrom(new Uint8Array([0x4D, 0x5A, 0x90, 0x00]), 'fake.png', 'image/png');
+    const fake = fileFrom(new Uint8Array([0x4d, 0x5a, 0x90, 0x00]), 'fake.png', 'image/png');
     await expect(loadImage(fake)).rejects.toThrow(/not a valid PNG, JPG, or WebP|does not match/i);
   });
 
@@ -38,7 +38,7 @@ describe('loadImage magic-byte sniffing', () => {
   });
 
   it('rejects files below the 12-byte sniff window', async () => {
-    const tiny = fileFrom(new Uint8Array([0x89, 0x50, 0x4E]), 'tiny.png', 'image/png');
+    const tiny = fileFrom(new Uint8Array([0x89, 0x50, 0x4e]), 'tiny.png', 'image/png');
     await expect(loadImage(tiny)).rejects.toThrow(/not a valid PNG, JPG, or WebP/i);
   });
 

--- a/tests/utils/zip.test.ts
+++ b/tests/utils/zip.test.ts
@@ -27,8 +27,9 @@ describe('safeZipEntryName', () => {
   });
 
   it('strips unsafe characters', () => {
-    expect(safeZipEntryName(1, 12, 'file/with:bad*chars?.png'))
-      .toBe('nukebg-01-file_with_bad_chars_.png');
+    expect(safeZipEntryName(1, 12, 'file/with:bad*chars?.png')).toBe(
+      'nukebg-01-file_with_bad_chars_.png',
+    );
   });
 
   it('falls back to "image" when base name is empty', () => {

--- a/tests/version-coherence.test.ts
+++ b/tests/version-coherence.test.ts
@@ -27,7 +27,8 @@ describe(`version coherence (package.json @ ${expected})`, () => {
 
   it('src/utils/image-io.ts PNG metadata carries the same version', () => {
     const src = read('src/utils/image-io.ts');
-    expect(src).toMatch(new RegExp(`'Software':\\s*'NukeBG v${esc(expected)}'`));
+    // Prettier may strip quotes from the property key; accept either form.
+    expect(src).toMatch(new RegExp(`['"]?Software['"]?:\\s*'NukeBG v${esc(expected)}'`));
   });
 
   it('index.html JSON-LD softwareVersion carries the same version', () => {

--- a/tests/version-consistency.test.ts
+++ b/tests/version-consistency.test.ts
@@ -30,7 +30,9 @@ describe('version consistency', () => {
 
   it('index.html JSON-LD softwareVersion matches package.json', () => {
     const html = read('index.html');
-    expect(html).toMatch(new RegExp(`"softwareVersion"\\s*:\\s*"${VERSION.replace(/\./g, '\\.')}"`));
+    expect(html).toMatch(
+      new RegExp(`"softwareVersion"\\s*:\\s*"${VERSION.replace(/\./g, '\\.')}"`),
+    );
   });
 
   it('src/main.ts console logo shows the current version', () => {

--- a/tests/visual-validation.test.ts
+++ b/tests/visual-validation.test.ts
@@ -21,7 +21,7 @@ import { solidImage, checkerboardImage, paintRect } from './helpers';
 function runCvPipeline(
   pixels: Uint8ClampedArray,
   width: number,
-  height: number
+  height: number,
 ): { alpha: Uint8Array; fgPercent: number } {
   const bgInfo = detectBgColors(pixels, width, height);
 
@@ -31,23 +31,28 @@ function runCvPipeline(
     const grid = detectCheckerGrid(pixels, width, height, bgInfo.colorA, bgInfo.colorB);
     if (grid.gridSize > 0) {
       bgMask = gridFloodFill(
-        pixels, width, height,
-        bgInfo.colorA, bgInfo.colorB,
-        grid.gridSize, grid.phase
+        pixels,
+        width,
+        height,
+        bgInfo.colorA,
+        bgInfo.colorB,
+        grid.gridSize,
+        grid.phase,
       );
       let bgCount = 0;
       for (let i = 0; i < bgMask.length; i++) if (bgMask[i]) bgCount++;
       const coverage = bgCount / (width * height);
       if (coverage < CV_PARAMS.LOW_COVERAGE_THRESHOLD) {
         const exclMask = subjectExclusion(
-          pixels, width, height,
-          bgInfo.colorA, bgInfo.colorB,
-          grid.gridSize, grid.phase
+          pixels,
+          width,
+          height,
+          bgInfo.colorA,
+          bgInfo.colorB,
+          grid.gridSize,
+          grid.phase,
         );
-        const floodMask = simpleFloodFill(
-          pixels, width, height,
-          bgInfo.colorA, bgInfo.colorB
-        );
+        const floodMask = simpleFloodFill(pixels, width, height, bgInfo.colorA, bgInfo.colorB);
         bgMask = new Uint8Array(width * height);
         for (let i = 0; i < bgMask.length; i++) {
           bgMask[i] = exclMask[i] || floodMask[i] ? 1 : 0;
@@ -84,80 +89,86 @@ function runCvPipeline(
 }
 
 describe('Validacion visual: mascot images sinteticas', () => {
-
   it('mascot-cartoon: sujeto colorido sobre checkerboard tiene >20% foreground', () => {
-    const w = 256, h = 256, gs = 16;
+    const w = 256,
+      h = 256,
+      gs = 16;
     const dark: [number, number, number] = [191, 191, 191];
     const light: [number, number, number] = [255, 255, 255];
     const pixels = checkerboardImage(w, h, gs, dark, light);
 
     // Mascota cartoon: forma irregular con multiples colores
-    paintRect(pixels, w, 80, 40, 96, 176, 220, 60, 60);   // cuerpo rojo
-    paintRect(pixels, w, 100, 50, 56, 40, 255, 200, 150);  // cara
-    paintRect(pixels, w, 100, 150, 56, 40, 60, 60, 200);   // pies azules
-    paintRect(pixels, w, 70, 80, 20, 60, 220, 60, 60);     // brazo izq
-    paintRect(pixels, w, 166, 80, 20, 60, 220, 60, 60);    // brazo der
+    paintRect(pixels, w, 80, 40, 96, 176, 220, 60, 60); // cuerpo rojo
+    paintRect(pixels, w, 100, 50, 56, 40, 255, 200, 150); // cara
+    paintRect(pixels, w, 100, 150, 56, 40, 60, 60, 200); // pies azules
+    paintRect(pixels, w, 70, 80, 20, 60, 220, 60, 60); // brazo izq
+    paintRect(pixels, w, 166, 80, 20, 60, 220, 60, 60); // brazo der
 
     const { fgPercent } = runCvPipeline(pixels, w, h);
     expect(fgPercent).toBeGreaterThan(20);
   });
 
   it('mascot-geometric: formas geometricas sobre fondo blanco tiene >20% foreground', () => {
-    const w = 256, h = 256;
+    const w = 256,
+      h = 256;
     const pixels = solidImage(w, h, 255, 255, 255);
 
     // Mascota geometrica: triangulo + circulo simulados con rects
-    paintRect(pixels, w, 60, 30, 136, 196, 50, 150, 200);  // cuerpo azul
-    paintRect(pixels, w, 90, 50, 76, 76, 255, 200, 50);     // cara amarilla
-    paintRect(pixels, w, 100, 180, 56, 40, 50, 200, 50);    // pies verdes
+    paintRect(pixels, w, 60, 30, 136, 196, 50, 150, 200); // cuerpo azul
+    paintRect(pixels, w, 90, 50, 76, 76, 255, 200, 50); // cara amarilla
+    paintRect(pixels, w, 100, 180, 56, 40, 50, 200, 50); // pies verdes
 
     const { fgPercent } = runCvPipeline(pixels, w, h);
     expect(fgPercent).toBeGreaterThan(20);
   });
 
   it('mascot-realistic: sujeto con detalles sobre fondo negro tiene >20% foreground', () => {
-    const w = 256, h = 256;
+    const w = 256,
+      h = 256;
     const pixels = solidImage(w, h, 0, 0, 0);
 
     // Mascota realista: tonos de piel y ropa
-    paintRect(pixels, w, 70, 30, 116, 196, 180, 130, 90);   // cuerpo
-    paintRect(pixels, w, 90, 40, 76, 76, 220, 180, 150);     // cara
-    paintRect(pixels, w, 70, 140, 116, 86, 50, 50, 150);     // pantalones
-    paintRect(pixels, w, 85, 200, 40, 26, 80, 40, 20);       // zapato izq
-    paintRect(pixels, w, 131, 200, 40, 26, 80, 40, 20);      // zapato der
+    paintRect(pixels, w, 70, 30, 116, 196, 180, 130, 90); // cuerpo
+    paintRect(pixels, w, 90, 40, 76, 76, 220, 180, 150); // cara
+    paintRect(pixels, w, 70, 140, 116, 86, 50, 50, 150); // pantalones
+    paintRect(pixels, w, 85, 200, 40, 26, 80, 40, 20); // zapato izq
+    paintRect(pixels, w, 131, 200, 40, 26, 80, 40, 20); // zapato der
 
     const { fgPercent } = runCvPipeline(pixels, w, h);
     expect(fgPercent).toBeGreaterThan(20);
   });
 
   it('mascot-pixel: pixel art sobre checkerboard tiene >20% foreground', () => {
-    const w = 128, h = 128, gs = 8;
+    const w = 128,
+      h = 128,
+      gs = 8;
     const dark: [number, number, number] = [191, 191, 191];
     const light: [number, number, number] = [255, 255, 255];
     const pixels = checkerboardImage(w, h, gs, dark, light);
 
     // Mascota pixel art: bloques solidos
-    paintRect(pixels, w, 40, 16, 48, 96, 200, 80, 80);    // cuerpo
-    paintRect(pixels, w, 48, 24, 32, 24, 255, 200, 160);   // cara
-    paintRect(pixels, w, 48, 80, 16, 24, 200, 80, 80);     // pie izq
-    paintRect(pixels, w, 72, 80, 16, 24, 200, 80, 80);     // pie der
+    paintRect(pixels, w, 40, 16, 48, 96, 200, 80, 80); // cuerpo
+    paintRect(pixels, w, 48, 24, 32, 24, 255, 200, 160); // cara
+    paintRect(pixels, w, 48, 80, 16, 24, 200, 80, 80); // pie izq
+    paintRect(pixels, w, 72, 80, 16, 24, 200, 80, 80); // pie der
 
     const { fgPercent } = runCvPipeline(pixels, w, h);
     expect(fgPercent).toBeGreaterThan(20);
   });
 
   it('mascot-icon-m: icono M sobre fondo gris tiene >20% foreground', () => {
-    const w = 128, h = 128;
+    const w = 128,
+      h = 128;
     // Fondo gris solido
     const pixels = solidImage(w, h, 220, 220, 220);
 
     // Letra M estilizada
-    paintRect(pixels, w, 20, 20, 88, 88, 30, 30, 150);     // fondo azul oscuro
-    paintRect(pixels, w, 30, 30, 12, 68, 255, 255, 255);    // pata izq M
-    paintRect(pixels, w, 86, 30, 12, 68, 255, 255, 255);    // pata der M
-    paintRect(pixels, w, 42, 45, 12, 30, 255, 255, 255);    // diagonal izq
-    paintRect(pixels, w, 60, 45, 12, 30, 255, 255, 255);    // diagonal der
-    paintRect(pixels, w, 50, 55, 14, 15, 255, 255, 255);    // centro V
+    paintRect(pixels, w, 20, 20, 88, 88, 30, 30, 150); // fondo azul oscuro
+    paintRect(pixels, w, 30, 30, 12, 68, 255, 255, 255); // pata izq M
+    paintRect(pixels, w, 86, 30, 12, 68, 255, 255, 255); // pata der M
+    paintRect(pixels, w, 42, 45, 12, 30, 255, 255, 255); // diagonal izq
+    paintRect(pixels, w, 60, 45, 12, 30, 255, 255, 255); // diagonal der
+    paintRect(pixels, w, 50, 55, 14, 15, 255, 255, 255); // centro V
 
     const { fgPercent } = runCvPipeline(pixels, w, h);
     expect(fgPercent).toBeGreaterThan(20);
@@ -165,9 +176,30 @@ describe('Validacion visual: mascot images sinteticas', () => {
 
   it('todas las mascot images producen alpha con valores validos (0-255)', () => {
     const images = [
-      { name: 'solid-white', pixels: (() => { const p = solidImage(64, 64, 255, 255, 255); paintRect(p, 64, 16, 16, 32, 32, 100, 50, 50); return p; })() },
-      { name: 'solid-black', pixels: (() => { const p = solidImage(64, 64, 0, 0, 0); paintRect(p, 64, 16, 16, 32, 32, 200, 150, 100); return p; })() },
-      { name: 'checker', pixels: (() => { const p = checkerboardImage(64, 64, 8, [191, 191, 191], [255, 255, 255]); paintRect(p, 64, 16, 16, 32, 32, 200, 50, 50); return p; })() },
+      {
+        name: 'solid-white',
+        pixels: (() => {
+          const p = solidImage(64, 64, 255, 255, 255);
+          paintRect(p, 64, 16, 16, 32, 32, 100, 50, 50);
+          return p;
+        })(),
+      },
+      {
+        name: 'solid-black',
+        pixels: (() => {
+          const p = solidImage(64, 64, 0, 0, 0);
+          paintRect(p, 64, 16, 16, 32, 32, 200, 150, 100);
+          return p;
+        })(),
+      },
+      {
+        name: 'checker',
+        pixels: (() => {
+          const p = checkerboardImage(64, 64, 8, [191, 191, 191], [255, 255, 255]);
+          paintRect(p, 64, 16, 16, 32, 32, 200, 50, 50);
+          return p;
+        })(),
+      },
     ];
 
     for (const { pixels } of images) {
@@ -195,8 +227,17 @@ describe('Validacion visual: mascot images sinteticas', () => {
 
     for (const { w, h } of sizes) {
       const pixels = solidImage(w, h, 255, 255, 255);
-      paintRect(pixels, w, Math.floor(w * 0.25), Math.floor(h * 0.25),
-        Math.floor(w * 0.5), Math.floor(h * 0.5), 200, 50, 50);
+      paintRect(
+        pixels,
+        w,
+        Math.floor(w * 0.25),
+        Math.floor(h * 0.25),
+        Math.floor(w * 0.5),
+        Math.floor(h * 0.5),
+        200,
+        50,
+        50,
+      );
 
       const { alpha, fgPercent } = runCvPipeline(pixels, w, h);
 


### PR DESCRIPTION
Closes #134.

One-shot `npm run format` per the long-standing CI comment. **125 files** touched, mostly whitespace + quote normalisation. Zero behaviour changes — verified by 673 tests still passing.

## Side effects handled in the same PR

- **CSP hashes regenerated** in nginx.conf + public/_headers (3 hashes — JSON-LD inline scripts shifted SHA inputs after prettier reformatted them)
- **`'Software'` key un-quoted** by prettier; version-coherence test relaxed to accept either form
- **Theme `data-theme="X"` → `'X'`**; theme-switcher test relaxed to accept either quote style
- **Several brittle source-pattern tests** broke because their regex assumed single-line code that prettier wrapped to multiline. Loosened patterns to span newlines via `[\s\S]*?`. Long-term fix is the behavioural-test migration in #135.

## CI

`continue-on-error` flipped from `true` to `false` on the Lint + format job. The repo can no longer accumulate format debt silently.

673 tests passing.