### PR TITLE
fix(reactor): honour [hidden] attribute on ar-reactor + ar-post-cta

### DIFF
--- a/src/components/ar-post-cta.ts
+++ b/src/components/ar-post-cta.ts
@@ -126,6 +126,12 @@ class ArPostCta extends HTMLElement {
         margin: var(--space-3, 0.75rem) auto 0;
         padding: 0 var(--space-3, 0.75rem);
       }
+      /* Same custom-element gotcha as ar-reactor: \`:host { display: block }\`
+         beats the browser-default \`[hidden] { display: none }\`, so the
+         host has to opt back in explicitly. */
+      :host([hidden]) {
+        display: none;
+      }
       .cta-bar {
         display: flex;
         align-items: center;

--- a/src/components/ar-reactor.ts
+++ b/src/components/ar-reactor.ts
@@ -182,6 +182,13 @@ class ArReactor extends HTMLElement {
         font-family: 'JetBrains Mono', monospace;
         color: var(--color-text-primary, #00ff41);
       }
+      /* Custom-element gotcha: an explicit \`:host { display: block }\`
+         overrides the browser-default \`[hidden] { display: none }\` rule,
+         so the host stays visible even when the hash router applies the
+         \`hidden\` attribute. Restore the expected behaviour. */
+      :host([hidden]) {
+        display: none;
+      }
       .reactor-head {
         margin-bottom: var(--space-5, 1.5rem);
       }

--- a/tests/components/host-hidden-honor.test.ts
+++ b/tests/components/host-hidden-honor.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect, vi, beforeAll } from 'vitest';
+
+/**
+ * Regression guard for the v2.9.0 production bug where the /reactor
+ * page rendered inline on the home page.
+ *
+ * Cause: a custom element with an explicit `:host { display: block }`
+ * rule overrides the browser-default `[hidden] { display: none }`. The
+ * hash router sets `<ar-reactor hidden>`, but without a matching
+ * `:host([hidden]) { display: none }` rule the host stays visible.
+ *
+ * This test mounts every page-level custom element (ar-reactor +
+ * ar-post-cta) and confirms the shadow stylesheet honours the hidden
+ * attribute. Add new entries below if more top-level custom elements
+ * land in the page tree.
+ */
+
+beforeAll(() => {
+  // ar-reactor's connectedCallback fetches /donors.json before rendering.
+  // happy-dom would actually try a network call — short-circuit so the
+  // shadow tree paints synchronously on the first microtask.
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(() =>
+      Promise.resolve({ ok: false, status: 404, json: async () => ({}) } as unknown as Response),
+    ),
+  );
+});
+
+import '../../src/components/ar-reactor';
+import '../../src/components/ar-post-cta';
+
+async function flushAsync(): Promise<void> {
+  for (let i = 0; i < 5; i++) await Promise.resolve();
+  await new Promise((r) => setTimeout(r, 0));
+}
+
+const HOST_HIDDEN_RULE = /:host\(\[hidden\]\)\s*\{[^}]*display:\s*none/;
+
+describe('page-level custom elements honour the hidden attribute (#137 regression)', () => {
+  describe('<ar-reactor> — /reactor transparency page', () => {
+    it('shadow stylesheet declares :host([hidden]) { display: none }', async () => {
+      const el = document.createElement('ar-reactor');
+      document.body.appendChild(el);
+      await flushAsync();
+      const styleEl = el.shadowRoot!.querySelector('style');
+      expect(styleEl, '<ar-reactor> must render an inline <style>').not.toBeNull();
+      expect(styleEl!.textContent).toMatch(HOST_HIDDEN_RULE);
+      el.remove();
+    });
+
+    it('reports hidden=true when the attribute is set', async () => {
+      const el = document.createElement('ar-reactor');
+      el.hidden = true;
+      document.body.appendChild(el);
+      await flushAsync();
+      expect(el.hasAttribute('hidden')).toBe(true);
+      expect(el.hidden).toBe(true);
+      el.remove();
+    });
+  });
+
+  describe('<ar-post-cta> — post-process tip CTA', () => {
+    // ar-post-cta only paints its <style> when a CTA is actively shown.
+    // Drive it via the public ar:nuke-success event + fake timers so the
+    // 1s "settle" delay before show() resolves immediately.
+    it('shadow stylesheet declares :host([hidden]) { display: none } once a CTA is shown', () => {
+      vi.useFakeTimers();
+      // Force a non-dismissed empty state so the first nuke triggers
+      // the first-star CTA deterministically.
+      try {
+        localStorage.removeItem('nukebg:cta-dismissed');
+        localStorage.removeItem('nukebg:nuke-count');
+      } catch {
+        /* localStorage unavailable in some envs — fall through */
+      }
+      const el = document.createElement('ar-post-cta');
+      document.body.appendChild(el);
+      document.dispatchEvent(new CustomEvent('ar:nuke-success'));
+      vi.advanceTimersByTime(1100);
+      const styleEl = el.shadowRoot!.querySelector('style');
+      expect(styleEl, '<ar-post-cta> must render <style> once a CTA is shown').not.toBeNull();
+      expect(styleEl!.textContent).toMatch(HOST_HIDDEN_RULE);
+      el.remove();
+      vi.useRealTimers();
+    });
+  });
+});


### PR DESCRIPTION
**Production hotfix** — the v2.9.0 \`/reactor\` page renders inline on the home page. Confirmed live on nukebg.app.

## Cause

A custom element with an explicit \`:host { display: block }\` rule **overrides the browser-default \`[hidden] { display: none }\`**. The hash router in \`main.ts\` sets \`<ar-reactor hidden>\` correctly on every load that is NOT on the \`#reactor\` hash, but the host stays visible because the CSS rule keeps it at \`display: block\`.

## Fix

Add \`:host([hidden]) { display: none }\` to both \`ar-reactor\` and \`ar-post-cta\` (defensive — same pattern in \`:host { display: block }\`).

## Verification

Drove Playwright before + after:

| Hash | hidden attr | display | offsetHeight |
|---|---|---|---|
| \`/\` (before fix) | true | block ❌ | 1427 |
| \`/\` (after fix) | true | none ✅ | 0 |
| \`/#reactor\` | false | block ✅ | 1427 |

## Regression guard

New \`tests/components/host-hidden-honor.test.ts\` mounts each page-level custom element and asserts the shadow stylesheet declares the \`:host([hidden])\` rule. ar-post-cta needs an \`ar:nuke-success\` event + fake timers to drive its lazy render — both branches covered.

## Verification
- 822/822 vitest pass (was 819, +3 regression cases)
- \`tsc --noEmit\` clean

## Next
After this lands on dev, cut **v2.9.1** to push the fix to prod.