### PR TITLE
refactor(ar-app): extract batch queue into BatchOrchestrator (#47 Phase 1a)

### DIFF
--- a/src/components/ar-app.ts
+++ b/src/components/ar-app.ts
@@ -9,8 +9,10 @@ import type { ArDownload } from './ar-download';
 import type { ArEditor } from './ar-editor';
 import type { ArDropzone } from './ar-dropzone';
 import type { ArBatchGrid } from './ar-batch-grid';
-import type { BatchItem, StageSnapshot } from '../types/batch';
-import { createZip, safeZipEntryName, downloadBlob } from '../utils/zip';
+import {
+  BatchOrchestrator,
+  type BatchStageCallback,
+} from '../controllers/batch-orchestrator';
 import {
   refineEdges,
   dropOrphanBlobs,
@@ -46,13 +48,9 @@ export class ArApp extends HTMLElement {
   private boundPwaInstallableHandler: (() => void) | null = null;
   private abortController: AbortController | null = null;
   private batchGrid: ArBatchGrid | null = null;
-  private batchItems: BatchItem[] = [];
-  private batchMode: 'off' | 'grid' | 'detail' = 'off';
-  private batchDetailId: string | null = null;
-  private batchAborted = false;
-  /** Item currently being processed by the batch queue. The pipeline stage
-   * callback reads this to append snapshots to the right item's history. */
-  private batchCurrentProcessingItem: BatchItem | null = null;
+  /** Owns batch queue state + per-item processing loop. Wired up in
+   *  setupComponents() once UI refs are resolved. See #47/Phase-1. */
+  private batch!: BatchOrchestrator;
 
   constructor() {
     super();
@@ -1049,6 +1047,37 @@ export class ArApp extends HTMLElement {
     this.editor = this.shadowRoot!.querySelector('ar-editor')!;
     this.dropzone = this.shadowRoot!.querySelector('ar-dropzone')! as ArDropzone;
     this.batchGrid = this.shadowRoot!.querySelector('#batch-grid') as ArBatchGrid;
+
+    // Batch orchestrator owns queue state + per-item processing. Host
+    // (this component) keeps the pipeline + AbortController + thumbnail
+    // helper + UI swap, exposed through the BatchHost interface.
+    this.batch = new BatchOrchestrator(
+      {
+        viewer: this.viewer,
+        progress: this.progress,
+        download: this.download,
+        batchGrid: this.batchGrid,
+      },
+      {
+        installBatchStageCallback: (cb: BatchStageCallback) => {
+          if (!this.pipeline) {
+            this.pipeline = new PipelineOrchestrator(cb);
+          } else {
+            this.pipeline.setStageCallback(cb);
+          }
+          return this.pipeline;
+        },
+        setProcessingAbortController: (c) => {
+          this.processingAbortController = c;
+        },
+        makeThumbnail: (img, maxSide) => this.makeThumbnail(img, maxSide),
+        enterGridMode: () => this.setBatchUiMode('grid'),
+      },
+    );
+    // When an item finishes mid-processing AND the user is watching its
+    // detail view, re-render so they see the result/error without going
+    // back to the grid.
+    this.batch.setOnItemRefreshed((id) => this.openBatchDetail(id));
   }
 
   /** Actualiza textos sin re-renderizar todo el componente */
@@ -1164,8 +1193,8 @@ export class ArApp extends HTMLElement {
         if (this.processingAbortController && !this.processingAbortController.signal.aborted) {
           this.processingAbortController.abort('user cancelled');
         }
-        if (this.batchMode !== 'off') {
-          this.batchAborted = true;
+        if (this.batch.isInBatchMode()) {
+          this.batch.abort();
         }
       },
       { signal },
@@ -1320,7 +1349,7 @@ export class ArApp extends HTMLElement {
           this.isProcessing = false;
           this.enableWorkspaceButtons();
         }
-        await this.startBatch(detail.images);
+        await this.batch.start(detail.images);
       },
       { signal },
     );
@@ -1337,7 +1366,7 @@ export class ArApp extends HTMLElement {
     this.shadowRoot!.addEventListener(
       'batch:download-zip',
       async () => {
-        await this.downloadBatchZip();
+        await this.batch.downloadZip();
       },
       { signal },
     );
@@ -1847,145 +1876,13 @@ export class ArApp extends HTMLElement {
       single.style.display = 'flex';
       detailBar.style.display = 'flex';
     }
-    this.batchMode = mode;
-  }
-
-  private async startBatch(
-    images: Array<{
-      file: File;
-      imageData: ImageData;
-      originalImageData: ImageData;
-      originalWidth: number;
-      originalHeight: number;
-      wasDownsampled: boolean;
-    }>,
-  ): Promise<void> {
-    this.batchAborted = false;
-    this.batchItems = images.map((img, i) => ({
-      id: `batch-${Date.now()}-${i}`,
-      originalName: img.file.name || `image-${i + 1}.png`,
-      file: img.file,
-      imageData: img.imageData,
-      originalImageData: img.originalImageData ?? img.imageData,
-      state: 'pending',
-      result: null,
-      finalImageData: null,
-      thumbnailUrl: this.makeThumbnail(img.originalImageData ?? img.imageData),
-      stageHistory: [],
-    }));
-
-    // setBatchUiMode handles hero/workspace/dropzone visibility for grid mode.
-    this.setBatchUiMode('grid');
-
-    if (this.batchGrid) {
-      this.batchGrid.setItems(this.batchItems);
-      this.batchGrid.setCurrentIndex(0);
-    }
-
-    // Stage callback: drives the live progress console AND records the
-    // event into the item being processed so we can replay the exact
-    // sequence (running → done / skipped / error) if the user reopens
-    // that item's detail later.
-    const batchStageCallback = (
-      stage: PipelineStage,
-      status: StageStatus,
-      message?: string,
-    ): void => {
-      this.progress.setStage(stage, status, message);
-      const current = this.batchCurrentProcessingItem;
-      if (current) current.stageHistory.push({ stage, status, message });
-    };
-
-    if (!this.pipeline) {
-      this.pipeline = new PipelineOrchestrator(batchStageCallback);
-    } else {
-      this.pipeline.setStageCallback(batchStageCallback);
-    }
-
-    await this.runBatchQueue();
-  }
-
-  private async runBatchQueue(): Promise<void> {
-    for (let i = 0; i < this.batchItems.length; i++) {
-      if (this.batchAborted) return;
-      const item = this.batchItems[i];
-      if (item.state === 'done' || item.state === 'discarded') continue;
-      if (this.batchGrid) this.batchGrid.setCurrentIndex(i);
-      item.state = 'processing';
-      // Fresh slate for this item: empty history, empty live console.
-      item.stageHistory = [];
-      this.progress.reset();
-      this.progress.setRunning(true);
-      this.batchCurrentProcessingItem = item;
-      if (this.batchGrid) this.batchGrid.updateItem(item.id, 'processing');
-      // One signal per batch item so cancelling the batch aborts the
-      // in-flight one promptly without waiting for the current stage.
-      this.processingAbortController = new AbortController();
-      try {
-        const result = await this.pipeline!.process(
-          item.imageData,
-          ArApp.MODEL_ID,
-          'high-power',
-          this.processingAbortController.signal,
-        );
-        if (this.batchAborted) return;
-        const composed = composeAtOriginal({
-          originalRgba: item.originalImageData.data,
-          originalWidth: item.originalImageData.width,
-          originalHeight: item.originalImageData.height,
-          workingRgba: result.workingPixels,
-          workingWidth: result.workingWidth,
-          workingHeight: result.workingHeight,
-          workingAlpha: result.workingAlpha,
-          inpaintMask: result.watermarkMask,
-        });
-        const finalImageData =
-          result.contentType === 'PHOTO' || result.contentType === 'ILLUSTRATION'
-            ? promoteSpeckleAlpha(fillSubjectHoles(dropOrphanBlobs(composed)))
-            : composed;
-        item.result = result;
-        item.finalImageData = finalImageData;
-        item.thumbnailUrl = this.makeThumbnail(finalImageData);
-        item.state = 'done';
-        if (this.batchGrid) this.batchGrid.updateItem(item.id, 'done', item.thumbnailUrl);
-        // If the user is currently watching this item's live detail view,
-        // swap it to the done view so they see the result without going back.
-        if (this.batchDetailId === item.id) {
-          await this.openBatchDetail(item.id);
-        }
-      } catch (err) {
-        // Abort during batch = user cancelled. Don't mark the item as
-        // failed; the outer batchAborted check will return on next tick.
-        if (err instanceof PipelineAbortError || this.batchAborted) {
-          this.progress.setRunning(false);
-          return;
-        }
-        item.errorMessage = err instanceof Error ? err.message : String(err);
-        item.state = 'failed';
-        if (this.batchGrid) this.batchGrid.updateItem(item.id, 'failed');
-        if (this.batchDetailId === item.id) {
-          await this.openBatchDetail(item.id);
-        }
-      }
-    }
-    this.progress.setRunning(false);
-    this.batchCurrentProcessingItem = null;
-  }
-
-  /** Replay a finished item's captured stage events into the shared
-   * progress console. Resets first so no stale state from the previous
-   * item leaks through, then reapplies each snapshot in order. */
-  private replayStageHistory(history: StageSnapshot[]): void {
-    this.progress.reset();
-    for (const snap of history) {
-      this.progress.setStage(snap.stage, snap.status, snap.message);
-    }
+    this.batch.setMode(mode);
   }
 
   private async openBatchDetail(id: string): Promise<void> {
-    const item = this.batchItems.find((i) => i.id === id);
+    const item = this.batch.findItem(id);
     if (!item) return;
-    this.batchDetailId = id;
+    this.batch.setDetailId(id);
 
     const failedBar = this.shadowRoot!.querySelector('#batch-failed-bar') as HTMLElement;
     const retryBtn = this.shadowRoot!.querySelector('#batch-retry-btn') as HTMLElement;
@@ -2031,7 +1928,7 @@ export class ArApp extends HTMLElement {
       // Fallback for edge cases where nothing was captured: synthesize a
       // single error stage so the user still sees what went wrong.
       if (item.stageHistory.length > 0) {
-        this.replayStageHistory(item.stageHistory);
+        this.batch.replayStageHistory(item.stageHistory);
       } else {
         this.progress.reset();
         this.progress.setStage(
@@ -2066,7 +1963,7 @@ export class ArApp extends HTMLElement {
       // Replay per-item stage history so each finished image shows its own
       // icons (done/skipped) and timings — previously we just reset(),
       // which left every stage 'pending' and blanked out every icon.
-      this.replayStageHistory(item.stageHistory);
+      this.batch.replayStageHistory(item.stageHistory);
       this.download.reset();
       const finalImageData = item.finalImageData ?? item.result.imageData;
       const blob = await exportPng(finalImageData);
@@ -2087,7 +1984,7 @@ export class ArApp extends HTMLElement {
   }
 
   private closeBatchDetail(): void {
-    this.batchDetailId = null;
+    this.batch.setDetailId(null);
     this.preEditResult = null;
     this.cachedEditResult = null;
     this.lastResultImageData = null;
@@ -2104,37 +2001,17 @@ export class ArApp extends HTMLElement {
   }
 
   private async retryBatchItem(): Promise<void> {
-    if (!this.batchDetailId) return;
-    const item = this.batchItems.find((i) => i.id === this.batchDetailId);
-    if (!item) return;
-    item.state = 'pending';
-    item.errorMessage = undefined;
-    item.stageHistory = [];
-    if (this.batchGrid) this.batchGrid.updateItem(item.id, 'pending');
+    const id = this.batch.getDetailId();
+    if (!id) return;
     this.closeBatchDetail();
-    await this.runBatchQueue();
+    await this.batch.retry(id);
   }
 
   private discardBatchItem(): void {
-    if (!this.batchDetailId) return;
-    const item = this.batchItems.find((i) => i.id === this.batchDetailId);
-    if (!item) return;
-    item.state = 'discarded';
-    if (this.batchGrid) this.batchGrid.updateItem(item.id, 'discarded');
+    const id = this.batch.getDetailId();
+    if (!id) return;
+    this.batch.markDiscarded(id);
     this.closeBatchDetail();
-  }
-
-  private async downloadBatchZip(): Promise<void> {
-    const done = this.batchItems.filter((i) => i.state === 'done' && i.result);
-    if (done.length === 0) return;
-    const files = await Promise.all(
-      done.map(async (item, idx) => ({
-        name: safeZipEntryName(idx + 1, done.length, item.originalName),
-        blob: await exportPng(item.finalImageData ?? item.result!.imageData),
-      })),
-    );
-    const zip = await createZip(files);
-    downloadBlob(zip, `nukebg-batch-${Date.now()}.zip`);
   }
 
   private resetToIdle(): void {
@@ -2162,14 +2039,12 @@ export class ArApp extends HTMLElement {
     this.currentImageData = null;
     this.currentOriginalImageData = null;
 
-    if (this.batchMode !== 'off') {
-      this.batchAborted = true;
+    if (this.batch.isInBatchMode()) {
+      this.batch.abort();
       // Stop the in-flight pipeline run too — otherwise workers keep
       // processing the current item until its natural stage boundary.
       this.processingAbortController?.abort('batch aborted');
-      this.batchItems = [];
-      this.batchDetailId = null;
-      this.batchMode = 'off';
+      this.batch.reset();
     }
     // Keep pipeline alive for next image (model stays loaded)
   }

--- a/src/components/ar-app.ts
+++ b/src/components/ar-app.ts
@@ -9,10 +9,7 @@ import type { ArDownload } from './ar-download';
 import type { ArEditor } from './ar-editor';
 import type { ArDropzone } from './ar-dropzone';
 import type { ArBatchGrid } from './ar-batch-grid';
-import {
-  BatchOrchestrator,
-  type BatchStageCallback,
-} from '../controllers/batch-orchestrator';
+import { BatchOrchestrator, type BatchStageCallback } from '../controllers/batch-orchestrator';
 import {
   refineEdges,
   dropOrphanBlobs,

--- a/src/controllers/batch-orchestrator.ts
+++ b/src/controllers/batch-orchestrator.ts
@@ -1,0 +1,297 @@
+/**
+ * Batch queue controller. Owns the multi-image processing state machine
+ * (items, mode, detail-id, abort flag, currently-processing item) and the
+ * per-item pipeline execution loop. Extracted from ar-app.ts in #47/Phase-1
+ * so the host component shrinks toward pure orchestration + render.
+ *
+ * The host (ar-app) keeps:
+ *   - The PipelineOrchestrator instance (single-image flow shares it)
+ *   - The in-flight AbortController (cancel-processing handler must reach it
+ *     on either path)
+ *   - The detail-view rendering (it touches single-image fields + DOM
+ *     templates that live in the host)
+ *
+ * The orchestrator never reaches into the host directly — it talks through
+ * the BatchHost interface. The host passes itself in at construction.
+ */
+import { PipelineAbortError, type PipelineOrchestrator } from '../pipeline/orchestrator';
+import type { PipelineStage, StageStatus } from '../types/pipeline';
+import type { ModelId } from '../types/worker-messages';
+import type { ArViewer } from '../components/ar-viewer';
+import type { ArProgress } from '../components/ar-progress';
+import type { ArDownload } from '../components/ar-download';
+import type { ArBatchGrid } from '../components/ar-batch-grid';
+import type { BatchItem, StageSnapshot } from '../types/batch';
+import { createZip, safeZipEntryName, downloadBlob } from '../utils/zip';
+import {
+  dropOrphanBlobs,
+  fillSubjectHoles,
+  promoteSpeckleAlpha,
+} from '../pipeline/finalize';
+import { composeAtOriginal } from '../utils/final-composite';
+import { exportPng } from '../utils/image-io';
+
+export type BatchMode = 'off' | 'grid' | 'detail';
+
+export type BatchStageCallback = (
+  stage: PipelineStage,
+  status: StageStatus,
+  message?: string,
+) => void;
+
+/** UI components the orchestrator drives. Owned by host; orchestrator
+ *  borrows references. */
+export interface BatchUi {
+  viewer: ArViewer;
+  progress: ArProgress;
+  download: ArDownload;
+  batchGrid: ArBatchGrid | null;
+}
+
+/** Host-private capabilities the orchestrator needs to call into. */
+export interface BatchHost {
+  /** Install the per-batch stage callback onto the (lazy) pipeline and
+   *  return the armed pipeline for `process()` calls. The host owns the
+   *  lazy-creation logic so single-image flow can share the same instance. */
+  installBatchStageCallback(cb: BatchStageCallback): PipelineOrchestrator;
+
+  /** Set the AbortController for the in-flight item. Host stores it so the
+   *  global `ar:cancel-processing` handler can abort either single-image
+   *  or batch flows uniformly. */
+  setProcessingAbortController(c: AbortController | null): void;
+
+  /** Build a thumbnail data-URL. Host owns this because it uses a DOM
+   *  canvas (orchestrator stays DOM-free except for borrowed components). */
+  makeThumbnail(img: ImageData, maxSide?: number): string;
+
+  /** Called once when `start()` flips the UI to grid mode — host swaps
+   *  the hero/workspace DOM. Pure UI, no return value. */
+  enterGridMode(): void;
+}
+
+export class BatchOrchestrator {
+  private static readonly MODEL_ID: ModelId = 'briaai/RMBG-1.4';
+
+  private items: BatchItem[] = [];
+  private mode: BatchMode = 'off';
+  private detailId: string | null = null;
+  private aborted = false;
+  private currentProcessingItem: BatchItem | null = null;
+
+  /** Optional callback invoked when an item finishes processing AND
+   *  it's the one currently shown in detail view. Host wires this so the
+   *  detail UI auto-refreshes from "live" to "done"/"failed". */
+  private onItemRefreshed?: (id: string) => Promise<void> | void;
+
+  constructor(
+    private ui: BatchUi,
+    private host: BatchHost,
+  ) {}
+
+  // ── Accessors ──────────────────────────────────────────────────────
+
+  getMode(): BatchMode {
+    return this.mode;
+  }
+
+  isInBatchMode(): boolean {
+    return this.mode !== 'off';
+  }
+
+  getDetailId(): string | null {
+    return this.detailId;
+  }
+
+  findItem(id: string): BatchItem | undefined {
+    return this.items.find((i) => i.id === id);
+  }
+
+  // ── Mutators wired from host UI handlers ──────────────────────────
+
+  setMode(mode: BatchMode): void {
+    this.mode = mode;
+  }
+
+  setDetailId(id: string | null): void {
+    this.detailId = id;
+  }
+
+  abort(): void {
+    this.aborted = true;
+  }
+
+  setOnItemRefreshed(cb: (id: string) => Promise<void> | void): void {
+    this.onItemRefreshed = cb;
+  }
+
+  // ── Public lifecycle ───────────────────────────────────────────────
+
+  /** Initialize a new batch from dropped images and run the queue. */
+  async start(
+    images: Array<{
+      file: File;
+      imageData: ImageData;
+      originalImageData: ImageData;
+      originalWidth: number;
+      originalHeight: number;
+      wasDownsampled: boolean;
+    }>,
+  ): Promise<void> {
+    this.aborted = false;
+    this.items = images.map((img, i) => ({
+      id: `batch-${Date.now()}-${i}`,
+      originalName: img.file.name || `image-${i + 1}.png`,
+      file: img.file,
+      imageData: img.imageData,
+      originalImageData: img.originalImageData ?? img.imageData,
+      state: 'pending',
+      result: null,
+      finalImageData: null,
+      thumbnailUrl: this.host.makeThumbnail(img.originalImageData ?? img.imageData),
+      stageHistory: [],
+    }));
+
+    this.mode = 'grid';
+    this.host.enterGridMode();
+
+    if (this.ui.batchGrid) {
+      this.ui.batchGrid.setItems(this.items);
+      this.ui.batchGrid.setCurrentIndex(0);
+    }
+
+    await this.runQueue();
+  }
+
+  /** Run the queue until all items are done/failed/discarded. Re-entrant
+   *  from retry flows — re-installs the stage callback each time so the
+   *  pipeline records into the current batch's items. */
+  async runQueue(): Promise<void> {
+    const stageCallback: BatchStageCallback = (stage, status, message) => {
+      this.ui.progress.setStage(stage, status, message);
+      const current = this.currentProcessingItem;
+      if (current) current.stageHistory.push({ stage, status, message });
+    };
+    const pipeline = this.host.installBatchStageCallback(stageCallback);
+
+    for (let i = 0; i < this.items.length; i++) {
+      if (this.aborted) return;
+      const item = this.items[i];
+      if (item.state === 'done' || item.state === 'discarded') continue;
+      if (this.ui.batchGrid) this.ui.batchGrid.setCurrentIndex(i);
+      item.state = 'processing';
+      // Fresh slate for this item: empty history, empty live console.
+      item.stageHistory = [];
+      this.ui.progress.reset();
+      this.ui.progress.setRunning(true);
+      this.currentProcessingItem = item;
+      if (this.ui.batchGrid) this.ui.batchGrid.updateItem(item.id, 'processing');
+      // One signal per batch item so cancelling the batch aborts the
+      // in-flight one promptly without waiting for the current stage.
+      const ac = new AbortController();
+      this.host.setProcessingAbortController(ac);
+      try {
+        const result = await pipeline.process(
+          item.imageData,
+          BatchOrchestrator.MODEL_ID,
+          'high-power',
+          ac.signal,
+        );
+        if (this.aborted) return;
+        const composed = composeAtOriginal({
+          originalRgba: item.originalImageData.data,
+          originalWidth: item.originalImageData.width,
+          originalHeight: item.originalImageData.height,
+          workingRgba: result.workingPixels,
+          workingWidth: result.workingWidth,
+          workingHeight: result.workingHeight,
+          workingAlpha: result.workingAlpha,
+          inpaintMask: result.watermarkMask,
+        });
+        const finalImageData =
+          result.contentType === 'PHOTO' || result.contentType === 'ILLUSTRATION'
+            ? promoteSpeckleAlpha(fillSubjectHoles(dropOrphanBlobs(composed)))
+            : composed;
+        item.result = result;
+        item.finalImageData = finalImageData;
+        item.thumbnailUrl = this.host.makeThumbnail(finalImageData);
+        item.state = 'done';
+        if (this.ui.batchGrid) this.ui.batchGrid.updateItem(item.id, 'done', item.thumbnailUrl);
+        // Auto-refresh detail view if the user is currently watching this item.
+        if (this.detailId === item.id && this.onItemRefreshed) {
+          await this.onItemRefreshed(item.id);
+        }
+      } catch (err) {
+        // Abort during batch = user cancelled. Don't mark the item as
+        // failed; the outer abort check returns on next tick.
+        if (err instanceof PipelineAbortError || this.aborted) {
+          this.ui.progress.setRunning(false);
+          return;
+        }
+        item.errorMessage = err instanceof Error ? err.message : String(err);
+        item.state = 'failed';
+        if (this.ui.batchGrid) this.ui.batchGrid.updateItem(item.id, 'failed');
+        if (this.detailId === item.id && this.onItemRefreshed) {
+          await this.onItemRefreshed(item.id);
+        }
+      }
+    }
+    this.ui.progress.setRunning(false);
+    this.currentProcessingItem = null;
+  }
+
+  /** Mark a failed item as pending and re-run the queue. Host wires this
+   *  to the retry button. Caller is expected to close detail view first. */
+  async retry(id: string): Promise<void> {
+    const item = this.items.find((i) => i.id === id);
+    if (!item) return;
+    item.state = 'pending';
+    item.errorMessage = undefined;
+    item.stageHistory = [];
+    if (this.ui.batchGrid) this.ui.batchGrid.updateItem(item.id, 'pending');
+    await this.runQueue();
+  }
+
+  /** Mark an item as discarded so it's excluded from the ZIP and the
+   *  queue skips it on a re-run. */
+  markDiscarded(id: string): void {
+    const item = this.items.find((i) => i.id === id);
+    if (!item) return;
+    item.state = 'discarded';
+    if (this.ui.batchGrid) this.ui.batchGrid.updateItem(item.id, 'discarded');
+  }
+
+  /** Replay a finished item's captured stage events into the shared
+   *  progress console. Resets first so no stale state from the previous
+   *  item leaks through, then reapplies each snapshot in order. */
+  replayStageHistory(history: StageSnapshot[]): void {
+    this.ui.progress.reset();
+    for (const snap of history) {
+      this.ui.progress.setStage(snap.stage, snap.status, snap.message);
+    }
+  }
+
+  /** ZIP the finished items and trigger a browser download. */
+  async downloadZip(): Promise<void> {
+    const done = this.items.filter((i) => i.state === 'done' && i.result);
+    if (done.length === 0) return;
+    const files = await Promise.all(
+      done.map(async (item, idx) => ({
+        name: safeZipEntryName(idx + 1, done.length, item.originalName),
+        blob: await exportPng(item.finalImageData ?? item.result!.imageData),
+      })),
+    );
+    const zip = await createZip(files);
+    downloadBlob(zip, `nukebg-batch-${Date.now()}.zip`);
+  }
+
+  /** Wipe queue state. Called from host's resetToIdle when the user
+   *  hits "back" on a running/finished batch. */
+  reset(): void {
+    this.items = [];
+    this.detailId = null;
+    this.mode = 'off';
+    this.currentProcessingItem = null;
+    // Keep `aborted = true` so any in-flight runQueue tick returns on
+    // its next iteration; runQueue resets it at the next start().
+  }
+}

--- a/src/controllers/batch-orchestrator.ts
+++ b/src/controllers/batch-orchestrator.ts
@@ -23,11 +23,7 @@ import type { ArDownload } from '../components/ar-download';
 import type { ArBatchGrid } from '../components/ar-batch-grid';
 import type { BatchItem, StageSnapshot } from '../types/batch';
 import { createZip, safeZipEntryName, downloadBlob } from '../utils/zip';
-import {
-  dropOrphanBlobs,
-  fillSubjectHoles,
-  promoteSpeckleAlpha,
-} from '../pipeline/finalize';
+import { dropOrphanBlobs, fillSubjectHoles, promoteSpeckleAlpha } from '../pipeline/finalize';
 import { composeAtOriginal } from '../utils/final-composite';
 import { exportPng } from '../utils/image-io';
 


### PR DESCRIPTION
## Summary

Pulls the batch queue state machine and per-item processing loop out of `ar-app.ts` (2178 LOC) into a new `src/controllers/batch-orchestrator.ts` (~280 LOC). Single-image flow + DOM template rendering stays in `ar-app.ts` because they intermix heavily with shared state.

Part of #47 Phase 1. Phase 1b (PWA install extraction) will land separately.

## Split

**Owned by `BatchOrchestrator`:**
- State: `items`, `mode`, `detailId`, `aborted`, `currentProcessingItem`
- Lifecycle: `start()`, `runQueue()`, `retry()`, `markDiscarded()`, `reset()`
- Pure: `downloadZip()`, `replayStageHistory()`

**Kept in `ar-app.ts` (touches single-image state + DOM templates):**
- `openBatchDetail()` / `closeBatchDetail()` rendering
- `setBatchUiMode()` hero/workspace DOM swap
- `retryBatchItem()` / `discardBatchItem()` (now thin delegating wrappers)

## Boundary contract

The orchestrator never reaches into `ar-app` fields directly. It talks through the `BatchHost` interface:

- `installBatchStageCallback(cb)` — host owns the lazy pipeline + the stage-callback-per-batch wiring; orchestrator gets back the armed `PipelineOrchestrator` for `process()` calls.
- `setProcessingAbortController(c)` — host stores it so the global cancel-processing handler can find the in-flight signal regardless of single/batch path.
- `makeThumbnail(img, maxSide?)` — host owns this because it uses a DOM canvas.
- `enterGridMode()` — host swaps hero/workspace DOM.

Detail-view auto-refresh on item completion happens through `setOnItemRefreshed(cb)`. No direct DOM cross-reach.

## Validation gates

| Gate | Before | After |
|------|--------|-------|
| `npm test` | 834/834 | **834/834** ✅ |
| `npm run typecheck` | clean | **clean** ✅ |
| `npm run build` | success | **success** ✅ |
| `index-*.js` bundle | 466.91 kB / 125.66 gzip | 467.82 kB / 126.02 gzip |
| Bundle delta | — | **+0.19% raw, +0.29% gzip** (well under 5% gate) |

## What this is NOT

- Not a behavior change. Public events (`ar:image-loaded`, `batch:item-click`, `ar:cancel-processing`, etc.) are wired identically. Single-image flow untouched.
- Not a PWA-install split (Phase 1b).
- Not a fix for the `coche-capture.spec.ts` cold-start flake (#160) — that may still appear in CI.

## Test plan

- [x] `npm test` green locally (vitest, 834 tests).
- [x] `npm run typecheck` green.
- [x] `npm run build` success.
- [ ] Manual smoke on `npm run dev`:
  - [ ] Drop a single image — single-image flow runs to completion.
  - [ ] Drop multiple images — grid populates, queue processes serially, ZIP download works.
  - [ ] Click an in-flight item — detail view shows live progress, auto-refreshes to "done" when item finishes.
  - [ ] Cancel during batch — queue stops, UI returns to idle.
  - [ ] Click a failed item — failed bar shows, retry re-runs queue.

## Roll-back

If anything breaks downstream: `git reset --hard pre-split-baseline` resets dev to the pre-Phase-1 state.

Refs #47.