### PR TITLE
release: v2.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,82 @@ Unreleased entries accumulate on the `dev` branch. When we cut a release we copy
 
 ## [Unreleased]
 
+## [2.9.0] — 2026-04-26
+
+### Added
+
+- **`/reactor` transparency page** — public sunk-cost + forward-burn breakdown
+  (estimated hours × fair Spain rate, AI assistant subs + domain), runtime
+  remaining vs. lifetime donations, donor consent workflow with 7-day GDPR
+  removal SLA, and methodology footnote.
+  ([#137](https://github.com/yocreoquesi/nukebg/pull/137),
+  [#138](https://github.com/yocreoquesi/nukebg/pull/138),
+  [#139](https://github.com/yocreoquesi/nukebg/pull/139),
+  [#140](https://github.com/yocreoquesi/nukebg/pull/140),
+  [#141](https://github.com/yocreoquesi/nukebg/pull/141))
+- **Footer + marquee runtime-aware copy** — Ko-fi CTA renamed to "Tip the
+  reactor", marquee surfaces forward runtime when funded.
+  ([#138](https://github.com/yocreoquesi/nukebg/pull/138))
+- **Post-process CTA rotation** — first-star at run #1, five-tip at #5,
+  ten-review at #10. localStorage-tracked, dismissable.
+  ([#139](https://github.com/yocreoquesi/nukebg/pull/139))
+- **Manual remove-watermark lasso action** — distinct from erase-object: uses
+  PatchMatch inpaint to reconstruct pixels rather than zeroing alpha.
+  Best for unwanted logos / marks the auto-detector misses.
+  ([#152](https://github.com/yocreoquesi/nukebg/pull/152))
+- **SHA-256 supply-chain verification for RMBG-1.4 + MobileSAM** — both models
+  now pinned to a 40-hex commit SHA and hash-verified post-download (mirrors
+  the existing LaMa pattern). Tampered or upstream-replaced blobs are rejected
+  before reaching the ONNX runtime.
+  ([#132](https://github.com/yocreoquesi/nukebg/pull/132))
+- **Contributor licensing terms (CLA)** alongside MobileSAM + LaMa license
+  documentation in repo. ([#130](https://github.com/yocreoquesi/nukebg/pull/130))
+
+### Changed
+
+- **Watermark detection: color-specificity gate** — rejects Gemini-sparkle
+  false positives that the deviation accumulator was flagging on real photos.
+  ([#152](https://github.com/yocreoquesi/nukebg/pull/152))
+- **ES localization rewritten in peninsular tuteo** — voseo forms removed
+  (no more "dejá / mirá / mandá / aparecés"), Spanglish cleaned ("watermark"
+  → "marca de agua"), the broken `hero.subtitle.short` fragment fixed to
+  mirror the EN imperative, and the brand verb \`nukea / nukear / nukeada\`
+  preserved where the EN uses "nuke".
+  ([#147](https://github.com/yocreoquesi/nukebg/pull/147))
+- **Download CTAs stack at ≤640px** (was ≤480) so the buttons no longer
+  overflow on mid-size mobile viewports.
+  ([#150](https://github.com/yocreoquesi/nukebg/pull/150))
+- **CI: Lint + format job is now blocking** after the prettier sweep
+  cleared the 159-file backlog.
+  ([#134](https://github.com/yocreoquesi/nukebg/pull/134))
+
+### Removed
+
+- **Quiet mode toggle** — redundant after the Reactor pivot. The motion /
+  flicker layer it gated had already been removed; OS \`prefers-reduced-motion\`
+  is the only switch that still matters.
+  ([#148](https://github.com/yocreoquesi/nukebg/pull/148))
+- **Web Share button** in the result actions — duplicated the native browser
+  share, made the CTA row overflow on mobile.
+  ([#150](https://github.com/yocreoquesi/nukebg/pull/150))
+- **"Nueva imagen" command-bar button** — duplicate of "procesar otra".
+  ([#151](https://github.com/yocreoquesi/nukebg/pull/151))
+- **Camera CTA + "Tomar foto"** in the dropzone — confusing on mobile, the
+  native file picker already exposes the camera.
+  ([#155](https://github.com/yocreoquesi/nukebg/pull/155))
+
+### Fixed
+
+- **Mobile hero `$` glyph duplication** — the short-form hero was rendering
+  `$ $` because both the template and the i18n short-form prefixed the
+  prompt. ([#155](https://github.com/yocreoquesi/nukebg/pull/155))
+- **Footer "privacy" overflow on ≤480 px** — hidden on the smallest
+  viewports so the brand row fits.
+  ([#155](https://github.com/yocreoquesi/nukebg/pull/155))
+- **e2e \`coche-capture\` cold-start budget bumped** — partial fix
+  (200 s → 300 s). Proper warmup beforeAll tracked separately in #160.
+  ([#160](https://github.com/yocreoquesi/nukebg/issues/160))
+
 ## [2.8.0] — 2026-04-25
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 > Nuke backgrounds from any image. 100% client-side. Zero uploads. Zero BS.
 
-[![Version](https://img.shields.io/badge/version-2.8.0-brightgreen.svg)](https://github.com/yocreoquesi/nukebg/releases)
+[![Version](https://img.shields.io/badge/version-2.9.0-brightgreen.svg)](https://github.com/yocreoquesi/nukebg/releases)
 [![License: GPL-3.0](https://img.shields.io/badge/License-GPL%20v3-blue.svg)](https://www.gnu.org/licenses/gpl-3.0)
 [![Client-Side](https://img.shields.io/badge/Processing-100%25%20Client--Side-green.svg)](#-privacy)
 [![Ko-fi](https://img.shields.io/badge/Ko--fi-Support%20NukeBG-FF5E5B?logo=ko-fi&logoColor=white)](https://ko-fi.com/yocreoquesi)

--- a/index.html
+++ b/index.html
@@ -151,7 +151,7 @@
           "PNG export with true alpha transparency"
         ],
         "screenshot": "https://nukebg.app/og-image.png",
-        "softwareVersion": "2.8.0",
+        "softwareVersion": "2.9.0",
         "license": "https://www.gnu.org/licenses/gpl-3.0.html",
         "isAccessibleForFree": true,
         "creator": {
@@ -483,7 +483,7 @@
     <ar-post-cta id="post-cta"></ar-post-cta>
 
     <footer class="footer hazard-border-top" role="contentinfo">
-      <span>NukeBG <span style="color: var(--color-text-tertiary)">v2.8.0</span></span>
+      <span>NukeBG <span style="color: var(--color-text-tertiary)">v2.9.0</span></span>
       <span class="footer-sep">|</span>
       <span>GPL-3.0</span>
       <span class="footer-sep">|</span>

--- a/infra/nginx.conf
+++ b/infra/nginx.conf
@@ -31,7 +31,7 @@ server {
     #   new Function() WASM bootstrap.
     # - sha256 hashes cover the 3 inline JSON-LD blocks in index.html.
     #   Regenerate with `node scripts/compute-csp-hashes.mjs` after edits.
-    add_header Content-Security-Policy "default-src 'self'; script-src 'self' blob: 'wasm-unsafe-eval' 'unsafe-eval' 'sha256-LAtNqeqhdzzGqXdTx12HjOtj8QmXv4qw7OsNW7BCFUw=' 'sha256-uZm4Xh9FxR3B7WjPHL5pbehtSMYTCy9JWzQzl3/UKA0=' 'sha256-o1DLxvGFHY9H1AG6Sro58slSTxU3T7zb020gfyqbFwM=' https://cdn.jsdelivr.net; worker-src 'self' blob:; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; connect-src 'self' https://huggingface.co https://cdn-lfs.huggingface.co https://cdn-lfs-us-1.huggingface.co https://cdn.jsdelivr.net https://cas-bridge.xethub.hf.co; font-src 'self'; object-src 'none'; base-uri 'self'; form-action 'none'" always;
+    add_header Content-Security-Policy "default-src 'self'; script-src 'self' blob: 'wasm-unsafe-eval' 'unsafe-eval' 'sha256-w7MMhkg0c88co2zUdjlGo3WNvVl3sCQqw/MLgtdH+AY=' 'sha256-uZm4Xh9FxR3B7WjPHL5pbehtSMYTCy9JWzQzl3/UKA0=' 'sha256-o1DLxvGFHY9H1AG6Sro58slSTxU3T7zb020gfyqbFwM=' https://cdn.jsdelivr.net; worker-src 'self' blob:; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; connect-src 'self' https://huggingface.co https://cdn-lfs.huggingface.co https://cdn-lfs-us-1.huggingface.co https://cdn.jsdelivr.net https://cas-bridge.xethub.hf.co; font-src 'self'; object-src 'none'; base-uri 'self'; form-action 'none'" always;
 
     # Cache static assets
     # Note: add_header in location blocks replaces parent headers in nginx,
@@ -46,7 +46,7 @@ server {
         add_header Strict-Transport-Security "max-age=63072000; includeSubDomains; preload" always;
         add_header Cross-Origin-Opener-Policy "same-origin" always;
         add_header X-DNS-Prefetch-Control "off" always;
-        add_header Content-Security-Policy "default-src 'self'; script-src 'self' blob: 'wasm-unsafe-eval' 'unsafe-eval' 'sha256-LAtNqeqhdzzGqXdTx12HjOtj8QmXv4qw7OsNW7BCFUw=' 'sha256-uZm4Xh9FxR3B7WjPHL5pbehtSMYTCy9JWzQzl3/UKA0=' 'sha256-o1DLxvGFHY9H1AG6Sro58slSTxU3T7zb020gfyqbFwM=' https://cdn.jsdelivr.net; worker-src 'self' blob:; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; connect-src 'self' https://huggingface.co https://cdn-lfs.huggingface.co https://cdn-lfs-us-1.huggingface.co https://cdn.jsdelivr.net https://cas-bridge.xethub.hf.co; font-src 'self'; object-src 'none'; base-uri 'self'; form-action 'none'" always;
+        add_header Content-Security-Policy "default-src 'self'; script-src 'self' blob: 'wasm-unsafe-eval' 'unsafe-eval' 'sha256-w7MMhkg0c88co2zUdjlGo3WNvVl3sCQqw/MLgtdH+AY=' 'sha256-uZm4Xh9FxR3B7WjPHL5pbehtSMYTCy9JWzQzl3/UKA0=' 'sha256-o1DLxvGFHY9H1AG6Sro58slSTxU3T7zb020gfyqbFwM=' https://cdn.jsdelivr.net; worker-src 'self' blob:; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; connect-src 'self' https://huggingface.co https://cdn-lfs.huggingface.co https://cdn-lfs-us-1.huggingface.co https://cdn.jsdelivr.net https://cas-bridge.xethub.hf.co; font-src 'self'; object-src 'none'; base-uri 'self'; form-action 'none'" always;
     }
 
     # ONNX model files — cache aggressively, same-origin so CORP is fine
@@ -60,7 +60,7 @@ server {
         add_header Strict-Transport-Security "max-age=63072000; includeSubDomains; preload" always;
         add_header Cross-Origin-Opener-Policy "same-origin" always;
         add_header X-DNS-Prefetch-Control "off" always;
-        add_header Content-Security-Policy "default-src 'self'; script-src 'self' blob: 'wasm-unsafe-eval' 'unsafe-eval' 'sha256-LAtNqeqhdzzGqXdTx12HjOtj8QmXv4qw7OsNW7BCFUw=' 'sha256-uZm4Xh9FxR3B7WjPHL5pbehtSMYTCy9JWzQzl3/UKA0=' 'sha256-o1DLxvGFHY9H1AG6Sro58slSTxU3T7zb020gfyqbFwM=' https://cdn.jsdelivr.net; worker-src 'self' blob:; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; connect-src 'self' https://huggingface.co https://cdn-lfs.huggingface.co https://cdn-lfs-us-1.huggingface.co https://cdn.jsdelivr.net https://cas-bridge.xethub.hf.co; font-src 'self'; object-src 'none'; base-uri 'self'; form-action 'none'" always;
+        add_header Content-Security-Policy "default-src 'self'; script-src 'self' blob: 'wasm-unsafe-eval' 'unsafe-eval' 'sha256-w7MMhkg0c88co2zUdjlGo3WNvVl3sCQqw/MLgtdH+AY=' 'sha256-uZm4Xh9FxR3B7WjPHL5pbehtSMYTCy9JWzQzl3/UKA0=' 'sha256-o1DLxvGFHY9H1AG6Sro58slSTxU3T7zb020gfyqbFwM=' https://cdn.jsdelivr.net; worker-src 'self' blob:; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; connect-src 'self' https://huggingface.co https://cdn-lfs.huggingface.co https://cdn-lfs-us-1.huggingface.co https://cdn.jsdelivr.net https://cas-bridge.xethub.hf.co; font-src 'self'; object-src 'none'; base-uri 'self'; form-action 'none'" always;
     }
 
     # SPA fallback

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "nukebg",
-  "version": "2.8.0",
+  "version": "2.9.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "nukebg",
-      "version": "2.8.0",
+      "version": "2.9.0",
       "license": "GPL-3.0",
       "dependencies": {
         "@huggingface/transformers": "^3.8.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "nukebg",
   "private": true,
-  "version": "2.8.0",
+  "version": "2.9.0",
   "type": "module",
   "description": "NukeBG: Nuke AI backgrounds, checkerboard patterns, and watermarks. 100% client-side. Zero uploads. Zero BS.",
   "license": "GPL-3.0-only",

--- a/public/_headers
+++ b/public/_headers
@@ -7,7 +7,7 @@
   Cross-Origin-Resource-Policy: same-origin
   X-DNS-Prefetch-Control: off
   Strict-Transport-Security: max-age=63072000; includeSubDomains; preload
-  Content-Security-Policy: default-src 'self'; script-src 'self' blob: 'wasm-unsafe-eval' 'unsafe-eval' 'sha256-LAtNqeqhdzzGqXdTx12HjOtj8QmXv4qw7OsNW7BCFUw=' 'sha256-uZm4Xh9FxR3B7WjPHL5pbehtSMYTCy9JWzQzl3/UKA0=' 'sha256-o1DLxvGFHY9H1AG6Sro58slSTxU3T7zb020gfyqbFwM=' https://cdn.jsdelivr.net; worker-src 'self' blob:; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; connect-src 'self' https://huggingface.co https://cdn-lfs.huggingface.co https://cdn-lfs-us-1.huggingface.co https://cdn.jsdelivr.net https://cas-bridge.xethub.hf.co; font-src 'self'; object-src 'none'; base-uri 'self'; form-action 'none'
+  Content-Security-Policy: default-src 'self'; script-src 'self' blob: 'wasm-unsafe-eval' 'unsafe-eval' 'sha256-w7MMhkg0c88co2zUdjlGo3WNvVl3sCQqw/MLgtdH+AY=' 'sha256-uZm4Xh9FxR3B7WjPHL5pbehtSMYTCy9JWzQzl3/UKA0=' 'sha256-o1DLxvGFHY9H1AG6Sro58slSTxU3T7zb020gfyqbFwM=' https://cdn.jsdelivr.net; worker-src 'self' blob:; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; connect-src 'self' https://huggingface.co https://cdn-lfs.huggingface.co https://cdn-lfs-us-1.huggingface.co https://cdn.jsdelivr.net https://cas-bridge.xethub.hf.co; font-src 'self'; object-src 'none'; base-uri 'self'; form-action 'none'
 
 /assets/*
   Cache-Control: public, max-age=31536000, immutable

--- a/src/main.ts
+++ b/src/main.ts
@@ -161,7 +161,7 @@ function createShortcutOverlay(): HTMLDivElement {
 function showConsoleLogo(): void {
   const logo = `
 %c    ☢ NUKEBG ☢
-    v2.8.0 | Terminal Edition
+    v2.9.0 | Terminal Edition
 
     Your images never leave this machine.
     Don't believe us? Read the source:

--- a/src/utils/image-io.ts
+++ b/src/utils/image-io.ts
@@ -168,7 +168,7 @@ export async function exportPng(imageData: ImageData): Promise<Blob> {
     });
   }
   return injectPngMetadata(rawBlob, {
-    Software: 'NukeBG v2.8.0',
+    Software: 'NukeBG v2.9.0',
     Source: 'https://nukebg.app',
   });
 }


### PR DESCRIPTION
Cuts **v2.9.0** from \`dev\`. After this lands on \`dev\` (CI green), I'll open a second \`dev → main\` PR with a merge commit and tag the release on main.

## What ships

### New
- **\`/reactor\` transparency page** — public sunk-cost + forward-burn breakdown with donor consent flow + 7-day GDPR removal SLA (#137 #138 #139 #140 #141)
- **Manual remove-watermark lasso action** via PatchMatch inpaint — distinct from erase-object (#152)
- **SHA-256 supply-chain verification** for RMBG-1.4 + MobileSAM, mirroring the LaMa pattern (#132)
- **Contributor licensing terms (CLA)** + MobileSAM/LaMa license docs (#130)

### Changed
- **Watermark detection: color-specificity gate** kills Gemini-sparkle false positives (#152)
- **ES localization rewritten** to peninsular tuteo (no voseo), Spanglish purged, hero.subtitle.short fixed (#147)
- **Download CTAs stack at ≤640px** (was ≤480) (#150)
- **CI Lint+format is now blocking** after the prettier sweep cleared the backlog (#134)

### Removed
- **Quiet mode toggle** — redundant after Reactor pivot (#148)
- **Web Share button** — duplicated native browser share, made mobile row overflow (#150)
- **"Nueva imagen" cmd-bar button** — duplicate of "procesar otra" (#151)
- **Camera CTA** — confusing; native file picker already exposes camera (#155)

### Fixed
- **Mobile hero \`$\` glyph duplication** + footer privacy overflow on ≤480 px (#155)
- **e2e \`coche-capture\` cold-start budget** bumped 200s → 300s (partial; full warmup fix tracked in #160)

## Version surfaces touched
\`package.json\`, \`package-lock.json\`, \`index.html\` (\`softwareVersion\` JSON-LD + footer badge), \`README.md\` shield, \`src/main.ts\` console banner, \`src/utils/image-io.ts\` PNG metadata. CSP hash regenerated in \`infra/nginx.conf\` + \`public/_headers\` for the new \`softwareVersion\` value.

## Verification
- 689/689 vitest pass (incl. 13 version-coherence tests)
- \`tsc --noEmit\` clean
- \`prettier --check\` clean on the changeset

## Known issue
\`coche-capture\` e2e still flakes on cold-start beyond 5 minutes — non-blocking, ships red on CI as it has been for the last 10+ runs. Proper warmup-beforeAll fix in #160 for v2.9.x.