### PR TITLE
fix(e2e): bump coche-capture timeouts for CI cold-start (#160)

### DIFF
--- a/e2e/coche-capture.spec.ts
+++ b/e2e/coche-capture.spec.ts
@@ -10,7 +10,12 @@ const OUT_DIR = resolve(__dirname, '../.halo-check');
 test.describe.configure({ mode: 'serial' });
 
 test('capture coche output + mirror console/network', async ({ page }, testInfo) => {
-  test.setTimeout(240_000);
+  // First spec in serial mode → pays full cold-start ML warmup
+  // (model download + WASM init + first inference). On CI runners this
+  // routinely takes 4–5 minutes; the previous 200s/240s budget timed
+  // out consistently. The follow-up specs (football, motostest) reuse
+  // the warm pipeline and finish well under their own budgets.
+  test.setTimeout(360_000);
   mkdirSync(OUT_DIR, { recursive: true });
 
   const logs: string[] = [];
@@ -23,7 +28,7 @@ test('capture coche output + mirror console/network', async ({ page }, testInfo)
   await fileInput.setInputFiles(FIXTURE);
 
   const downloadBtn = page.locator('ar-download').locator('#dl-png');
-  await expect(downloadBtn).toHaveAttribute('href', /^blob:/, { timeout: 200_000 });
+  await expect(downloadBtn).toHaveAttribute('href', /^blob:/, { timeout: 300_000 });
 
   const outPath = resolve(OUT_DIR, `coche.png`);
   const downloadPromise = page.waitForEvent('download');


### PR DESCRIPTION
Closes #160.

## Symptom

\`e2e/coche-capture.spec.ts\` was failing on every recent dev/PR run with:
\`\`\`
expect(locator).toHaveAttribute('href', /^blob:/)
  Expected pattern: /^blob:/
  Received string:  ""
\`\`\`

## Cause
First spec in serial mode → eats the full ML warmup (model download + WASM init + first inference). On CI runners that exceeds the 200s \`toHaveAttribute\` budget. Local dev passes because the model cache is warm and CPU is faster.

## Fix
Bump just \`coche-capture\` (the cold one):
- \`toHaveAttribute\` timeout: 200_000 → 300_000
- test-level \`setTimeout\`: 240_000 → 360_000

Football + motostest keep tight budgets — they reuse the warm pipeline.

## Follow-up (not this PR)
A proper fix would add a \`beforeAll\` warmup step so none of the capture specs pay cold-start individually. Tracked separately if it becomes a problem; bumping the budget is enough for now.