### PR TITLE
fix(theme): bump amber tertiary to #b06400 for WCAG AA pass on black

### DIFF
--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -153,7 +153,10 @@
 :root[data-theme='amber'] {
   --color-text-primary: #ff8c00;
   --color-text-secondary: #cc7000;
-  --color-text-tertiary: #995300;
+  /* Tertiary was #995300 (3.59:1 on black, fails WCAG AA). Bumped to
+     #b06400 (~4.67:1, AA pass) while keeping it dimmer than secondary
+     to preserve the primary > secondary > tertiary luminance ramp. */
+  --color-text-tertiary: #b06400;
   --color-accent-rgb: 255, 140, 0;
   --color-accent-primary: #ff8c00;
   --color-accent-hover: #ffaa33;

--- a/tests/color-consistency.test.ts
+++ b/tests/color-consistency.test.ts
@@ -46,6 +46,7 @@ const FORBIDDEN_HEX = [
   '#008830', // previous tertiary — keep blocked so it can't regress
   '#1a3a1a', // --color-surface-border
   '#ffd700', // old --color-accent (no longer exists)
+  '#995300', // amber tertiary previous (3.59:1 fail) — keep blocked
 ];
 
 // Allowed contexts where these hex values appear as CSS variable FALLBACKS


### PR DESCRIPTION
## Summary

Amber theme's `--color-text-tertiary` was `#995300` = **3.59:1** contrast against `#000`, failing WCAG AA (which needs 4.5:1 for normal text). Bumped to `#b06400` = **4.67:1** while keeping it dimmer than amber secondary (`#cc7000` = 5.89:1) so the `primary > secondary > tertiary` luminance ramp stays intact.

## Audit correction

Issue #185 originally claimed yellow tertiary and amber secondary also failed. Recomputation per WCAG 2.1 disagrees — both pass cleanly:

| Token | Hex | Ratio vs `#000` | AA |
|-------|-----|-----------------|----|
| yellow tertiary | `#998800` | 5.88:1 | ✅ |
| amber secondary | `#cc7000` | 5.89:1 | ✅ |
| amber tertiary | `#995300` | 3.59:1 | ❌ |

So this PR is a 1-line fix — only amber tertiary. The issue body has been updated to reflect this.

## Regression guard

Added `#995300` to `FORBIDDEN_HEX` in `tests/color-consistency.test.ts` so the old hex can't sneak back into any component CSS.

## Test plan

- [x] `npx vitest run tests/color-consistency.test.ts` — 137 tests pass.
- [ ] Switch the theme picker to **amber** in production build, verify timestamps / quiet labels are legible against `#000` and against `#0a0a0a` (bg-secondary).

Closes #185.