### PR TITLE
fix(ci): skip onnxruntime-node CUDA download (unblocks Cloudflare Pages)

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,13 @@
+# Skip the onnxruntime-node CUDA download.
+#
+# `onnxruntime-node` is a transitive dependency of @huggingface/transformers.
+# Its postinstall script tries to fetch ~200 MB of CUDA binaries from
+# GitHub Releases, which:
+#   1. We never use — NukeBG is 100% client-side and runs onnxruntime-web
+#      in the browser, not the Node bindings.
+#   2. Made Cloudflare Pages deploys fail when github.com returned a
+#      502 on 2026-04-26 (build for v2.9.0).
+# This flag tells the postinstall to noop. The package itself still
+# installs (transformers.js requires it as a peer for type-resolution
+# in Node contexts), just without the CUDA EP binaries.
+onnxruntime-node-install-cuda=skip


### PR DESCRIPTION
**Production deploy hotfix.** Cloudflare Pages build for v2.9.0 + the i18n / hidden-attr fixes failed on 2026-04-26 because \`onnxruntime-node\` tried to fetch ~200 MB of CUDA binaries from GitHub Releases and got a 502.

\`\`\`
npm error path /opt/buildhome/repo/node_modules/onnxruntime-node
npm error Downloading "https://github.com/microsoft/onnxruntime/releases/download/v1.21.0/onnxruntime-linux-x64-gpu-1.21.0.tgz"...
npm error Failed to download the binaries: 502 Bad Gateway or Proxy Error.
\`\`\`

## Why this is wasted bandwidth in the first place

\`onnxruntime-node\` is a transitive dependency of \`@huggingface/transformers\` (peer for type resolution in Node contexts). NukeBG **never** uses it — the app is 100% client-side and runs \`onnxruntime-web\` in the browser. Downloading the CUDA EP blob is pure waste even when github.com is up, and a deploy hazard when it isn't.

## Fix

Add \`.npmrc\` with one line: \`onnxruntime-node-install-cuda=skip\`. The package itself still installs (so type imports keep resolving), the postinstall just no-ops instead of trying to download the binary blob.

## Verification

| Check | Result |
|---|---|
| \`rm -rf node_modules/onnxruntime-node && npm install\` | ✅ clean install, no CUDA fetch |
| \`npm test\` | ✅ 822/822 |
| \`npm run typecheck\` | ✅ clean |
| \`npm run build\` (mirrors CF Pages) | ✅ \`built in 1.88s\` |

## Impact
- Unblocks v2.9.1 deploy
- Hardens every future deploy against intermittent github.com / Releases CDN hiccups
- Saves ~200 MB of unnecessary download per CI run