### PR TITLE
release: v2.9.2 → main

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,18 @@ Unreleased entries accumulate on the `dev` branch. When we cut a release we copy
 
 ## [Unreleased]
 
+## [2.9.2] — 2026-04-27
+
+### Changed
+
+- **Footer copy slimmed + tone softened**. The redundant
+  "Tus im\u00E1genes nunca salen de tu dispositivo" line is gone
+  (already covered by the hero subtitle and the marquee), and the
+  funding status reads humbler: "Updates ship while resources allow
+  \u2014 {runtime} of runway at {burn}" instead of the previous
+  "Ships only while the budget holds. Currently funded for…" doom
+  framing. Translations updated in all six locales.
+
 ## [2.9.1] — 2026-04-27
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 > Nuke backgrounds from any image. 100% client-side. Zero uploads. Zero BS.
 
-[![Version](https://img.shields.io/badge/version-2.9.1-brightgreen.svg)](https://github.com/yocreoquesi/nukebg/releases)
+[![Version](https://img.shields.io/badge/version-2.9.2-brightgreen.svg)](https://github.com/yocreoquesi/nukebg/releases)
 [![License: GPL-3.0](https://img.shields.io/badge/License-GPL%20v3-blue.svg)](https://www.gnu.org/licenses/gpl-3.0)
 [![Client-Side](https://img.shields.io/badge/Processing-100%25%20Client--Side-green.svg)](#-privacy)
 

--- a/index.html
+++ b/index.html
@@ -151,7 +151,7 @@
           "PNG export with true alpha transparency"
         ],
         "screenshot": "https://nukebg.app/og-image.png",
-        "softwareVersion": "2.9.1",
+        "softwareVersion": "2.9.2",
         "license": "https://www.gnu.org/licenses/gpl-3.0.html",
         "isAccessibleForFree": true,
         "creator": {
@@ -483,7 +483,7 @@
     <ar-post-cta id="post-cta"></ar-post-cta>
 
     <footer class="footer hazard-border-top" role="contentinfo">
-      <span>NukeBG <span style="color: var(--color-text-tertiary)">v2.9.1</span></span>
+      <span>NukeBG <span style="color: var(--color-text-tertiary)">v2.9.2</span></span>
       <span class="footer-sep">|</span>
       <span>GPL-3.0</span>
       <span class="footer-sep">|</span>
@@ -560,11 +560,8 @@
           title="Yellow"
         ></button>
       </div>
-      <span class="footer-privacy" id="footer-privacy"
-        >Your images never leave your device. Zero uploads. Zero BS.</span
-      >
       <span class="footer-reactor-status" id="footer-reactor-status"
-        >Ships only while the budget holds (€91/mo). Currently funded for 0 months.</span
+        >Ships will keep coming as long as resources allow. 0 months of runway at €91/mo.</span
       >
       <span class="footer-holiday" id="footer-holiday"></span>
     </footer>

--- a/infra/nginx.conf
+++ b/infra/nginx.conf
@@ -31,7 +31,7 @@ server {
     #   new Function() WASM bootstrap.
     # - sha256 hashes cover the 3 inline JSON-LD blocks in index.html.
     #   Regenerate with `node scripts/compute-csp-hashes.mjs` after edits.
-    add_header Content-Security-Policy "default-src 'self'; script-src 'self' blob: 'wasm-unsafe-eval' 'unsafe-eval' 'sha256-mIcEwWjsYk3dAQWKxztVzouiBQRsPqCJ6MztRt86+gg=' 'sha256-uZm4Xh9FxR3B7WjPHL5pbehtSMYTCy9JWzQzl3/UKA0=' 'sha256-o1DLxvGFHY9H1AG6Sro58slSTxU3T7zb020gfyqbFwM=' https://cdn.jsdelivr.net; worker-src 'self' blob:; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; connect-src 'self' https://huggingface.co https://cdn-lfs.huggingface.co https://cdn-lfs-us-1.huggingface.co https://cdn.jsdelivr.net https://cas-bridge.xethub.hf.co; font-src 'self'; object-src 'none'; base-uri 'self'; form-action 'none'" always;
+    add_header Content-Security-Policy "default-src 'self'; script-src 'self' blob: 'wasm-unsafe-eval' 'unsafe-eval' 'sha256-AkZw589HA0bIkavV03HKAnK0j7ro8iTj2aXirr7E+aI=' 'sha256-uZm4Xh9FxR3B7WjPHL5pbehtSMYTCy9JWzQzl3/UKA0=' 'sha256-o1DLxvGFHY9H1AG6Sro58slSTxU3T7zb020gfyqbFwM=' https://cdn.jsdelivr.net; worker-src 'self' blob:; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; connect-src 'self' https://huggingface.co https://cdn-lfs.huggingface.co https://cdn-lfs-us-1.huggingface.co https://cdn.jsdelivr.net https://cas-bridge.xethub.hf.co; font-src 'self'; object-src 'none'; base-uri 'self'; form-action 'none'" always;
 
     # Cache static assets
     # Note: add_header in location blocks replaces parent headers in nginx,
@@ -46,7 +46,7 @@ server {
         add_header Strict-Transport-Security "max-age=63072000; includeSubDomains; preload" always;
         add_header Cross-Origin-Opener-Policy "same-origin" always;
         add_header X-DNS-Prefetch-Control "off" always;
-        add_header Content-Security-Policy "default-src 'self'; script-src 'self' blob: 'wasm-unsafe-eval' 'unsafe-eval' 'sha256-mIcEwWjsYk3dAQWKxztVzouiBQRsPqCJ6MztRt86+gg=' 'sha256-uZm4Xh9FxR3B7WjPHL5pbehtSMYTCy9JWzQzl3/UKA0=' 'sha256-o1DLxvGFHY9H1AG6Sro58slSTxU3T7zb020gfyqbFwM=' https://cdn.jsdelivr.net; worker-src 'self' blob:; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; connect-src 'self' https://huggingface.co https://cdn-lfs.huggingface.co https://cdn-lfs-us-1.huggingface.co https://cdn.jsdelivr.net https://cas-bridge.xethub.hf.co; font-src 'self'; object-src 'none'; base-uri 'self'; form-action 'none'" always;
+        add_header Content-Security-Policy "default-src 'self'; script-src 'self' blob: 'wasm-unsafe-eval' 'unsafe-eval' 'sha256-AkZw589HA0bIkavV03HKAnK0j7ro8iTj2aXirr7E+aI=' 'sha256-uZm4Xh9FxR3B7WjPHL5pbehtSMYTCy9JWzQzl3/UKA0=' 'sha256-o1DLxvGFHY9H1AG6Sro58slSTxU3T7zb020gfyqbFwM=' https://cdn.jsdelivr.net; worker-src 'self' blob:; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; connect-src 'self' https://huggingface.co https://cdn-lfs.huggingface.co https://cdn-lfs-us-1.huggingface.co https://cdn.jsdelivr.net https://cas-bridge.xethub.hf.co; font-src 'self'; object-src 'none'; base-uri 'self'; form-action 'none'" always;
     }
 
     # ONNX model files — cache aggressively, same-origin so CORP is fine
@@ -60,7 +60,7 @@ server {
         add_header Strict-Transport-Security "max-age=63072000; includeSubDomains; preload" always;
         add_header Cross-Origin-Opener-Policy "same-origin" always;
         add_header X-DNS-Prefetch-Control "off" always;
-        add_header Content-Security-Policy "default-src 'self'; script-src 'self' blob: 'wasm-unsafe-eval' 'unsafe-eval' 'sha256-mIcEwWjsYk3dAQWKxztVzouiBQRsPqCJ6MztRt86+gg=' 'sha256-uZm4Xh9FxR3B7WjPHL5pbehtSMYTCy9JWzQzl3/UKA0=' 'sha256-o1DLxvGFHY9H1AG6Sro58slSTxU3T7zb020gfyqbFwM=' https://cdn.jsdelivr.net; worker-src 'self' blob:; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; connect-src 'self' https://huggingface.co https://cdn-lfs.huggingface.co https://cdn-lfs-us-1.huggingface.co https://cdn.jsdelivr.net https://cas-bridge.xethub.hf.co; font-src 'self'; object-src 'none'; base-uri 'self'; form-action 'none'" always;
+        add_header Content-Security-Policy "default-src 'self'; script-src 'self' blob: 'wasm-unsafe-eval' 'unsafe-eval' 'sha256-AkZw589HA0bIkavV03HKAnK0j7ro8iTj2aXirr7E+aI=' 'sha256-uZm4Xh9FxR3B7WjPHL5pbehtSMYTCy9JWzQzl3/UKA0=' 'sha256-o1DLxvGFHY9H1AG6Sro58slSTxU3T7zb020gfyqbFwM=' https://cdn.jsdelivr.net; worker-src 'self' blob:; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; connect-src 'self' https://huggingface.co https://cdn-lfs.huggingface.co https://cdn-lfs-us-1.huggingface.co https://cdn.jsdelivr.net https://cas-bridge.xethub.hf.co; font-src 'self'; object-src 'none'; base-uri 'self'; form-action 'none'" always;
     }
 
     # SPA fallback

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "nukebg",
-  "version": "2.9.1",
+  "version": "2.9.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "nukebg",
-      "version": "2.9.1",
+      "version": "2.9.2",
       "license": "GPL-3.0",
       "dependencies": {
         "@huggingface/transformers": "^3.8.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "nukebg",
   "private": true,
-  "version": "2.9.1",
+  "version": "2.9.2",
   "type": "module",
   "description": "NukeBG: Nuke AI backgrounds, checkerboard patterns, and watermarks. 100% client-side. Zero uploads. Zero BS.",
   "license": "GPL-3.0-only",

--- a/public/_headers
+++ b/public/_headers
@@ -7,7 +7,7 @@
   Cross-Origin-Resource-Policy: same-origin
   X-DNS-Prefetch-Control: off
   Strict-Transport-Security: max-age=63072000; includeSubDomains; preload
-  Content-Security-Policy: default-src 'self'; script-src 'self' blob: 'wasm-unsafe-eval' 'unsafe-eval' 'sha256-mIcEwWjsYk3dAQWKxztVzouiBQRsPqCJ6MztRt86+gg=' 'sha256-uZm4Xh9FxR3B7WjPHL5pbehtSMYTCy9JWzQzl3/UKA0=' 'sha256-o1DLxvGFHY9H1AG6Sro58slSTxU3T7zb020gfyqbFwM=' https://cdn.jsdelivr.net; worker-src 'self' blob:; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; connect-src 'self' https://huggingface.co https://cdn-lfs.huggingface.co https://cdn-lfs-us-1.huggingface.co https://cdn.jsdelivr.net https://cas-bridge.xethub.hf.co; font-src 'self'; object-src 'none'; base-uri 'self'; form-action 'none'
+  Content-Security-Policy: default-src 'self'; script-src 'self' blob: 'wasm-unsafe-eval' 'unsafe-eval' 'sha256-AkZw589HA0bIkavV03HKAnK0j7ro8iTj2aXirr7E+aI=' 'sha256-uZm4Xh9FxR3B7WjPHL5pbehtSMYTCy9JWzQzl3/UKA0=' 'sha256-o1DLxvGFHY9H1AG6Sro58slSTxU3T7zb020gfyqbFwM=' https://cdn.jsdelivr.net; worker-src 'self' blob:; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; connect-src 'self' https://huggingface.co https://cdn-lfs.huggingface.co https://cdn-lfs-us-1.huggingface.co https://cdn.jsdelivr.net https://cas-bridge.xethub.hf.co; font-src 'self'; object-src 'none'; base-uri 'self'; form-action 'none'
 
 /assets/*
   Cache-Control: public, max-age=31536000, immutable

--- a/src/i18n/index.ts
+++ b/src/i18n/index.ts
@@ -189,7 +189,7 @@ const translations: Translations = {
     // Header / Footer (index.html)
     'header.skipLink': 'Skip to main content',
     'footer.reactorLinkAria': 'View project costs and runtime \u2014 currently funded for {runtime}',
-    'footer.reactorStatus': 'Ships only while the budget holds ({burn}). Currently funded for {runtime}.',
+    'footer.reactorStatus': 'Updates ship while resources allow \u2014 {runtime} of runway at {burn}.',
     'marquee.funding': 'development funded for {runtime} \u2014 tip to extend runway',
     'cta.firstStar.text': '$ if this saved you 5 minutes, drop a star on the repo',
     'cta.firstStar.cta': 'star on github',
@@ -233,7 +233,6 @@ const translations: Translations = {
     'reactor.removalNotice': 'If you appear on this page and want to be removed, email yocreoquesi at gmail dot com — done within 7 days, no questions.',
     'reactor.noSupportersYet': 'No supporters yet — code shipping is currently funded by the maintainer pocket. Tip below to extend the runway.',
     'reactor.anonymousLine': '+ {count} anonymous supporters ({total} combined)',
-    'footer.privacy': 'Your images never leave your device. Zero uploads. Zero BS.',
 
     // Pipeline error
     'pipeline.error': 'Processing failed: {msg}',
@@ -454,7 +453,7 @@ const translations: Translations = {
     // Header / Footer (index.html)
     'header.skipLink': 'Saltar al contenido principal',
     'footer.reactorLinkAria': 'Ver costes del proyecto y runtime \u2014 ahora financiado para {runtime}',
-    'footer.reactorStatus': 'Solo se actualiza mientras dure el presupuesto ({burn}). Ahora financiado para {runtime}.',
+    'footer.reactorStatus': 'Las actualizaciones llegan mientras los recursos lo permitan \u2014 {runtime} de margen a {burn}.',
     'marquee.funding': 'desarrollo financiado por {runtime} \u2014 alimenta el reactor',
     'cta.firstStar.text': '$ si te ahorró 5 minutos, deja una estrella en el repo',
     'cta.firstStar.cta': 'estrella en github',
@@ -498,7 +497,6 @@ const translations: Translations = {
     'reactor.removalNotice': 'Si apareces en esta página y quieres que te quitemos, manda un correo a yocreoquesi arroba gmail punto com — resuelto en 7 días, sin preguntas.',
     'reactor.noSupportersYet': 'Sin supporters todavía — el shipeo de código está financiado actualmente por el bolsillo del maintainer. Alimenta abajo para extender el runway.',
     'reactor.anonymousLine': '+ {count} supporters anónimos ({total} combinados)',
-    'footer.privacy': 'Tus im\u00E1genes nunca salen de tu dispositivo. Cero subidas. Cero complicaciones.',
 
     // Pipeline error
     'pipeline.error': 'Procesamiento fallido: {msg}',
@@ -719,7 +717,7 @@ const translations: Translations = {
     // Header / Footer (index.html)
     'header.skipLink': 'Aller au contenu principal',
     'footer.reactorLinkAria': 'Voir les co\u00FBts du projet et le runtime \u2014 actuellement financ\u00E9 pour {runtime}',
-    'footer.reactorStatus': 'Mises \u00E0 jour tant que le budget tient ({burn}). Actuellement financ\u00E9 pour {runtime}.',
+    'footer.reactorStatus': 'Les mises \u00E0 jour arrivent tant que les ressources le permettent \u2014 {runtime} d\u2019autonomie \u00E0 {burn}.',
     'marquee.funding': 'd\u00E9veloppement financ\u00E9 pour {runtime} \u2014 soutiens pour prolonger',
     'cta.firstStar.text': '$ si ça t a fait gagner 5 minutes, laisse une étoile sur le repo',
     'cta.firstStar.cta': 'étoile sur github',
@@ -763,7 +761,6 @@ const translations: Translations = {
     'reactor.removalNotice': 'Si tu apparais sur cette page et veux être retiré, envoie un email à yocreoquesi arobase gmail point com — fait sous 7 jours, sans questions.',
     'reactor.noSupportersYet': 'Pas encore de supporters — le shipping de code est actuellement financé par les fonds personnels du maintainer. Alimente en dessous pour étendre le runway.',
     'reactor.anonymousLine': '+ {count} supporters anonymes ({total} cumulé)',
-    'footer.privacy': 'Tes images ne quittent jamais ton appareil. Z\u00E9ro upload. Z\u00E9ro baratin.',
 
     // Pipeline error
     'pipeline.error': 'Traitement \u00E9chou\u00E9 : {msg}',
@@ -984,7 +981,7 @@ const translations: Translations = {
     // Header / Footer (index.html)
     'header.skipLink': 'Zum Hauptinhalt springen',
     'footer.reactorLinkAria': 'Projektkosten und Laufzeit ansehen \u2014 derzeit finanziert f\u00FCr {runtime}',
-    'footer.reactorStatus': 'Wird nur ausgeliefert, solange das Budget reicht ({burn}). Derzeit finanziert f\u00FCr {runtime}.',
+    'footer.reactorStatus': 'Updates kommen, solange die Mittel reichen \u2014 {runtime} Reichweite bei {burn}.',
     'marquee.funding': 'Entwicklung finanziert f\u00FCr {runtime} \u2014 spende, um zu verl\u00E4ngern',
     'cta.firstStar.text': '$ wenn das 5 Minuten gespart hat, gib einen Stern auf dem Repo',
     'cta.firstStar.cta': 'Stern auf GitHub',
@@ -1028,7 +1025,6 @@ const translations: Translations = {
     'reactor.removalNotice': 'Wenn Sie auf dieser Seite erscheinen und entfernt werden möchten, mailen Sie an yocreoquesi at gmail dot com — innerhalb 7 Tagen erledigt, keine Fragen.',
     'reactor.noSupportersYet': 'Noch keine Supporter — Code-Shipping wird aktuell aus eigener Tasche des Maintainers finanziert. Speisen Sie unten, um das Runway zu verlängern.',
     'reactor.anonymousLine': '+ {count} anonyme Supporter ({total} kombiniert)',
-    'footer.privacy': 'Deine Bilder verlassen nie dein Ger\u00E4t. Null Uploads. Null Bullshit.',
 
     // Pipeline error
     'pipeline.error': 'Verarbeitung fehlgeschlagen: {msg}',
@@ -1249,7 +1245,7 @@ const translations: Translations = {
     // Header / Footer (index.html)
     'header.skipLink': 'Pular para o conte\u00FAdo principal',
     'footer.reactorLinkAria': 'Ver custos do projeto e runtime \u2014 atualmente financiado por {runtime}',
-    'footer.reactorStatus': 'S\u00F3 atualiza enquanto o or\u00E7amento durar ({burn}). Atualmente financiado por {runtime}.',
+    'footer.reactorStatus': 'Atualiza\u00E7\u00F5es chegam enquanto os recursos permitirem \u2014 {runtime} de margem a {burn}.',
     'marquee.funding': 'desenvolvimento financiado por {runtime} \u2014 apoia para estender',
     'cta.firstStar.text': '$ se te poupou 5 minutos, deixa uma estrela no repo',
     'cta.firstStar.cta': 'estrela no github',
@@ -1293,7 +1289,6 @@ const translations: Translations = {
     'reactor.removalNotice': 'Se você aparece nesta página e quer ser removido, envie email para yocreoquesi arroba gmail ponto com — feito em 7 dias, sem perguntas.',
     'reactor.noSupportersYet': 'Sem supporters ainda — o shipping de código está financiado pelo bolso do maintainer. Alimente abaixo para estender o runway.',
     'reactor.anonymousLine': '+ {count} supporters anônimos ({total} combinado)',
-    'footer.privacy': 'Suas imagens nunca saem do seu dispositivo. Zero uploads. Zero enrola\u00E7\u00E3o.',
 
     // Pipeline error
     'pipeline.error': 'Processamento falhou: {msg}',
@@ -1514,7 +1509,7 @@ const translations: Translations = {
     // Header / Footer (index.html)
     'header.skipLink': '\u8DF3\u8F6C\u5230\u4E3B\u8981\u5185\u5BB9',
     'footer.reactorLinkAria': '\u67E5\u770B\u9879\u76EE\u6210\u672C\u4E0E\u8FD0\u884C\u65F6\u95F4 \u2014 \u76EE\u524D\u53EF\u7EF4\u6301 {runtime}',
-    'footer.reactorStatus': '\u4EC5\u5728\u9884\u7B97\u5141\u8BB8\u65F6\u66F4\u65B0\uFF08{burn}\uFF09\u3002\u76EE\u524D\u53EF\u7EF4\u6301 {runtime}\u3002',
+    'footer.reactorStatus': '\u8D44\u6E90\u5141\u8BB8\u65F6\u6301\u7EED\u63A8\u9001\u66F4\u65B0 \u2014 {burn} \u4E0B\u8FD8\u53EF\u7EF4\u6301 {runtime}\u3002',
     'marquee.funding': '\u5F00\u53D1\u8D44\u91D1\u53EF\u7EF4\u6301 {runtime} \u2014 \u8D5E\u52A9\u4EE5\u5EF6\u957F',
     'cta.firstStar.text': '$ \u5982\u679C\u7701\u4E86\u4F60 5 \u5206\u949F, \u8BF7\u5728\u4ED3\u5E93\u70B9\u4E2A star',
     'cta.firstStar.cta': 'github star',
@@ -1558,7 +1553,6 @@ const translations: Translations = {
     'reactor.removalNotice': '\u5982\u679C\u60A8\u51FA\u73B0\u5728\u6B64\u9875\u9762\u5E76\u5E0C\u671B\u88AB\u79FB\u9664, \u8BF7\u53D1\u9001\u90AE\u4EF6\u81F3 yocreoquesi at gmail dot com \u2014 7 \u5929\u5185\u5904\u7406, \u4E0D\u95EE\u95EE\u9898\u3002',
     'reactor.noSupportersYet': '\u8FD8\u6CA1\u6709\u652F\u6301\u8005 \u2014 \u4EE3\u7801\u53D1\u5E03\u76EE\u524D\u7531\u7EF4\u62A4\u8005\u81EA\u638F\u8170\u5305\u8D44\u52A9\u3002\u5728\u4E0B\u9762\u8D44\u52A9\u4EE5\u5EF6\u957F\u8FD0\u884C\u65F6\u95F4\u3002',
     'reactor.anonymousLine': '+ {count} \u4F4D\u533F\u540D\u652F\u6301\u8005 (\u5408\u8BA1 {total})',
-    'footer.privacy': '\u4F60\u7684\u56FE\u7247\u6C38\u8FDC\u4E0D\u4F1A\u79BB\u5F00\u4F60\u7684\u8BBE\u5907\u3002\u96F6\u4E0A\u4F20\u3002\u4E0D\u6574\u865A\u7684\u3002',
 
     // Pipeline error
     'pipeline.error': '\u5904\u7406\u5931\u8D25: {msg}',

--- a/src/main.ts
+++ b/src/main.ts
@@ -161,7 +161,7 @@ function createShortcutOverlay(): HTMLDivElement {
 function showConsoleLogo(): void {
   const logo = `
 %c    ☢ NUKEBG ☢
-    v2.9.1 | Terminal Edition
+    v2.9.2 | Terminal Edition
 
     Your images never leave this machine.
     Don't believe us? Read the source:
@@ -635,8 +635,6 @@ function initI18n(): void {
 function updateHtmlTexts(): void {
   const skipLink = document.getElementById('skip-link');
   if (skipLink) skipLink.textContent = t('header.skipLink');
-  const footerPrivacy = document.getElementById('footer-privacy');
-  if (footerPrivacy) footerPrivacy.textContent = t('footer.privacy');
 }
 
 // === Terminal Prompt Easter Egg ===

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -639,12 +639,6 @@ body::after {
   }
 }
 
-.footer-privacy {
-  display: block;
-  margin-top: var(--space-3);
-  font-size: var(--text-sm);
-}
-
 .footer-holiday {
   display: block;
   margin-top: var(--space-2);
@@ -864,11 +858,6 @@ body::after {
   }
   .footer-sep {
     margin: 0 var(--space-1);
-  }
-  .footer-privacy {
-    /* #149 — already shown in marquee + hero subtitle on mobile;
-       repeating it in the footer is just clutter on a narrow viewport */
-    display: none;
   }
   .footer-reactor-status {
     font-size: var(--text-xs);

--- a/src/utils/image-io.ts
+++ b/src/utils/image-io.ts
@@ -168,7 +168,7 @@ export async function exportPng(imageData: ImageData): Promise<Blob> {
     });
   }
   return injectPngMetadata(rawBlob, {
-    Software: 'NukeBG v2.9.1',
+    Software: 'NukeBG v2.9.2',
     Source: 'https://nukebg.app',
   });
 }


### PR DESCRIPTION
Merges \`dev\` into \`main\` to ship **v2.9.2**.

- #175 — slim footer + humbler funding tone (drop redundant privacy line, rewrite reactor-status copy)

Merge commit (not squash) to preserve per-PR history.

See [CHANGELOG → 2.9.2](https://github.com/yocreoquesi/nukebg/blob/dev/CHANGELOG.md#292--2026-04-27) for full notes.