### PR TITLE
release: v2.9.3 — fix marquee overlap + footer status on its own line

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,24 @@ Unreleased entries accumulate on the `dev` branch. When we cut a release we copy
 
 ## [Unreleased]
 
+## [2.9.3] — 2026-04-27
+
+### Fixed
+
+- **Top marquee no longer overlaps itself**. The marquee text was
+  declared twice inside one `<span>` and animated from `100% \u2192 -100%`,
+  so on wide viewports the two halves visibly overlapped (and the
+  privacy line was only present in the first half — inconsistent).
+  Switched to the standard seamless-marquee pattern: two `marquee-half`
+  children animating `0 \u2192 -50%` so when one half scrolls off the left,
+  the second half sits exactly where it started. One continuous
+  message, no doubled overlap. Removed the redundant "Your images
+  never leave your device" segment along the way.
+- **Footer reactor-status sits on its own line at the bottom** now,
+  instead of wrapping into the row with the version / GitHub /
+  reactor link / theme picker. `display: block; width: 100%;` on
+  `.footer-reactor-status` forces the line break.
+
 ## [2.9.2] — 2026-04-27
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 > Nuke backgrounds from any image. 100% client-side. Zero uploads. Zero BS.
 
-[![Version](https://img.shields.io/badge/version-2.9.2-brightgreen.svg)](https://github.com/yocreoquesi/nukebg/releases)
+[![Version](https://img.shields.io/badge/version-2.9.3-brightgreen.svg)](https://github.com/yocreoquesi/nukebg/releases)
 [![License: GPL-3.0](https://img.shields.io/badge/License-GPL%20v3-blue.svg)](https://www.gnu.org/licenses/gpl-3.0)
 [![Client-Side](https://img.shields.io/badge/Processing-100%25%20Client--Side-green.svg)](#-privacy)
 

--- a/index.html
+++ b/index.html
@@ -151,7 +151,7 @@
           "PNG export with true alpha transparency"
         ],
         "screenshot": "https://nukebg.app/og-image.png",
-        "softwareVersion": "2.9.2",
+        "softwareVersion": "2.9.3",
         "license": "https://www.gnu.org/licenses/gpl-3.0.html",
         "isAccessibleForFree": true,
         "creator": {
@@ -483,7 +483,7 @@
     <ar-post-cta id="post-cta"></ar-post-cta>
 
     <footer class="footer hazard-border-top" role="contentinfo">
-      <span>NukeBG <span style="color: var(--color-text-tertiary)">v2.9.2</span></span>
+      <span>NukeBG <span style="color: var(--color-text-tertiary)">v2.9.3</span></span>
       <span class="footer-sep">|</span>
       <span>GPL-3.0</span>
       <span class="footer-sep">|</span>

--- a/infra/nginx.conf
+++ b/infra/nginx.conf
@@ -31,7 +31,7 @@ server {
     #   new Function() WASM bootstrap.
     # - sha256 hashes cover the 3 inline JSON-LD blocks in index.html.
     #   Regenerate with `node scripts/compute-csp-hashes.mjs` after edits.
-    add_header Content-Security-Policy "default-src 'self'; script-src 'self' blob: 'wasm-unsafe-eval' 'unsafe-eval' 'sha256-AkZw589HA0bIkavV03HKAnK0j7ro8iTj2aXirr7E+aI=' 'sha256-uZm4Xh9FxR3B7WjPHL5pbehtSMYTCy9JWzQzl3/UKA0=' 'sha256-o1DLxvGFHY9H1AG6Sro58slSTxU3T7zb020gfyqbFwM=' https://cdn.jsdelivr.net; worker-src 'self' blob:; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; connect-src 'self' https://huggingface.co https://cdn-lfs.huggingface.co https://cdn-lfs-us-1.huggingface.co https://cdn.jsdelivr.net https://cas-bridge.xethub.hf.co; font-src 'self'; object-src 'none'; base-uri 'self'; form-action 'none'" always;
+    add_header Content-Security-Policy "default-src 'self'; script-src 'self' blob: 'wasm-unsafe-eval' 'unsafe-eval' 'sha256-VNNR/gYXuX5FMhOTNNudFPbc42ZcgMo6dqMSzcd+M6U=' 'sha256-uZm4Xh9FxR3B7WjPHL5pbehtSMYTCy9JWzQzl3/UKA0=' 'sha256-o1DLxvGFHY9H1AG6Sro58slSTxU3T7zb020gfyqbFwM=' https://cdn.jsdelivr.net; worker-src 'self' blob:; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; connect-src 'self' https://huggingface.co https://cdn-lfs.huggingface.co https://cdn-lfs-us-1.huggingface.co https://cdn.jsdelivr.net https://cas-bridge.xethub.hf.co; font-src 'self'; object-src 'none'; base-uri 'self'; form-action 'none'" always;
 
     # Cache static assets
     # Note: add_header in location blocks replaces parent headers in nginx,
@@ -46,7 +46,7 @@ server {
         add_header Strict-Transport-Security "max-age=63072000; includeSubDomains; preload" always;
         add_header Cross-Origin-Opener-Policy "same-origin" always;
         add_header X-DNS-Prefetch-Control "off" always;
-        add_header Content-Security-Policy "default-src 'self'; script-src 'self' blob: 'wasm-unsafe-eval' 'unsafe-eval' 'sha256-AkZw589HA0bIkavV03HKAnK0j7ro8iTj2aXirr7E+aI=' 'sha256-uZm4Xh9FxR3B7WjPHL5pbehtSMYTCy9JWzQzl3/UKA0=' 'sha256-o1DLxvGFHY9H1AG6Sro58slSTxU3T7zb020gfyqbFwM=' https://cdn.jsdelivr.net; worker-src 'self' blob:; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; connect-src 'self' https://huggingface.co https://cdn-lfs.huggingface.co https://cdn-lfs-us-1.huggingface.co https://cdn.jsdelivr.net https://cas-bridge.xethub.hf.co; font-src 'self'; object-src 'none'; base-uri 'self'; form-action 'none'" always;
+        add_header Content-Security-Policy "default-src 'self'; script-src 'self' blob: 'wasm-unsafe-eval' 'unsafe-eval' 'sha256-VNNR/gYXuX5FMhOTNNudFPbc42ZcgMo6dqMSzcd+M6U=' 'sha256-uZm4Xh9FxR3B7WjPHL5pbehtSMYTCy9JWzQzl3/UKA0=' 'sha256-o1DLxvGFHY9H1AG6Sro58slSTxU3T7zb020gfyqbFwM=' https://cdn.jsdelivr.net; worker-src 'self' blob:; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; connect-src 'self' https://huggingface.co https://cdn-lfs.huggingface.co https://cdn-lfs-us-1.huggingface.co https://cdn.jsdelivr.net https://cas-bridge.xethub.hf.co; font-src 'self'; object-src 'none'; base-uri 'self'; form-action 'none'" always;
     }
 
     # ONNX model files — cache aggressively, same-origin so CORP is fine
@@ -60,7 +60,7 @@ server {
         add_header Strict-Transport-Security "max-age=63072000; includeSubDomains; preload" always;
         add_header Cross-Origin-Opener-Policy "same-origin" always;
         add_header X-DNS-Prefetch-Control "off" always;
-        add_header Content-Security-Policy "default-src 'self'; script-src 'self' blob: 'wasm-unsafe-eval' 'unsafe-eval' 'sha256-AkZw589HA0bIkavV03HKAnK0j7ro8iTj2aXirr7E+aI=' 'sha256-uZm4Xh9FxR3B7WjPHL5pbehtSMYTCy9JWzQzl3/UKA0=' 'sha256-o1DLxvGFHY9H1AG6Sro58slSTxU3T7zb020gfyqbFwM=' https://cdn.jsdelivr.net; worker-src 'self' blob:; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; connect-src 'self' https://huggingface.co https://cdn-lfs.huggingface.co https://cdn-lfs-us-1.huggingface.co https://cdn.jsdelivr.net https://cas-bridge.xethub.hf.co; font-src 'self'; object-src 'none'; base-uri 'self'; form-action 'none'" always;
+        add_header Content-Security-Policy "default-src 'self'; script-src 'self' blob: 'wasm-unsafe-eval' 'unsafe-eval' 'sha256-VNNR/gYXuX5FMhOTNNudFPbc42ZcgMo6dqMSzcd+M6U=' 'sha256-uZm4Xh9FxR3B7WjPHL5pbehtSMYTCy9JWzQzl3/UKA0=' 'sha256-o1DLxvGFHY9H1AG6Sro58slSTxU3T7zb020gfyqbFwM=' https://cdn.jsdelivr.net; worker-src 'self' blob:; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; connect-src 'self' https://huggingface.co https://cdn-lfs.huggingface.co https://cdn-lfs-us-1.huggingface.co https://cdn.jsdelivr.net https://cas-bridge.xethub.hf.co; font-src 'self'; object-src 'none'; base-uri 'self'; form-action 'none'" always;
     }
 
     # SPA fallback

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "nukebg",
-  "version": "2.9.2",
+  "version": "2.9.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "nukebg",
-      "version": "2.9.2",
+      "version": "2.9.3",
       "license": "GPL-3.0",
       "dependencies": {
         "@huggingface/transformers": "^3.8.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "nukebg",
   "private": true,
-  "version": "2.9.2",
+  "version": "2.9.3",
   "type": "module",
   "description": "NukeBG: Nuke AI backgrounds, checkerboard patterns, and watermarks. 100% client-side. Zero uploads. Zero BS.",
   "license": "GPL-3.0-only",

--- a/public/_headers
+++ b/public/_headers
@@ -7,7 +7,7 @@
   Cross-Origin-Resource-Policy: same-origin
   X-DNS-Prefetch-Control: off
   Strict-Transport-Security: max-age=63072000; includeSubDomains; preload
-  Content-Security-Policy: default-src 'self'; script-src 'self' blob: 'wasm-unsafe-eval' 'unsafe-eval' 'sha256-AkZw589HA0bIkavV03HKAnK0j7ro8iTj2aXirr7E+aI=' 'sha256-uZm4Xh9FxR3B7WjPHL5pbehtSMYTCy9JWzQzl3/UKA0=' 'sha256-o1DLxvGFHY9H1AG6Sro58slSTxU3T7zb020gfyqbFwM=' https://cdn.jsdelivr.net; worker-src 'self' blob:; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; connect-src 'self' https://huggingface.co https://cdn-lfs.huggingface.co https://cdn-lfs-us-1.huggingface.co https://cdn.jsdelivr.net https://cas-bridge.xethub.hf.co; font-src 'self'; object-src 'none'; base-uri 'self'; form-action 'none'
+  Content-Security-Policy: default-src 'self'; script-src 'self' blob: 'wasm-unsafe-eval' 'unsafe-eval' 'sha256-VNNR/gYXuX5FMhOTNNudFPbc42ZcgMo6dqMSzcd+M6U=' 'sha256-uZm4Xh9FxR3B7WjPHL5pbehtSMYTCy9JWzQzl3/UKA0=' 'sha256-o1DLxvGFHY9H1AG6Sro58slSTxU3T7zb020gfyqbFwM=' https://cdn.jsdelivr.net; worker-src 'self' blob:; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; connect-src 'self' https://huggingface.co https://cdn-lfs.huggingface.co https://cdn-lfs-us-1.huggingface.co https://cdn.jsdelivr.net https://cas-bridge.xethub.hf.co; font-src 'self'; object-src 'none'; base-uri 'self'; form-action 'none'
 
 /assets/*
   Cache-Control: public, max-age=31536000, immutable

--- a/src/components/ar-app.ts
+++ b/src/components/ar-app.ts
@@ -457,9 +457,19 @@ export class ArApp extends HTMLElement {
           -webkit-mask-image: linear-gradient(90deg, transparent, #000 48px, #000 calc(100% - 48px), transparent);
                   mask-image: linear-gradient(90deg, transparent, #000 48px, #000 calc(100% - 48px), transparent);
         }
-        .marquee-bleed span {
-          display: inline-block;
-          animation: marquee-scroll 26s linear infinite;
+        .marquee-bleed > span {
+          display: inline-flex;
+          gap: 0;
+          animation: marquee-scroll 32s linear infinite;
+          will-change: transform;
+        }
+        /* Two identical halves animate from 0 to -50%; when the first
+           half scrolls off the left, the second half sits exactly where
+           the first started — seamless, single continuous message
+           (no doubled overlap on wide viewports). */
+        .marquee-bleed > span > span.marquee-half {
+          flex: 0 0 auto;
+          padding-right: 3em;
         }
         /* Consolidated [STATUS] line */
         .status-line {
@@ -561,11 +571,11 @@ export class ArApp extends HTMLElement {
           .status-details summary { min-height: 44px; padding: 10px 0; }
         }
         @keyframes marquee-scroll {
-          0% { transform: translateX(100%); }
-          100% { transform: translateX(-100%); }
+          0% { transform: translateX(0); }
+          100% { transform: translateX(-50%); }
         }
         @media (prefers-reduced-motion: reduce) {
-          .marquee-bleed span { animation: none; }
+          .marquee-bleed > span { animation: none; }
         }
 
         /* Smoke is rendered outside shadow DOM - see main thread */
@@ -923,7 +933,7 @@ export class ArApp extends HTMLElement {
       <!-- Full-bleed marquee outside the main column per design #69.
            Gradient mask fades text in/out at the edges so it never
            clips mid-word the way the old column-scoped marquee did. -->
-      <div class="marquee-bleed" id="precision-marquee-bleed"><span>☢ NUKEBG | DROP. NUKE. DOWNLOAD. | Your images never leave your device | <span data-marquee-runtime>development funded for 0 months — tip to extend runway</span> | nukebg.app ☢ NUKEBG | DROP. NUKE. DOWNLOAD. | <span data-marquee-runtime>development funded for 0 months — tip to extend runway</span> | nukebg.app ☢</span></div>
+      <div class="marquee-bleed" id="precision-marquee-bleed"><span><span class="marquee-half">☢ NUKEBG | DROP. NUKE. DOWNLOAD. | <span data-marquee-runtime>development funded for 0 months — tip to extend runway</span> | nukebg.app ☢</span><span class="marquee-half" aria-hidden="true">☢ NUKEBG | DROP. NUKE. DOWNLOAD. | <span data-marquee-runtime>development funded for 0 months — tip to extend runway</span> | nukebg.app ☢</span></span></div>
 
       <section class="hero" id="hero">
         <h1>

--- a/src/main.ts
+++ b/src/main.ts
@@ -161,7 +161,7 @@ function createShortcutOverlay(): HTMLDivElement {
 function showConsoleLogo(): void {
   const logo = `
 %c    ☢ NUKEBG ☢
-    v2.9.2 | Terminal Edition
+    v2.9.3 | Terminal Edition
 
     Your images never leave this machine.
     Don't believe us? Read the source:

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -639,6 +639,14 @@ body::after {
   }
 }
 
+.footer-reactor-status {
+  display: block;
+  width: 100%;
+  margin-top: var(--space-3);
+  font-size: var(--text-sm);
+  color: var(--color-text-tertiary);
+}
+
 .footer-holiday {
   display: block;
   margin-top: var(--space-2);

--- a/src/utils/image-io.ts
+++ b/src/utils/image-io.ts
@@ -168,7 +168,7 @@ export async function exportPng(imageData: ImageData): Promise<Blob> {
     });
   }
   return injectPngMetadata(rawBlob, {
-    Software: 'NukeBG v2.9.2',
+    Software: 'NukeBG v2.9.3',
     Source: 'https://nukebg.app',
   });
 }


### PR DESCRIPTION
Marquee no longer doubles itself on wide viewports; footer reactor-status drops to its own line. See [CHANGELOG → 2.9.3](https://github.com/yocreoquesi/nukebg/blob/fix/marquee-single-seamless/CHANGELOG.md#293--2026-04-27).