### PR TITLE
release: v2.9.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,65 @@ Unreleased entries accumulate on the `dev` branch. When we cut a release we copy
 
 ## [Unreleased]
 
+## [2.9.1] — 2026-04-27
+
+### Fixed
+
+- **`/reactor` rendered inline on the home page**. `<ar-reactor>` ignored its
+  `hidden` attribute because `:host { display: block }` overrides the
+  browser-default `[hidden] { display: none }` rule. Added the explicit
+  `:host([hidden]) { display: none }` companion to both `ar-reactor` and
+  `ar-post-cta` and a regression guard in
+  `tests/components/host-hidden-honor.test.ts`.
+  ([#167](https://github.com/yocreoquesi/nukebg/pull/167))
+- **`/#reactor` rendered hard-left** instead of in the centered 960 px
+  column the home view uses. The global `* { margin: 0 }` reset beat
+  the component's `:host { margin: 0 auto }` (rules outside a shadow
+  root always trump `:host`). Added an external `#reactor-section` rule
+  that restores centering and matches `.main-content`'s width so
+  navigating home → /#reactor → home stays in the same column.
+  ([#172](https://github.com/yocreoquesi/nukebg/pull/172))
+- **Footer rendered the literal string `footer.reactorStatus`** instead
+  of the translated text. The reactor-status injector calls three i18n
+  keys (`footer.reactorStatus`, `marquee.funding`, `footer.kofiAria`)
+  that were never added to `src/i18n/index.ts`; with no entry, `t()`
+  returns the raw key. Added the 3 missing keys to all six locales
+  with `{burn}` / `{runtime}` interpolation.
+  ([#168](https://github.com/yocreoquesi/nukebg/pull/168))
+- **Cloudflare Pages deploys failed** when github.com Releases
+  returned a 502 because `onnxruntime-node`'s postinstall fetched
+  ~200 MB of CUDA binaries we never use (NukeBG runs
+  `onnxruntime-web` in the browser). Added `.npmrc` with
+  `onnxruntime-node-install-cuda=skip` — the package still installs
+  (transformers.js needs it for type resolution in Node contexts),
+  the postinstall just no-ops.
+  ([#169](https://github.com/yocreoquesi/nukebg/pull/169))
+
+### Changed
+
+- **Footer link to `/reactor`**. Replaced the footer's "☕ Tip the
+  reactor" Ko-fi link with `# /sys/reactor` pointing at the existing
+  transparency page (`#reactor` hash route). The reactor page already
+  has its own "Alimentar el reactor →" CTA into Ko-fi, so the
+  donation flow now naturally lands through the cost-breakdown first
+  — more honest, less pushy. Also fixes the previously-unreachable
+  transparency page.
+  ([#170](https://github.com/yocreoquesi/nukebg/pull/170))
+- **README donation link cleanup**. Cut from 5 mentions of Ko-fi /
+  Sponsor (3 in the first scroll) to 2 mentions consolidated in the
+  `## > support` section. Added a quick-link to the `/reactor`
+  transparency page in the masthead links bar.
+  ([#170](https://github.com/yocreoquesi/nukebg/pull/170))
+
+### Internal
+
+- **Behavioural test coverage for the 7 untested web components**
+  — ar-viewer, ar-dropzone, ar-app, ar-editor-advanced, ar-privacy,
+  ar-batch-grid, ar-batch-item. +130 cases (689 → 819 tests). Two
+  brittle source-pattern tests retired now that their surface is
+  covered behaviourally.
+  ([#166](https://github.com/yocreoquesi/nukebg/pull/166))
+
 ## [2.9.0] — 2026-04-26
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 > Nuke backgrounds from any image. 100% client-side. Zero uploads. Zero BS.
 
-[![Version](https://img.shields.io/badge/version-2.9.0-brightgreen.svg)](https://github.com/yocreoquesi/nukebg/releases)
+[![Version](https://img.shields.io/badge/version-2.9.1-brightgreen.svg)](https://github.com/yocreoquesi/nukebg/releases)
 [![License: GPL-3.0](https://img.shields.io/badge/License-GPL%20v3-blue.svg)](https://www.gnu.org/licenses/gpl-3.0)
 [![Client-Side](https://img.shields.io/badge/Processing-100%25%20Client--Side-green.svg)](#-privacy)
 

--- a/index.html
+++ b/index.html
@@ -151,7 +151,7 @@
           "PNG export with true alpha transparency"
         ],
         "screenshot": "https://nukebg.app/og-image.png",
-        "softwareVersion": "2.9.0",
+        "softwareVersion": "2.9.1",
         "license": "https://www.gnu.org/licenses/gpl-3.0.html",
         "isAccessibleForFree": true,
         "creator": {
@@ -483,7 +483,7 @@
     <ar-post-cta id="post-cta"></ar-post-cta>
 
     <footer class="footer hazard-border-top" role="contentinfo">
-      <span>NukeBG <span style="color: var(--color-text-tertiary)">v2.9.0</span></span>
+      <span>NukeBG <span style="color: var(--color-text-tertiary)">v2.9.1</span></span>
       <span class="footer-sep">|</span>
       <span>GPL-3.0</span>
       <span class="footer-sep">|</span>

--- a/infra/nginx.conf
+++ b/infra/nginx.conf
@@ -31,7 +31,7 @@ server {
     #   new Function() WASM bootstrap.
     # - sha256 hashes cover the 3 inline JSON-LD blocks in index.html.
     #   Regenerate with `node scripts/compute-csp-hashes.mjs` after edits.
-    add_header Content-Security-Policy "default-src 'self'; script-src 'self' blob: 'wasm-unsafe-eval' 'unsafe-eval' 'sha256-w7MMhkg0c88co2zUdjlGo3WNvVl3sCQqw/MLgtdH+AY=' 'sha256-uZm4Xh9FxR3B7WjPHL5pbehtSMYTCy9JWzQzl3/UKA0=' 'sha256-o1DLxvGFHY9H1AG6Sro58slSTxU3T7zb020gfyqbFwM=' https://cdn.jsdelivr.net; worker-src 'self' blob:; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; connect-src 'self' https://huggingface.co https://cdn-lfs.huggingface.co https://cdn-lfs-us-1.huggingface.co https://cdn.jsdelivr.net https://cas-bridge.xethub.hf.co; font-src 'self'; object-src 'none'; base-uri 'self'; form-action 'none'" always;
+    add_header Content-Security-Policy "default-src 'self'; script-src 'self' blob: 'wasm-unsafe-eval' 'unsafe-eval' 'sha256-mIcEwWjsYk3dAQWKxztVzouiBQRsPqCJ6MztRt86+gg=' 'sha256-uZm4Xh9FxR3B7WjPHL5pbehtSMYTCy9JWzQzl3/UKA0=' 'sha256-o1DLxvGFHY9H1AG6Sro58slSTxU3T7zb020gfyqbFwM=' https://cdn.jsdelivr.net; worker-src 'self' blob:; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; connect-src 'self' https://huggingface.co https://cdn-lfs.huggingface.co https://cdn-lfs-us-1.huggingface.co https://cdn.jsdelivr.net https://cas-bridge.xethub.hf.co; font-src 'self'; object-src 'none'; base-uri 'self'; form-action 'none'" always;
 
     # Cache static assets
     # Note: add_header in location blocks replaces parent headers in nginx,
@@ -46,7 +46,7 @@ server {
         add_header Strict-Transport-Security "max-age=63072000; includeSubDomains; preload" always;
         add_header Cross-Origin-Opener-Policy "same-origin" always;
         add_header X-DNS-Prefetch-Control "off" always;
-        add_header Content-Security-Policy "default-src 'self'; script-src 'self' blob: 'wasm-unsafe-eval' 'unsafe-eval' 'sha256-w7MMhkg0c88co2zUdjlGo3WNvVl3sCQqw/MLgtdH+AY=' 'sha256-uZm4Xh9FxR3B7WjPHL5pbehtSMYTCy9JWzQzl3/UKA0=' 'sha256-o1DLxvGFHY9H1AG6Sro58slSTxU3T7zb020gfyqbFwM=' https://cdn.jsdelivr.net; worker-src 'self' blob:; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; connect-src 'self' https://huggingface.co https://cdn-lfs.huggingface.co https://cdn-lfs-us-1.huggingface.co https://cdn.jsdelivr.net https://cas-bridge.xethub.hf.co; font-src 'self'; object-src 'none'; base-uri 'self'; form-action 'none'" always;
+        add_header Content-Security-Policy "default-src 'self'; script-src 'self' blob: 'wasm-unsafe-eval' 'unsafe-eval' 'sha256-mIcEwWjsYk3dAQWKxztVzouiBQRsPqCJ6MztRt86+gg=' 'sha256-uZm4Xh9FxR3B7WjPHL5pbehtSMYTCy9JWzQzl3/UKA0=' 'sha256-o1DLxvGFHY9H1AG6Sro58slSTxU3T7zb020gfyqbFwM=' https://cdn.jsdelivr.net; worker-src 'self' blob:; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; connect-src 'self' https://huggingface.co https://cdn-lfs.huggingface.co https://cdn-lfs-us-1.huggingface.co https://cdn.jsdelivr.net https://cas-bridge.xethub.hf.co; font-src 'self'; object-src 'none'; base-uri 'self'; form-action 'none'" always;
     }
 
     # ONNX model files — cache aggressively, same-origin so CORP is fine
@@ -60,7 +60,7 @@ server {
         add_header Strict-Transport-Security "max-age=63072000; includeSubDomains; preload" always;
         add_header Cross-Origin-Opener-Policy "same-origin" always;
         add_header X-DNS-Prefetch-Control "off" always;
-        add_header Content-Security-Policy "default-src 'self'; script-src 'self' blob: 'wasm-unsafe-eval' 'unsafe-eval' 'sha256-w7MMhkg0c88co2zUdjlGo3WNvVl3sCQqw/MLgtdH+AY=' 'sha256-uZm4Xh9FxR3B7WjPHL5pbehtSMYTCy9JWzQzl3/UKA0=' 'sha256-o1DLxvGFHY9H1AG6Sro58slSTxU3T7zb020gfyqbFwM=' https://cdn.jsdelivr.net; worker-src 'self' blob:; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; connect-src 'self' https://huggingface.co https://cdn-lfs.huggingface.co https://cdn-lfs-us-1.huggingface.co https://cdn.jsdelivr.net https://cas-bridge.xethub.hf.co; font-src 'self'; object-src 'none'; base-uri 'self'; form-action 'none'" always;
+        add_header Content-Security-Policy "default-src 'self'; script-src 'self' blob: 'wasm-unsafe-eval' 'unsafe-eval' 'sha256-mIcEwWjsYk3dAQWKxztVzouiBQRsPqCJ6MztRt86+gg=' 'sha256-uZm4Xh9FxR3B7WjPHL5pbehtSMYTCy9JWzQzl3/UKA0=' 'sha256-o1DLxvGFHY9H1AG6Sro58slSTxU3T7zb020gfyqbFwM=' https://cdn.jsdelivr.net; worker-src 'self' blob:; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; connect-src 'self' https://huggingface.co https://cdn-lfs.huggingface.co https://cdn-lfs-us-1.huggingface.co https://cdn.jsdelivr.net https://cas-bridge.xethub.hf.co; font-src 'self'; object-src 'none'; base-uri 'self'; form-action 'none'" always;
     }
 
     # SPA fallback

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "nukebg",
-  "version": "2.9.0",
+  "version": "2.9.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "nukebg",
-      "version": "2.9.0",
+      "version": "2.9.1",
       "license": "GPL-3.0",
       "dependencies": {
         "@huggingface/transformers": "^3.8.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "nukebg",
   "private": true,
-  "version": "2.9.0",
+  "version": "2.9.1",
   "type": "module",
   "description": "NukeBG: Nuke AI backgrounds, checkerboard patterns, and watermarks. 100% client-side. Zero uploads. Zero BS.",
   "license": "GPL-3.0-only",

--- a/public/_headers
+++ b/public/_headers
@@ -7,7 +7,7 @@
   Cross-Origin-Resource-Policy: same-origin
   X-DNS-Prefetch-Control: off
   Strict-Transport-Security: max-age=63072000; includeSubDomains; preload
-  Content-Security-Policy: default-src 'self'; script-src 'self' blob: 'wasm-unsafe-eval' 'unsafe-eval' 'sha256-w7MMhkg0c88co2zUdjlGo3WNvVl3sCQqw/MLgtdH+AY=' 'sha256-uZm4Xh9FxR3B7WjPHL5pbehtSMYTCy9JWzQzl3/UKA0=' 'sha256-o1DLxvGFHY9H1AG6Sro58slSTxU3T7zb020gfyqbFwM=' https://cdn.jsdelivr.net; worker-src 'self' blob:; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; connect-src 'self' https://huggingface.co https://cdn-lfs.huggingface.co https://cdn-lfs-us-1.huggingface.co https://cdn.jsdelivr.net https://cas-bridge.xethub.hf.co; font-src 'self'; object-src 'none'; base-uri 'self'; form-action 'none'
+  Content-Security-Policy: default-src 'self'; script-src 'self' blob: 'wasm-unsafe-eval' 'unsafe-eval' 'sha256-mIcEwWjsYk3dAQWKxztVzouiBQRsPqCJ6MztRt86+gg=' 'sha256-uZm4Xh9FxR3B7WjPHL5pbehtSMYTCy9JWzQzl3/UKA0=' 'sha256-o1DLxvGFHY9H1AG6Sro58slSTxU3T7zb020gfyqbFwM=' https://cdn.jsdelivr.net; worker-src 'self' blob:; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; connect-src 'self' https://huggingface.co https://cdn-lfs.huggingface.co https://cdn-lfs-us-1.huggingface.co https://cdn.jsdelivr.net https://cas-bridge.xethub.hf.co; font-src 'self'; object-src 'none'; base-uri 'self'; form-action 'none'
 
 /assets/*
   Cache-Control: public, max-age=31536000, immutable

--- a/src/main.ts
+++ b/src/main.ts
@@ -161,7 +161,7 @@ function createShortcutOverlay(): HTMLDivElement {
 function showConsoleLogo(): void {
   const logo = `
 %c    ☢ NUKEBG ☢
-    v2.9.0 | Terminal Edition
+    v2.9.1 | Terminal Edition
 
     Your images never leave this machine.
     Don't believe us? Read the source:

--- a/src/utils/image-io.ts
+++ b/src/utils/image-io.ts
@@ -168,7 +168,7 @@ export async function exportPng(imageData: ImageData): Promise<Blob> {
     });
   }
   return injectPngMetadata(rawBlob, {
-    Software: 'NukeBG v2.9.0',
+    Software: 'NukeBG v2.9.1',
     Source: 'https://nukebg.app',
   });
 }


### PR DESCRIPTION
Patch release rolling up the v2.9.0 production hotfixes:

| PR | What |
|---|---|
| #167 | \`:host([hidden])\` companion → \`<ar-reactor>\` honours \`hidden\` attribute (page no longer renders inline on home) |
| #168 | Add 3 missing reactor-injector i18n keys (footer no longer shows the literal \`footer.reactorStatus\`) |
| #169 | \`.npmrc\` skips onnxruntime-node CUDA download → Cloudflare Pages deploys don't depend on github.com Releases |
| #170 | UX: footer link now points at \`/#reactor\` (was previously unreachable); README dedupes 5 → 2 donation/sponsor mentions |
| #172 | Center \`/#reactor\` route to match \`.main-content\` width — home → /#reactor → home stays in the same column |

## Version surfaces touched
\`package.json\`, \`package-lock.json\`, \`index.html\` (\`softwareVersion\` JSON-LD + footer badge), \`README.md\` shield, \`src/main.ts\` console banner, \`src/utils/image-io.ts\` PNG metadata. Regenerated JSON-LD softwareVersion CSP hash — first of three hashes changed; updated in \`infra/nginx.conf\` (×3) and \`public/_headers\` (×1).

## Verification
- 822/822 vitest pass
- \`tsc --noEmit\` clean
- \`prettier --check\` clean
- \`npm run build\` clean (mirrors what CF Pages runs)

## Post-merge
- Open dev → main PR with merge commit
- Tag v2.9.1 on main
- Cloudflare Pages auto-deploys (this time without the github.com 502 hazard)