### PR TITLE
ux(footer+readme): surface /reactor + dedupe donation links

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,10 +5,8 @@
 [![Version](https://img.shields.io/badge/version-2.9.0-brightgreen.svg)](https://github.com/yocreoquesi/nukebg/releases)
 [![License: GPL-3.0](https://img.shields.io/badge/License-GPL%20v3-blue.svg)](https://www.gnu.org/licenses/gpl-3.0)
 [![Client-Side](https://img.shields.io/badge/Processing-100%25%20Client--Side-green.svg)](#-privacy)
-[![Ko-fi](https://img.shields.io/badge/Ko--fi-Support%20NukeBG-FF5E5B?logo=ko-fi&logoColor=white)](https://ko-fi.com/yocreoquesi)
-[![Sponsor](https://img.shields.io/badge/Sponsor-GitHub%20Sponsors-ea4aaa?logo=github-sponsors&logoColor=white)](https://github.com/sponsors/yocreoquesi)
 
-[Use NukeBG](https://nukebg.app) | [GitHub](https://github.com/yocreoquesi/nukebg) | [Sponsor](https://github.com/sponsors/yocreoquesi) | [Ko-fi](https://ko-fi.com/yocreoquesi)
+[Use NukeBG](https://nukebg.app) | [GitHub](https://github.com/yocreoquesi/nukebg) | [Reactor — costs & runtime](https://nukebg.app/#reactor)
 
 ---
 
@@ -213,6 +211,8 @@ If NukeBG saves you time, consider keeping the reactor running:
 [![Sponsor on GitHub](https://img.shields.io/badge/Sponsor-GitHub%20Sponsors-ea4aaa?logo=github-sponsors&logoColor=white&style=for-the-badge)](https://github.com/sponsors/yocreoquesi)
 
 [![Ko-fi](https://ko-fi.com/img/githubbutton_sm.svg)](https://ko-fi.com/yocreoquesi)
+
+See where the time and money go: [/#reactor](https://nukebg.app/#reactor) — public sunk-cost + monthly burn breakdown.
 
 ---
 

--- a/index.html
+++ b/index.html
@@ -492,13 +492,11 @@
       >
       <span class="footer-sep">|</span>
       <a
-        href="https://ko-fi.com/yocreoquesi"
-        target="_blank"
-        rel="noopener noreferrer"
-        class="kofi-link"
-        id="kofi-link"
-        aria-label="Tip the reactor"
-        >☕ Tip the reactor →</a
+        href="#reactor"
+        class="reactor-link"
+        id="reactor-link"
+        aria-label="View project costs and runtime"
+        ># /sys/reactor</a
       >
       <span class="footer-sep">|</span>
       <a href="#" id="clear-cache-btn" class="footer-cache-btn" title="Clear cached data and reload"

--- a/src/i18n/index.ts
+++ b/src/i18n/index.ts
@@ -188,8 +188,7 @@ const translations: Translations = {
     'firstRun.ready': '# ready — cached locally, offline-capable',
     // Header / Footer (index.html)
     'header.skipLink': 'Skip to main content',
-    'footer.kofi': '\u2615 Support on Ko-fi',
-    'footer.kofiAria': 'Tip on Ko-fi \u2014 currently funded for {runtime}',
+    'footer.reactorLinkAria': 'View project costs and runtime \u2014 currently funded for {runtime}',
     'footer.reactorStatus': 'Ships only while the budget holds ({burn}). Currently funded for {runtime}.',
     'marquee.funding': 'development funded for {runtime} \u2014 tip to extend runway',
     'cta.firstStar.text': '$ if this saved you 5 minutes, drop a star on the repo',
@@ -454,8 +453,7 @@ const translations: Translations = {
     'firstRun.ready': '# listo — cacheado localmente, listo offline',
     // Header / Footer (index.html)
     'header.skipLink': 'Saltar al contenido principal',
-    'footer.kofi': '\u2615 Apoyar en Ko-fi',
-    'footer.kofiAria': 'Donar en Ko-fi \u2014 ahora financiado para {runtime}',
+    'footer.reactorLinkAria': 'Ver costes del proyecto y runtime \u2014 ahora financiado para {runtime}',
     'footer.reactorStatus': 'Solo se actualiza mientras dure el presupuesto ({burn}). Ahora financiado para {runtime}.',
     'marquee.funding': 'desarrollo financiado por {runtime} \u2014 alimenta el reactor',
     'cta.firstStar.text': '$ si te ahorró 5 minutos, deja una estrella en el repo',
@@ -720,8 +718,7 @@ const translations: Translations = {
     'firstRun.ready': '# prêt — caché localement, prêt hors ligne',
     // Header / Footer (index.html)
     'header.skipLink': 'Aller au contenu principal',
-    'footer.kofi': '\u2615 Soutenir sur Ko-fi',
-    'footer.kofiAria': 'Soutenir sur Ko-fi \u2014 actuellement financ\u00E9 pour {runtime}',
+    'footer.reactorLinkAria': 'Voir les co\u00FBts du projet et le runtime \u2014 actuellement financ\u00E9 pour {runtime}',
     'footer.reactorStatus': 'Mises \u00E0 jour tant que le budget tient ({burn}). Actuellement financ\u00E9 pour {runtime}.',
     'marquee.funding': 'd\u00E9veloppement financ\u00E9 pour {runtime} \u2014 soutiens pour prolonger',
     'cta.firstStar.text': '$ si ça t a fait gagner 5 minutes, laisse une étoile sur le repo',
@@ -986,8 +983,7 @@ const translations: Translations = {
     'firstRun.ready': '# bereit — lokal zwischengespeichert, offline-fähig',
     // Header / Footer (index.html)
     'header.skipLink': 'Zum Hauptinhalt springen',
-    'footer.kofi': '\u2615 Unterst\u00FCtzen auf Ko-fi',
-    'footer.kofiAria': 'Auf Ko-fi unterst\u00FCtzen \u2014 derzeit finanziert f\u00FCr {runtime}',
+    'footer.reactorLinkAria': 'Projektkosten und Laufzeit ansehen \u2014 derzeit finanziert f\u00FCr {runtime}',
     'footer.reactorStatus': 'Wird nur ausgeliefert, solange das Budget reicht ({burn}). Derzeit finanziert f\u00FCr {runtime}.',
     'marquee.funding': 'Entwicklung finanziert f\u00FCr {runtime} \u2014 spende, um zu verl\u00E4ngern',
     'cta.firstStar.text': '$ wenn das 5 Minuten gespart hat, gib einen Stern auf dem Repo',
@@ -1252,8 +1248,7 @@ const translations: Translations = {
     'firstRun.ready': '# pronto — em cache local, pronto offline',
     // Header / Footer (index.html)
     'header.skipLink': 'Pular para o conte\u00FAdo principal',
-    'footer.kofi': '\u2615 Apoiar no Ko-fi',
-    'footer.kofiAria': 'Apoiar no Ko-fi \u2014 atualmente financiado por {runtime}',
+    'footer.reactorLinkAria': 'Ver custos do projeto e runtime \u2014 atualmente financiado por {runtime}',
     'footer.reactorStatus': 'S\u00F3 atualiza enquanto o or\u00E7amento durar ({burn}). Atualmente financiado por {runtime}.',
     'marquee.funding': 'desenvolvimento financiado por {runtime} \u2014 apoia para estender',
     'cta.firstStar.text': '$ se te poupou 5 minutos, deixa uma estrela no repo',
@@ -1518,8 +1513,7 @@ const translations: Translations = {
     'firstRun.ready': '# \u5C31\u7EEA — \u672C\u5730\u7F13\u5B58\uFF0C\u53EF\u79BB\u7EBF\u4F7F\u7528',
     // Header / Footer (index.html)
     'header.skipLink': '\u8DF3\u8F6C\u5230\u4E3B\u8981\u5185\u5BB9',
-    'footer.kofi': '\u2615 \u5728 Ko-fi \u4E0A\u652F\u6301\u6211\u4EEC',
-    'footer.kofiAria': '\u5728 Ko-fi \u4E0A\u8D5E\u52A9 \u2014 \u76EE\u524D\u8D44\u91D1\u53EF\u7EF4\u6301 {runtime}',
+    'footer.reactorLinkAria': '\u67E5\u770B\u9879\u76EE\u6210\u672C\u4E0E\u8FD0\u884C\u65F6\u95F4 \u2014 \u76EE\u524D\u53EF\u7EF4\u6301 {runtime}',
     'footer.reactorStatus': '\u4EC5\u5728\u9884\u7B97\u5141\u8BB8\u65F6\u66F4\u65B0\uFF08{burn}\uFF09\u3002\u76EE\u524D\u53EF\u7EF4\u6301 {runtime}\u3002',
     'marquee.funding': '\u5F00\u53D1\u8D44\u91D1\u53EF\u7EF4\u6301 {runtime} \u2014 \u8D5E\u52A9\u4EE5\u5EF6\u957F',
     'cta.firstStar.text': '$ \u5982\u679C\u7701\u4E86\u4F60 5 \u5206\u949F, \u8BF7\u5728\u4ED3\u5E93\u70B9\u4E2A star',

--- a/src/main.ts
+++ b/src/main.ts
@@ -635,8 +635,6 @@ function initI18n(): void {
 function updateHtmlTexts(): void {
   const skipLink = document.getElementById('skip-link');
   if (skipLink) skipLink.textContent = t('header.skipLink');
-  const kofiLink = document.getElementById('kofi-link');
-  if (kofiLink) kofiLink.textContent = t('footer.kofi');
   const footerPrivacy = document.getElementById('footer-privacy');
   if (footerPrivacy) footerPrivacy.textContent = t('footer.privacy');
 }
@@ -1052,7 +1050,7 @@ function initReactorStatus(): void {
   void applyReactorStatus({
     footerStatus: (runtime) => t('footer.reactorStatus', { burn, runtime }),
     marqueeFunding: (runtime) => t('marquee.funding', { burn, runtime }),
-    kofiAriaLabel: (runtime) => t('footer.kofiAria', { runtime }),
+    reactorLinkAria: (runtime) => t('footer.reactorLinkAria', { runtime }),
   });
 }
 

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -636,14 +636,14 @@ body::after {
   color: var(--color-text-secondary);
 }
 
-.kofi-link {
+.reactor-link {
   color: var(--color-accent-primary) !important;
   font-weight: var(--font-semibold);
   text-shadow: 0 0 6px var(--color-accent-glow);
   transition: text-shadow var(--duration-fast);
 }
 
-.kofi-link:hover {
+.reactor-link:hover {
   text-shadow: 0 0 12px var(--color-accent-glow);
 }
 

--- a/src/utils/reactor-status-injector.ts
+++ b/src/utils/reactor-status-injector.ts
@@ -27,8 +27,8 @@ interface ReactorStatusStrings {
   footerStatus: (runtime: string) => string;
   /** Marquee segment. Receives `{runtime}` as the runtime label. */
   marqueeFunding: (runtime: string) => string;
-  /** aria-label / title for the Ko-fi link. Receives `{runtime}`. */
-  kofiAriaLabel: (runtime: string) => string;
+  /** aria-label for the footer link to the /reactor page. Receives `{runtime}`. */
+  reactorLinkAria: (runtime: string) => string;
 }
 
 export async function applyReactorStatus(strings: ReactorStatusStrings): Promise<void> {
@@ -66,8 +66,8 @@ function applyDom(runtimeLabel: string, strings: ReactorStatusStrings): void {
     el.textContent = strings.marqueeFunding(runtimeLabel);
   });
 
-  const kofi = document.getElementById('kofi-link');
-  if (kofi) kofi.setAttribute('aria-label', strings.kofiAriaLabel(runtimeLabel));
+  const reactorLink = document.getElementById('reactor-link');
+  if (reactorLink) reactorLink.setAttribute('aria-label', strings.reactorLinkAria(runtimeLabel));
 }
 
 /** Exported for tests — the burn rate in human-readable form. */


### PR DESCRIPTION
## What this changes

### App — footer
Replace the footer's \"☕ Tip the reactor\" Ko-fi link with **\`# /sys/reactor\`** pointing at the existing transparency page (\`#reactor\` hash route).

The reactor page already has its own \"Alimentar el reactor →\" CTA into Ko-fi, so the donation flow now naturally lands through the cost-breakdown first. More honest, less pushy, fixes the previously-unreachable transparency page.

Side cleanups:
- Drop unused \`footer.kofi\` i18n key (link text is brand-fixed now, same in all locales)
- Rename \`footer.kofiAria\` → \`footer.reactorLinkAria\` × 6 locales, reword to match new purpose
- Rename \`kofiAriaLabel\` → \`reactorLinkAria\` in the injector contract
- Rename \`.kofi-link\` → \`.reactor-link\` CSS
- Drop deprecated \`target=\"_blank\"\` (internal hash route now)

### README — donation link dedup

| Before | After |
|---|---|
| 5 mentions of Ko-fi/Sponsor (3 in first scroll) | **2** mentions, both in the \`## > support\` section |
| No reference to the \`/reactor\` transparency page | Linked from quick-links bar AND a one-liner in support section |

- Header badges row: dropped Ko-fi + Sponsor (kept Version / License / Client-Side — the informative ones)
- Quick-links bar: dropped \`Sponsor | Ko-fi\`, added \`Reactor — costs & runtime\`
- \`## > support\` section: unchanged badges + new line \"See where the time and money go: /#reactor — public sunk-cost + monthly burn breakdown\"

### Verified with Playwright
\`\`\`
reactor-link  → text \"# /sys/reactor\", href \"#reactor\",
                aria \"Ver costes del proyecto y runtime — ahora financiado para 0 months\" (es)
click         → location.hash \"#reactor\", reactor section visible
kofi-link     → gone (no DOM node by id)
\`\`\`

### Verification
- 822/822 vitest pass
- \`tsc --noEmit\` clean
- CSP hashes unchanged (footer link edit doesn't touch the JSON-LD blocks)