### PR TITLE
fix(reactor): center /#reactor route to match main app width

### DIFF
--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -490,6 +490,21 @@ body::after {
   width: 100%;
 }
 
+/* Page-level reactor route container. Sits as a sibling of <main> in
+   the body flex column. The universal `* { margin: 0 }` reset above
+   beats the component's `:host { margin: 0 auto }` (rules outside a
+   shadow root always trump :host defaults), so the host renders left
+   when the route is active. We restore the centering here and match
+   .main-content's max-width so navigating between / and /#reactor is
+   visually seamless. */
+#reactor-section {
+  max-width: 960px;
+  margin-left: auto;
+  margin-right: auto;
+  width: 100%;
+  flex: 1 0 auto;
+}
+
 /* === Footer === */
 .footer {
   border-top: 1px solid var(--color-surface-border, #1a3a1a);


### PR DESCRIPTION
## Bug

When navigating from \`/\` to \`/#reactor\` the page rendered hard-left in the viewport instead of staying in the centered 960px column the home view uses. Pressing the new \`# /sys/reactor\` footer link snapped content to the edge — visually disorienting.

## Cause

The global reset \`* { margin: 0 }\` (specificity 0,0,0,0) beats the component's \`:host { margin: 0 auto }\`. Rules outside a shadow root **always** trump \`:host\` defaults, so margin-left/right on the host computed to 0 and the body's flex-column layout placed it flush left.

## Fix

Add an external rule on \`#reactor-section\` that restores \`margin-left/right: auto\` and matches \`.main-content\`'s 960px max-width so home → /#reactor → home stays in the same column.

## Verified with Playwright (1400×900 viewport)

| | x | marginL | marginR | width |
|---|---|---|---|---|
| Before | 0 | 0px | 0px | 760 |
| After | 220 | 220px | 220px | 960 |

Centered + matches main column.