### PR TITLE
refactor(ar-editor): extract BrushStroke + HistoryManager (#47 Phase 2)

### DIFF
--- a/src/components/ar-editor.ts
+++ b/src/components/ar-editor.ts
@@ -5,22 +5,15 @@
  */
 
 import { t } from '../i18n';
-
-type BrushShape = 'circle' | 'square';
-
-interface HistoryEntry {
-  // Full RGBA snapshot. Needed because the Restore tool writes RGB (not just
-  // alpha); alpha-only snapshots cannot undo color changes. Bounded by
-  // maxHistory to keep memory predictable on large images.
-  rgba: Uint8ClampedArray;
-}
+import { BrushStroke, type BrushShape, type BrushTool } from '../lib/brush-stroke';
+import { HistoryManager } from '../lib/history-manager';
 
 /** Generate a CSS cursor data URL that matches the brush shape, size and tool */
 function makeBrushCursor(
   size: number,
   shape: BrushShape,
   zoom: number,
-  tool: 'erase' | 'restore' = 'erase',
+  tool: BrushTool = 'erase',
 ): string {
   const raw = size * zoom;
   // Defensive: Number.isFinite guards against NaN from upstream state bugs.
@@ -82,7 +75,7 @@ export class ArEditor extends HTMLElement {
   // Brush state
   private brushSize = 20;
   private brushShape: BrushShape = 'circle';
-  private tool: 'erase' | 'restore' = 'erase';
+  private tool: BrushTool = 'erase';
   private isErasing = false;
 
   // Background preview
@@ -93,12 +86,10 @@ export class ArEditor extends HTMLElement {
   private lastPinchDist = 0;
   private isTouchErasing = false;
 
-  // History
-  private undoStack: HistoryEntry[] = [];
-  private redoStack: HistoryEntry[] = [];
-  // Full-RGBA snapshots × maxHistory — budget this conservatively so large
-  // images (up to 4096² ≈ 67 MB per entry) don't blow RAM.
-  private maxHistory = 12;
+  // History — full-RGBA snapshots, FIFO cap. Restore tool writes RGB (not
+  // just alpha); alpha-only snapshots can't undo color changes. Cap = 12
+  // so large images (up to 4096² ≈ 67 MB per entry) don't blow RAM.
+  private history = new HistoryManager<Uint8ClampedArray>(12);
   private boundLocaleHandler: (() => void) | null = null;
   private abortController: AbortController | null = null;
 
@@ -997,8 +988,7 @@ export class ArEditor extends HTMLElement {
       this.height,
     );
 
-    this.undoStack = [];
-    this.redoStack = [];
+    this.history.clear();
     this.updateUndoRedoButtons();
 
     this.fitToView();
@@ -1251,30 +1241,14 @@ export class ArEditor extends HTMLElement {
    */
   private stamp(cx: number, cy: number): void {
     if (!this.imageData || !this.originalImage) return;
-    const data = this.imageData.data;
-    const src = this.originalImage.data;
-    const restore = this.tool === 'restore';
-    const r = Math.floor(this.brushSize / 2);
-    const circle = this.brushShape === 'circle';
-    const r2 = r * r;
-
-    for (let dy = -r; dy <= r; dy++) {
-      for (let dx = -r; dx <= r; dx++) {
-        const px = cx + dx;
-        const py = cy + dy;
-        if (px < 0 || px >= this.width || py < 0 || py >= this.height) continue;
-        if (circle && dx * dx + dy * dy > r2) continue;
-        const i = (py * this.width + px) * 4;
-        if (restore) {
-          data[i] = src[i];
-          data[i + 1] = src[i + 1];
-          data[i + 2] = src[i + 2];
-          data[i + 3] = src[i + 3];
-        } else {
-          data[i + 3] = 0;
-        }
-      }
-    }
+    const stroke = new BrushStroke({
+      cx,
+      cy,
+      tool: this.tool,
+      size: this.brushSize,
+      shape: this.brushShape,
+    });
+    stroke.apply(this.imageData, this.originalImage, this.width, this.height);
     this.redraw();
   }
 
@@ -1284,26 +1258,24 @@ export class ArEditor extends HTMLElement {
 
   private pushUndo(): void {
     if (!this.imageData) return;
-    this.undoStack.push({ rgba: this.snapshot() });
-    if (this.undoStack.length > this.maxHistory) this.undoStack.shift();
-    this.redoStack = [];
+    this.history.push(this.snapshot());
     this.updateUndoRedoButtons();
   }
 
   private undo(): void {
-    if (!this.undoStack.length || !this.imageData) return;
-    this.redoStack.push({ rgba: this.snapshot() });
-    const prev = this.undoStack.pop()!;
-    this.imageData.data.set(prev.rgba);
+    if (!this.imageData) return;
+    const prev = this.history.undo(this.snapshot());
+    if (!prev) return;
+    this.imageData.data.set(prev);
     this.updateUndoRedoButtons();
     this.redraw();
   }
 
   private redo(): void {
-    if (!this.redoStack.length || !this.imageData) return;
-    this.undoStack.push({ rgba: this.snapshot() });
-    const next = this.redoStack.pop()!;
-    this.imageData.data.set(next.rgba);
+    if (!this.imageData) return;
+    const next = this.history.redo(this.snapshot());
+    if (!next) return;
+    this.imageData.data.set(next);
     this.updateUndoRedoButtons();
     this.redraw();
   }
@@ -1311,8 +1283,8 @@ export class ArEditor extends HTMLElement {
   private updateUndoRedoButtons(): void {
     const undoBtn = this.shadowRoot!.querySelector('#undo-btn') as HTMLButtonElement;
     const redoBtn = this.shadowRoot!.querySelector('#redo-btn') as HTMLButtonElement;
-    if (undoBtn) undoBtn.disabled = this.undoStack.length === 0;
-    if (redoBtn) redoBtn.disabled = this.redoStack.length === 0;
+    if (undoBtn) undoBtn.disabled = !this.history.canUndo();
+    if (redoBtn) redoBtn.disabled = !this.history.canRedo();
   }
 
   /** Get the edited ImageData */
@@ -1323,8 +1295,7 @@ export class ArEditor extends HTMLElement {
   reset(): void {
     this.imageData = null;
     this.originalImage = null;
-    this.undoStack = [];
-    this.redoStack = [];
+    this.history.clear();
   }
 }
 

--- a/src/lib/brush-stroke.ts
+++ b/src/lib/brush-stroke.ts
@@ -1,0 +1,84 @@
+/**
+ * Immutable record of a single brush operation in the basic editor:
+ * a circular or square stamp at one image-pixel coordinate, in either
+ * 'erase' (zero alpha) or 'restore' (copy RGBA from the pre-segmentation
+ * source) mode.
+ *
+ * Extracted from `ar-editor.ts` in #47/Phase-2. The component used to
+ * inline this logic in a private `stamp()` method that mutated
+ * `this.imageData` directly. Pulling it out as a value type lets tests
+ * exercise the pixel arithmetic without spinning up a custom element,
+ * and keeps the component focused on input + canvas wiring.
+ *
+ * The class intentionally has no DOM / canvas dependencies — only
+ * ImageData buffers in and out. That makes it safe to call from a
+ * worker if we ever need to replay strokes off the main thread.
+ */
+export type BrushTool = 'erase' | 'restore';
+
+export type BrushShape = 'circle' | 'square';
+
+export interface BrushStrokeConfig {
+  /** Center X in image pixels. */
+  cx: number;
+  /** Center Y in image pixels. */
+  cy: number;
+  /** Erase = drop alpha to 0; restore = copy RGBA from `originalImage`. */
+  tool: BrushTool;
+  /** Diameter in image pixels. Radius is derived as `Math.floor(size / 2)`. */
+  size: number;
+  /** Footprint shape. Square is bbox; circle clips to (dx² + dy² ≤ r²). */
+  shape: BrushShape;
+}
+
+export class BrushStroke {
+  readonly cx: number;
+  readonly cy: number;
+  readonly tool: BrushTool;
+  readonly size: number;
+  readonly shape: BrushShape;
+
+  constructor(config: BrushStrokeConfig) {
+    this.cx = config.cx;
+    this.cy = config.cy;
+    this.tool = config.tool;
+    this.size = config.size;
+    this.shape = config.shape;
+  }
+
+  /**
+   * Apply this stroke onto `imageData` (mutating its pixel buffer).
+   * The `originalImage` source is only read when the tool is 'restore';
+   * 'erase' just zeros out alpha. Both buffers must share `width × height`
+   * dimensions; mismatches are caller error.
+   *
+   * Pixels outside the image bounds are skipped silently — the editor
+   * lets the user paint past the canvas edge without errors.
+   */
+  apply(imageData: ImageData, originalImage: ImageData, width: number, height: number): void {
+    const data = imageData.data;
+    const src = originalImage.data;
+    const restore = this.tool === 'restore';
+    const r = Math.floor(this.size / 2);
+    const circle = this.shape === 'circle';
+    const r2 = r * r;
+
+    for (let dy = -r; dy <= r; dy++) {
+      for (let dx = -r; dx <= r; dx++) {
+        const px = this.cx + dx;
+        const py = this.cy + dy;
+        if (px < 0 || px >= width || py < 0 || py >= height) continue;
+        if (circle && dx * dx + dy * dy > r2) continue;
+        const i = (py * width + px) * 4;
+        if (restore) {
+          data[i] = src[i];
+          data[i + 1] = src[i + 1];
+          data[i + 2] = src[i + 2];
+          data[i + 3] = src[i + 3];
+        } else {
+          data[i + 3] = 0;
+        }
+      }
+    }
+  }
+}

--- a/src/lib/history-manager.ts
+++ b/src/lib/history-manager.ts
@@ -1,0 +1,70 @@
+/**
+ * Bounded undo/redo stack, generic over the state shape it holds. The
+ * caller decides what a "state" is — for the basic editor it's a
+ * Uint8ClampedArray RGBA snapshot; for advanced editors it could be a
+ * stroke record or a typed delta.
+ *
+ * Extracted from `ar-editor.ts` in #47/Phase-2. The component used to
+ * carry two raw arrays (`undoStack` / `redoStack`) plus a hand-rolled
+ * `pushUndo / undo / redo` triplet. Pulling it out lets the advanced
+ * editor (Phase 3b) reuse the same primitive instead of growing yet
+ * another copy.
+ *
+ * Cap policy: FIFO eviction at `maxEntries`. The default of 12 matches
+ * the basic editor's existing budget — enough room for typical
+ * touch-up sessions without letting full-RGBA snapshots blow the heap
+ * on multi-megapixel images.
+ */
+export class HistoryManager<T> {
+  private undoStack: T[] = [];
+  private redoStack: T[] = [];
+
+  constructor(private readonly maxEntries: number = 12) {}
+
+  /** Push a new state. Drops the oldest entry once we exceed the cap.
+   *  Pushing always wipes the redo stack — once the user starts a fresh
+   *  branch of edits, the previously redoable entries are unreachable. */
+  push(state: T): void {
+    this.undoStack.push(state);
+    if (this.undoStack.length > this.maxEntries) {
+      this.undoStack.shift();
+    }
+    this.redoStack = [];
+  }
+
+  /** Pop the most recent undo entry and return it. The caller passes
+   *  the current state, which gets moved onto the redo stack so a
+   *  subsequent `redo()` can return to it. Returns null if the undo
+   *  stack is empty. */
+  undo(currentState: T): T | null {
+    const prev = this.undoStack.pop();
+    if (prev === undefined) return null;
+    this.redoStack.push(currentState);
+    return prev;
+  }
+
+  /** Pop the most recent redo entry and return it. Mirrors `undo()`:
+   *  current state moves to the undo stack. Returns null if the redo
+   *  stack is empty. */
+  redo(currentState: T): T | null {
+    const next = this.redoStack.pop();
+    if (next === undefined) return null;
+    this.undoStack.push(currentState);
+    return next;
+  }
+
+  canUndo(): boolean {
+    return this.undoStack.length > 0;
+  }
+
+  canRedo(): boolean {
+    return this.redoStack.length > 0;
+  }
+
+  /** Wipe both stacks. Call when the underlying state is replaced
+   *  wholesale (new image loaded, editor reset, etc.). */
+  clear(): void {
+    this.undoStack = [];
+    this.redoStack = [];
+  }
+}

--- a/tests/lib/brush-stroke.test.ts
+++ b/tests/lib/brush-stroke.test.ts
@@ -1,0 +1,126 @@
+import { describe, it, expect } from 'vitest';
+import { BrushStroke } from '../../src/lib/brush-stroke';
+
+/**
+ * Behavioural tests for BrushStroke.apply() — the pixel arithmetic
+ * pulled out of ar-editor.ts in #47/Phase-2.
+ *
+ * Strategy: build tiny ImageData buffers with a known initial pattern,
+ * apply a stroke, and assert exact pixel mutations. No DOM, no canvas.
+ */
+
+function makeImage(w: number, h: number, fill: [number, number, number, number]): ImageData {
+  const data = new Uint8ClampedArray(w * h * 4);
+  for (let i = 0; i < w * h; i++) {
+    data[i * 4] = fill[0];
+    data[i * 4 + 1] = fill[1];
+    data[i * 4 + 2] = fill[2];
+    data[i * 4 + 3] = fill[3];
+  }
+  // happy-dom doesn't ship a real ImageData ctor in every version — stub
+  // the minimum surface our code reads.
+  return { data, width: w, height: h, colorSpace: 'srgb' } as ImageData;
+}
+
+function alphaAt(img: ImageData, x: number, y: number): number {
+  return img.data[(y * img.width + x) * 4 + 3];
+}
+
+function rgbaAt(img: ImageData, x: number, y: number): [number, number, number, number] {
+  const i = (y * img.width + x) * 4;
+  return [img.data[i], img.data[i + 1], img.data[i + 2], img.data[i + 3]];
+}
+
+describe('BrushStroke', () => {
+  describe('erase tool', () => {
+    it('zeros alpha inside a square footprint', () => {
+      const img = makeImage(5, 5, [200, 100, 50, 255]);
+      const orig = makeImage(5, 5, [10, 20, 30, 255]); // unused for erase
+      const stroke = new BrushStroke({ cx: 2, cy: 2, tool: 'erase', size: 3, shape: 'square' });
+
+      stroke.apply(img, orig, 5, 5);
+
+      // Center 3x3 cleared (radius=1 → covers cx±1, cy±1)
+      for (let y = 1; y <= 3; y++) {
+        for (let x = 1; x <= 3; x++) {
+          expect(alphaAt(img, x, y)).toBe(0);
+        }
+      }
+      // Corners untouched
+      expect(alphaAt(img, 0, 0)).toBe(255);
+      expect(alphaAt(img, 4, 4)).toBe(255);
+      // RGB preserved (erase only touches alpha)
+      expect(rgbaAt(img, 2, 2)).toEqual([200, 100, 50, 0]);
+    });
+
+    it('clips to circular footprint when shape=circle', () => {
+      // size=3 → r=1 → r²=1. Diagonals (dx²+dy²=2) get skipped.
+      const img = makeImage(5, 5, [255, 255, 255, 255]);
+      const orig = makeImage(5, 5, [0, 0, 0, 0]);
+      const stroke = new BrushStroke({ cx: 2, cy: 2, tool: 'erase', size: 3, shape: 'circle' });
+
+      stroke.apply(img, orig, 5, 5);
+
+      // Cardinal neighbours cleared
+      expect(alphaAt(img, 2, 2)).toBe(0); // center
+      expect(alphaAt(img, 1, 2)).toBe(0);
+      expect(alphaAt(img, 3, 2)).toBe(0);
+      expect(alphaAt(img, 2, 1)).toBe(0);
+      expect(alphaAt(img, 2, 3)).toBe(0);
+      // Diagonal corners preserved
+      expect(alphaAt(img, 1, 1)).toBe(255);
+      expect(alphaAt(img, 3, 3)).toBe(255);
+    });
+
+    it('skips pixels outside image bounds without throwing', () => {
+      const img = makeImage(3, 3, [100, 100, 100, 255]);
+      const orig = makeImage(3, 3, [0, 0, 0, 0]);
+      // Centered at (0,0) with size=5 — half the footprint is OOB.
+      const stroke = new BrushStroke({ cx: 0, cy: 0, tool: 'erase', size: 5, shape: 'square' });
+
+      expect(() => stroke.apply(img, orig, 3, 3)).not.toThrow();
+      // In-bounds pixels in the top-left quadrant were touched.
+      expect(alphaAt(img, 0, 0)).toBe(0);
+      expect(alphaAt(img, 1, 1)).toBe(0);
+      expect(alphaAt(img, 2, 2)).toBe(0);
+    });
+  });
+
+  describe('restore tool', () => {
+    it('copies RGBA from originalImage at every painted pixel', () => {
+      const img = makeImage(5, 5, [0, 0, 0, 0]); // fully erased state
+      const orig = makeImage(5, 5, [220, 110, 55, 200]);
+      const stroke = new BrushStroke({ cx: 2, cy: 2, tool: 'restore', size: 3, shape: 'square' });
+
+      stroke.apply(img, orig, 5, 5);
+
+      expect(rgbaAt(img, 2, 2)).toEqual([220, 110, 55, 200]);
+      expect(rgbaAt(img, 1, 1)).toEqual([220, 110, 55, 200]);
+      expect(rgbaAt(img, 3, 3)).toEqual([220, 110, 55, 200]);
+      // Outside footprint untouched (still erased)
+      expect(rgbaAt(img, 0, 0)).toEqual([0, 0, 0, 0]);
+    });
+
+    it('respects circle shape clipping in restore mode too', () => {
+      const img = makeImage(5, 5, [0, 0, 0, 0]);
+      const orig = makeImage(5, 5, [255, 0, 0, 255]);
+      const stroke = new BrushStroke({ cx: 2, cy: 2, tool: 'restore', size: 3, shape: 'circle' });
+
+      stroke.apply(img, orig, 5, 5);
+
+      expect(rgbaAt(img, 2, 2)).toEqual([255, 0, 0, 255]);
+      expect(rgbaAt(img, 1, 1)).toEqual([0, 0, 0, 0]); // diagonal skipped
+    });
+  });
+
+  describe('immutability', () => {
+    it('exposes config as readonly fields', () => {
+      const stroke = new BrushStroke({ cx: 5, cy: 7, tool: 'erase', size: 10, shape: 'circle' });
+      expect(stroke.cx).toBe(5);
+      expect(stroke.cy).toBe(7);
+      expect(stroke.tool).toBe('erase');
+      expect(stroke.size).toBe(10);
+      expect(stroke.shape).toBe('circle');
+    });
+  });
+});

--- a/tests/lib/history-manager.test.ts
+++ b/tests/lib/history-manager.test.ts
@@ -1,0 +1,137 @@
+import { describe, it, expect } from 'vitest';
+import { HistoryManager } from '../../src/lib/history-manager';
+
+/**
+ * Behavioural tests for the generic undo/redo manager extracted from
+ * ar-editor.ts in #47/Phase-2.
+ */
+describe('HistoryManager', () => {
+  describe('push + undo/redo round-trip', () => {
+    it('returns the most recent push on undo', () => {
+      const h = new HistoryManager<string>();
+      h.push('a');
+      h.push('b');
+      h.push('c');
+
+      expect(h.undo('current')).toBe('c');
+      expect(h.undo('c-was-current')).toBe('b');
+      expect(h.undo('b-was-current')).toBe('a');
+    });
+
+    it('moves current state onto redo stack during undo', () => {
+      const h = new HistoryManager<string>();
+      h.push('a');
+      h.undo('current'); // current goes to redo stack
+      expect(h.canRedo()).toBe(true);
+      expect(h.redo('a')).toBe('current');
+    });
+
+    it('round-trips undo → redo with state preserved', () => {
+      const h = new HistoryManager<number>();
+      h.push(1);
+      h.push(2);
+      const undone = h.undo(3);
+      expect(undone).toBe(2);
+      const redone = h.redo(undone!);
+      expect(redone).toBe(3);
+    });
+
+    it('returns null when stacks are empty', () => {
+      const h = new HistoryManager<string>();
+      expect(h.undo('x')).toBeNull();
+      expect(h.redo('x')).toBeNull();
+    });
+  });
+
+  describe('redo invalidation', () => {
+    it('clears the redo stack when push is called after undo', () => {
+      const h = new HistoryManager<string>();
+      h.push('a');
+      h.push('b');
+      h.undo('current');
+      expect(h.canRedo()).toBe(true);
+
+      h.push('new-branch');
+      expect(h.canRedo()).toBe(false);
+    });
+  });
+
+  describe('cap policy', () => {
+    it('drops the oldest entry when maxEntries is exceeded', () => {
+      const h = new HistoryManager<string>(3);
+      h.push('a');
+      h.push('b');
+      h.push('c');
+      h.push('d'); // evicts 'a'
+
+      // Walk back as far as we can
+      expect(h.undo('current')).toBe('d');
+      expect(h.undo('d')).toBe('c');
+      expect(h.undo('c')).toBe('b');
+      // 'a' was evicted, no more entries
+      expect(h.undo('b')).toBeNull();
+    });
+
+    it('uses default cap of 12 when not specified', () => {
+      const h = new HistoryManager<number>();
+      for (let i = 0; i < 15; i++) h.push(i);
+
+      // 15 pushed, cap 12 → entries [3..14] should remain
+      const seen: number[] = [];
+      let cur = 99;
+      while (h.canUndo()) {
+        const v = h.undo(cur);
+        if (v !== null) {
+          seen.push(v);
+          cur = v;
+        }
+      }
+      expect(seen).toEqual([14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3]);
+    });
+  });
+
+  describe('canUndo / canRedo', () => {
+    it('reports false on a fresh manager', () => {
+      const h = new HistoryManager();
+      expect(h.canUndo()).toBe(false);
+      expect(h.canRedo()).toBe(false);
+    });
+
+    it('flips true after push', () => {
+      const h = new HistoryManager<number>();
+      h.push(1);
+      expect(h.canUndo()).toBe(true);
+      expect(h.canRedo()).toBe(false);
+    });
+  });
+
+  describe('clear', () => {
+    it('wipes both stacks', () => {
+      const h = new HistoryManager<string>();
+      h.push('a');
+      h.push('b');
+      h.undo('current');
+
+      h.clear();
+
+      expect(h.canUndo()).toBe(false);
+      expect(h.canRedo()).toBe(false);
+      expect(h.undo('x')).toBeNull();
+      expect(h.redo('x')).toBeNull();
+    });
+  });
+
+  describe('works with non-trivial state types', () => {
+    it('handles Uint8ClampedArray snapshots without issue', () => {
+      const h = new HistoryManager<Uint8ClampedArray>();
+      const a = new Uint8ClampedArray([1, 2, 3, 4]);
+      const b = new Uint8ClampedArray([5, 6, 7, 8]);
+      h.push(a);
+      h.push(b);
+
+      const cur = new Uint8ClampedArray([9, 9, 9, 9]);
+      const undone = h.undo(cur);
+      expect(undone).toBe(b); // identity preserved (no clone)
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Phase 2 of #47. Pulls two concerns out of `ar-editor.ts` into pure modules under `src/lib/`, each with its own behavioral test suite.

## What moved

### `src/lib/brush-stroke.ts` (89 LOC)
Immutable stroke record. `apply(imageData, originalImage, width, height)` carries the pixel arithmetic that used to live inline in `stamp()`. No DOM / canvas deps — safe to call from a worker if Phase 3 ever needs replay off the main thread.

### `src/lib/history-manager.ts` (70 LOC)
Generic `HistoryManager<T>` with FIFO cap. Basic editor instantiates as `HistoryManager<Uint8ClampedArray>`. Phase 3b will reuse the same primitive in the advanced editor instead of carrying yet another copy.

## Audit correction

Issue #47 / audit-#98 predicted the basic editor had a "lazy snapshot for >4k images" optimization. **It doesn't exist** — every push is an immediate full RGBA snapshot, FIFO of 12. No behavior change here, just bookkeeping.

## Test coverage

The existing `tests/components/ar-editor.test.ts` covers UI state + event dispatch but not pixel mutations or undo/redo round-trips. Added two unit-test files (17 tests total):

- `tests/lib/brush-stroke.test.ts` — erase/restore × circle/square × in-bounds/out-of-bounds, plus immutability.
- `tests/lib/history-manager.test.ts` — push/undo/redo round-trip, redo invalidation on new push, FIFO cap policy, empty-stack handling, generic-`<T>` smoke test.

These lock the new contract so future Phase 3 reuse stays honest.

## Validation gates

| Gate | Before | After |
|------|--------|-------|
| `npm test` | 834/834 | **851/851** ✅ (+17 new) |
| `npm run typecheck` | clean | **clean** ✅ |
| `npm run build` | success | **success** ✅ |
| `index-*.js` bundle | 468.10 kB / 126.09 gzip | 468.55 kB / 126.33 gzip |
| Bundle delta vs Phase-1b | — | **+0.45 kB raw / +0.24 kB gzip** (+0.10% / +0.19%) |
| Bundle delta vs pre-split-baseline | — | +1.64 kB raw / +0.67 kB gzip (**+0.35% / +0.53%**) |

## ar-app.ts size trajectory (cumulative)

| Stage | LOC | Δ |
|-------|-----|---|
| pre-split-baseline | 2178 | — |
| after Phase 1a | 2053 | −125 |
| after Phase 1b | 1969 | −84 |
| **Total Phase 1** | | **−209 (−9.6%)** |

`ar-editor.ts`: -29 LOC in this PR (1331 → 1302). Modest because the component still owns DOM + canvas + render + tool-routing.

## Test plan

- [x] `npm test` green locally (851 tests).
- [x] `npm run typecheck` green.
- [x] `npm run build` success.
- [ ] Manual smoke on `npm run dev`:
  - [ ] Drop image → edit → erase brush works pixel-for-pixel as before.
  - [ ] Restore brush brings back original RGBA.
  - [ ] Undo / redo cycles through stack of strokes.
  - [ ] Cap test: 13+ strokes, oldest evicted on undo.

## Roll-back

`git reset --hard pre-split-baseline` returns dev to pre-Phase-1 state. This Phase 2 PR is independent of Phase 1 and can be reverted alone too.

Refs #47.