### PR TITLE
refactor(ar-app): extract PWA install into AppInstaller (#47 Phase 1b)

### DIFF
--- a/src/components/ar-app.ts
+++ b/src/components/ar-app.ts
@@ -2,7 +2,8 @@ import { PipelineOrchestrator, PipelineAbortError } from '../pipeline/orchestrat
 import type { PipelineStage, StageStatus } from '../types/pipeline';
 import type { ModelId } from '../types/worker-messages';
 import { t } from '../i18n';
-import { installApp, isAppInstalled } from '../sw-register';
+import { isAppInstalled } from '../sw-register';
+import { AppInstaller } from '../controllers/app-install';
 import type { ArViewer } from './ar-viewer';
 import type { ArProgress } from './ar-progress';
 import type { ArDownload } from './ar-download';
@@ -42,8 +43,11 @@ export class ArApp extends HTMLElement {
   private preEditResult: ImageData | null = null;
   private cachedEditResult: ImageData | null = null;
   private boundLocaleHandler: (() => void) | null = null;
-  private boundPwaInstallableHandler: (() => void) | null = null;
   private abortController: AbortController | null = null;
+  /** Owns PWA install button + guide wiring. Initialized in
+   *  setupComponents() once the install-btn / install-guide nodes
+   *  exist. See #47/Phase-1b. */
+  private installer!: AppInstaller;
   private batchGrid: ArBatchGrid | null = null;
   /** Owns batch queue state + per-item processing loop. Wired up in
    *  setupComponents() once UI refs are resolved. See #47/Phase-1. */
@@ -137,8 +141,6 @@ export class ArApp extends HTMLElement {
   disconnectedCallback(): void {
     if (this.boundLocaleHandler)
       document.removeEventListener('nukebg:locale-changed', this.boundLocaleHandler);
-    if (this.boundPwaInstallableHandler)
-      document.removeEventListener('nukebg:pwa-installable', this.boundPwaInstallableHandler);
     this.abortController?.abort();
     this.abortController = null;
   }
@@ -1045,6 +1047,12 @@ export class ArApp extends HTMLElement {
     this.dropzone = this.shadowRoot!.querySelector('ar-dropzone')! as ArDropzone;
     this.batchGrid = this.shadowRoot!.querySelector('#batch-grid') as ArBatchGrid;
 
+    // PWA install button + guide controller. Lifetime tied to ar-app
+    // via the AbortSignal handed to attach() in setupEvents().
+    const installBtn = this.shadowRoot!.querySelector('#install-btn') as HTMLButtonElement;
+    const installGuide = this.shadowRoot!.querySelector('#install-guide') as HTMLDivElement;
+    this.installer = new AppInstaller(installBtn, installGuide);
+
     // Batch orchestrator owns queue state + per-item processing. Host
     // (this component) keeps the pipeline + AbortController + thumbnail
     // helper + UI swap, exposed through the BatchHost interface.
@@ -1118,11 +1126,7 @@ export class ArApp extends HTMLElement {
     if (statusLimBody) statusLimBody.innerHTML = t('features.limitations');
     const editBtn = root.querySelector('#edit-btn');
     if (editBtn) editBtn.textContent = this.preEditResult ? t('edit.discard') : t('edit.btn');
-    const installBtnEl = root.querySelector('#install-btn') as HTMLButtonElement;
-    if (installBtnEl) {
-      installBtnEl.textContent = isAppInstalled() ? t('pwa.installed') : t('pwa.install');
-      installBtnEl.setAttribute('aria-label', t('pwa.install'));
-    }
+    this.installer?.refreshText();
     const backBtnEl = root.querySelector('#back-to-grid-btn');
     if (backBtnEl) backBtnEl.textContent = t('batch.backToGrid');
     const retryBtnEl = root.querySelector('#batch-retry-btn');
@@ -1149,19 +1153,6 @@ export class ArApp extends HTMLElement {
             : 'cmdbar.failed';
       cmdStateLabel.textContent = t(key);
     }
-  }
-
-  private getInstallGuide(): string {
-    const ua = navigator.userAgent.toLowerCase();
-    let steps: string;
-    if (/firefox/i.test(ua)) {
-      steps = t('pwa.guideFirefox');
-    } else if (/iphone|ipad|ipod/i.test(ua)) {
-      steps = t('pwa.guideSafari');
-    } else {
-      steps = t('pwa.guideGeneric');
-    }
-    return `<div class="guide-motivation">${t('pwa.guideMotivation')}</div>${steps}<br><button class="install-guide-close">${t('pwa.guideDismiss')}</button>`;
   }
 
   private setupEvents(): void {
@@ -1243,68 +1234,9 @@ export class ArApp extends HTMLElement {
       }
     });
 
-    // PWA install button - mobile only
-    const installBtn = this.shadowRoot!.querySelector('#install-btn') as HTMLButtonElement;
-    const installGuide = this.shadowRoot!.querySelector('#install-guide') as HTMLDivElement;
-    let hasNativePrompt = false;
-
-    // If already installed, show the installed state
-    if (isAppInstalled()) {
-      installBtn.textContent = t('pwa.installed');
-      installBtn.classList.add('visible');
-      installBtn.disabled = true;
-    }
-
-    // Show install button when PWA native prompt is available (Chromium)
-    this.boundPwaInstallableHandler = () => {
-      hasNativePrompt = true;
-      if (!isAppInstalled()) {
-        installBtn.textContent = t('pwa.install');
-        installBtn.classList.add('visible');
-        installBtn.disabled = false;
-      }
-    };
-    document.addEventListener('nukebg:pwa-installable', this.boundPwaInstallableHandler);
-
-    // On mobile without native prompt, show install button after a delay
-    // (Firefox, Safari - they can install but need manual steps)
-    const isMobile = window.matchMedia('(hover: none), (pointer: coarse)').matches;
-    if (isMobile && !isAppInstalled()) {
-      setTimeout(() => {
-        if (!hasNativePrompt) {
-          installBtn.textContent = t('pwa.install');
-          installBtn.classList.add('visible');
-          installBtn.disabled = false;
-        }
-      }, 2000);
-    }
-
-    installBtn.addEventListener(
-      'click',
-      async () => {
-        // If native prompt available (Chromium), use it
-        if (hasNativePrompt) {
-          const accepted = await installApp();
-          if (accepted) {
-            installBtn.textContent = t('pwa.installed');
-            installBtn.disabled = true;
-            installGuide.classList.remove('visible');
-          }
-          return;
-        }
-        // Otherwise show browser-specific instructions
-        const guide = this.getInstallGuide();
-        installGuide.innerHTML = guide;
-        installGuide.classList.toggle('visible');
-        const closeBtn = installGuide.querySelector('.install-guide-close');
-        if (closeBtn) {
-          closeBtn.addEventListener('click', () => installGuide.classList.remove('visible'), {
-            signal,
-          });
-        }
-      },
-      { signal },
-    );
+    // PWA install button + guide — controller owns the wiring and uses
+    // the same AbortSignal so cleanup is automatic on disconnect.
+    this.installer.attach(signal);
 
     this.shadowRoot!.addEventListener(
       'ar:image-loaded',

--- a/src/controllers/app-install.ts
+++ b/src/controllers/app-install.ts
@@ -1,0 +1,103 @@
+/**
+ * Controller for the PWA install affordance:
+ *   - Toggles the install button between "install" / "installed".
+ *   - Listens for `nukebg:pwa-installable` (dispatched by sw-register on
+ *     `beforeinstallprompt`) to surface the native prompt path.
+ *   - Falls back to a 2s mobile-only delayed appearance for browsers
+ *     without `beforeinstallprompt` (Firefox / iOS Safari).
+ *   - On click: triggers native prompt OR shows browser-specific guide.
+ *
+ * Extracted from ar-app.ts in #47/Phase-1b. Native-prompt and installed
+ * detection live in `src/sw-register.ts`; this controller wires the UI
+ * to those primitives. AbortSignal-based cleanup, no manual disconnect.
+ */
+import { installApp, isAppInstalled } from '../sw-register';
+import { t } from '../i18n';
+
+export class AppInstaller {
+  private hasNativePrompt = false;
+
+  constructor(
+    private installBtn: HTMLButtonElement,
+    private installGuide: HTMLDivElement,
+  ) {}
+
+  /** Wire up listeners + initial state. AbortSignal lifetime ties
+   *  cleanup to the host component. */
+  attach(signal: AbortSignal): void {
+    if (isAppInstalled()) {
+      this.installBtn.textContent = t('pwa.installed');
+      this.installBtn.classList.add('visible');
+      this.installBtn.disabled = true;
+    }
+
+    const onInstallable = () => {
+      this.hasNativePrompt = true;
+      if (!isAppInstalled()) {
+        this.installBtn.textContent = t('pwa.install');
+        this.installBtn.classList.add('visible');
+        this.installBtn.disabled = false;
+      }
+    };
+    document.addEventListener('nukebg:pwa-installable', onInstallable, { signal });
+
+    // Firefox + iOS Safari can install via manual steps but never fire
+    // `beforeinstallprompt`. Surface the button after a short delay if
+    // the native prompt hasn't fired by then.
+    const isMobile = window.matchMedia('(hover: none), (pointer: coarse)').matches;
+    if (isMobile && !isAppInstalled()) {
+      setTimeout(() => {
+        if (!this.hasNativePrompt && !signal.aborted) {
+          this.installBtn.textContent = t('pwa.install');
+          this.installBtn.classList.add('visible');
+          this.installBtn.disabled = false;
+        }
+      }, 2000);
+    }
+
+    this.installBtn.addEventListener(
+      'click',
+      async () => {
+        if (this.hasNativePrompt) {
+          const accepted = await installApp();
+          if (accepted) {
+            this.installBtn.textContent = t('pwa.installed');
+            this.installBtn.disabled = true;
+            this.installGuide.classList.remove('visible');
+          }
+          return;
+        }
+        // Browser-specific instructions for non-Chromium installs.
+        this.installGuide.innerHTML = this.buildGuide();
+        this.installGuide.classList.toggle('visible');
+        const closeBtn = this.installGuide.querySelector('.install-guide-close');
+        if (closeBtn) {
+          closeBtn.addEventListener('click', () => this.installGuide.classList.remove('visible'), {
+            signal,
+          });
+        }
+      },
+      { signal },
+    );
+  }
+
+  /** Re-applies button text after a locale change. Host's updateTexts()
+   *  calls this so the button stays in sync with the active locale. */
+  refreshText(): void {
+    this.installBtn.textContent = isAppInstalled() ? t('pwa.installed') : t('pwa.install');
+    this.installBtn.setAttribute('aria-label', t('pwa.install'));
+  }
+
+  private buildGuide(): string {
+    const ua = navigator.userAgent.toLowerCase();
+    let steps: string;
+    if (/firefox/i.test(ua)) {
+      steps = t('pwa.guideFirefox');
+    } else if (/iphone|ipad|ipod/i.test(ua)) {
+      steps = t('pwa.guideSafari');
+    } else {
+      steps = t('pwa.guideGeneric');
+    }
+    return `<div class="guide-motivation">${t('pwa.guideMotivation')}</div>${steps}<br><button class="install-guide-close">${t('pwa.guideDismiss')}</button>`;
+  }
+}


### PR DESCRIPTION
## Summary

Pulls the PWA install button + guide handling out of `ar-app.ts` into `src/controllers/app-install.ts`. Closes **Phase 1** of #47.

`installApp` and `isAppInstalled` continue to live in `src/sw-register.ts` (where the `beforeinstallprompt` capture happens) — the new controller wires them to the install button + guide DOM nodes via an `attach(signal)` call.

## Cuts

- Removed `boundPwaInstallableHandler` field and the matching cleanup in `disconnectedCallback`. Controller uses `AbortSignal`-based listeners, so no manual `removeEventListener` is needed.
- Removed `getInstallGuide()` method (now `buildGuide()` on the controller).
- Removed the ~60 LOC install-button setup block from `setupEvents()` — replaced by a single `this.installer.attach(signal)` call.
- `updateTexts()` no longer inlines the `isAppInstalled() ? t('pwa.installed') : t('pwa.install')` bookkeeping; it delegates to `this.installer.refreshText()`.

## Boundary contract

```ts
new AppInstaller(installBtn, installGuide);  // wire DOM refs in setupComponents
this.installer.attach(signal);                // start listening (in setupEvents)
this.installer.refreshText();                  // call after locale change
```

That's the whole API. Internal state (`hasNativePrompt`, the 2s mobile fallback timer, the click-handler closure) is fully encapsulated.

## Validation gates

| Gate | Before | After |
|------|--------|-------|
| `npm test` | 834/834 | **834/834** ✅ |
| `npm run typecheck` | clean | **clean** ✅ |
| `npm run build` | success | **success** ✅ |
| `index-*.js` bundle | 467.82 kB / 126.02 gzip | 468.10 kB / 126.09 gzip |
| Bundle delta vs Phase-1a | — | **+0.28 kB raw / +0.07 kB gzip** (+0.06%) |
| Bundle delta vs pre-split-baseline | — | +1.19 kB raw / +0.43 kB gzip (**+0.25% / +0.34%**) |

## ar-app.ts size trajectory

| Stage | LOC | Δ |
|-------|-----|---|
| pre-split-baseline | 2178 | — |
| after Phase 1a (#198) | 2053 | −125 |
| after Phase 1b (this PR) | 1969 | −84 |
| **total Phase 1 reduction** | | **−209 (−9.6%)** |

## Test plan

- [x] `npm test` green locally.
- [x] `npm run typecheck` green.
- [x] `npm run build` success.
- [ ] Manual smoke on `npm run dev`:
  - [ ] Chromium: `beforeinstallprompt` fires → install button appears → click prompts → "installed" state.
  - [ ] Firefox / Safari: 2s mobile fallback appears → click shows browser-specific guide → close button hides it.
  - [ ] Locale switch: button text re-applies via `refreshText()`.
  - [ ] Already-installed state: button hidden / disabled per existing logic.

## Roll-back

`git reset --hard pre-split-baseline` returns dev to the pre-Phase-1 state. Phase 1a and 1b can also be reverted independently — they touch independent code paths.

Refs #47.