### PR TITLE
refactor(ar-editor-advanced): extract LassoModel (#47 Phase 3a)

### DIFF
--- a/src/components/ar-editor-advanced.ts
+++ b/src/components/ar-editor-advanced.ts
@@ -42,7 +42,8 @@ import { rasterizePolygon } from '../refine/roi-process';
 import { patchMatchInpaint } from '../workers/cv/patchmatch-inpaint';
 import { PATCHMATCH_PARAMS } from '../pipeline/constants';
 import { t } from '../i18n';
-import { simplifyClosed, type Point } from './lasso-simplify';
+import { type Point } from './lasso-simplify';
+import { LassoModel } from '../lib/lasso-model';
 
 const PAD_RATIO = 0.25;
 const DEFAULT_BRUSH = 24;
@@ -121,9 +122,9 @@ export class ArEditorAdvanced extends HTMLElement {
 
   // Lasso state (all coordinates in image-space — may be outside [0..w/h]
   // because the canvas is padded and loops can cross the image edge).
-  private lassoRaw: Point[] | null = null;
-  private lassoAnchors: Point[] | null = null;
-  private dragAnchorIndex: number | null = null;
+  /** Lasso state machine (raw path → simplified polygon → anchor drags).
+   *  Pure data, no DOM. See `src/lib/lasso-model.ts` (#47/Phase-3a). */
+  private lasso = new LassoModel();
 
   // Shared RMBG-1.4 loader, warmed on first refine and reused afterwards.
   private loader: ModelLoader | null = null;
@@ -1059,7 +1060,7 @@ export class ArEditorAdvanced extends HTMLElement {
             this.cancelAction();
             return;
           }
-          if (this.lassoAnchors || this.lassoRaw) {
+          if (this.lasso.getAnchors() || this.lasso.getRawPath()) {
             this.clearLasso();
             this.redrawDisplay();
           }
@@ -1120,10 +1121,10 @@ export class ArEditorAdvanced extends HTMLElement {
     if (this.tool === 'lasso') {
       if (this.pendingPreview) this.cancelPreview();
 
-      if (this.lassoAnchors) {
+      if (this.lasso.isClosed()) {
         const idx = this.hitAnchor(ix, iy);
         if (idx !== null) {
-          this.dragAnchorIndex = idx;
+          this.lasso.beginDragAnchor(idx);
           try {
             this.canvas.setPointerCapture(e.pointerId);
           } catch {
@@ -1142,7 +1143,7 @@ export class ArEditorAdvanced extends HTMLElement {
         /* noop */
       }
       this.drawing = true;
-      this.lassoRaw = [{ x: ix, y: iy }];
+      this.lasso.startAt({ x: ix, y: iy });
       this.redrawDisplay();
       return;
     }
@@ -1179,15 +1180,16 @@ export class ArEditorAdvanced extends HTMLElement {
     const [ix, iy] = this.eventToImageCoords(e);
 
     if (this.tool === 'lasso') {
-      if (this.dragAnchorIndex !== null && this.lassoAnchors) {
-        this.lassoAnchors[this.dragAnchorIndex] = { x: ix, y: iy };
+      const dragIdx = this.lasso.getDragAnchorIndex();
+      if (dragIdx !== null) {
+        this.lasso.moveAnchor(dragIdx, { x: ix, y: iy });
         this.redrawDisplay();
         return;
       }
-      if (this.drawing && this.lassoRaw) {
-        const last = this.lassoRaw[this.lassoRaw.length - 1];
-        if (Math.hypot(ix - last.x, iy - last.y) >= MIN_LASSO_POINT_DIST) {
-          this.lassoRaw.push({ x: ix, y: iy });
+      if (this.drawing && this.lasso.getRawPath()) {
+        const before = this.lasso.getRawPath()!.length;
+        this.lasso.addRawPoint({ x: ix, y: iy }, MIN_LASSO_POINT_DIST);
+        if (this.lasso.getRawPath()!.length !== before) {
           this.redrawDisplay();
           return;
         }
@@ -1222,24 +1224,21 @@ export class ArEditorAdvanced extends HTMLElement {
     }
 
     if (this.tool === 'lasso') {
-      if (this.dragAnchorIndex !== null) {
-        this.dragAnchorIndex = null;
+      if (this.lasso.getDragAnchorIndex() !== null) {
+        this.lasso.endDragAnchor();
         return;
       }
-      if (this.drawing && this.lassoRaw) {
-        if (this.lassoRaw.length >= MIN_ANCHORS) {
-          const w = this.current?.width ?? 0;
-          const h = this.current?.height ?? 0;
-          const eps = Math.max(1.5, Math.min(w, h) * LASSO_EPS_RATIO);
-          this.lassoAnchors = simplifyClosed(this.lassoRaw, eps);
-          if (this.lassoAnchors.length < MIN_ANCHORS) this.lassoAnchors = null;
-        }
-        this.lassoRaw = null;
+      if (this.drawing && this.lasso.getRawPath()) {
+        const w = this.current?.width ?? 0;
+        const h = this.current?.height ?? 0;
+        const eps = Math.max(1.5, Math.min(w, h) * LASSO_EPS_RATIO);
+        this.lasso.setSimplifyEpsilon(eps);
+        this.lasso.close();
       }
       this.drawing = false;
       this.syncLassoActionsUI();
       this.redrawDisplay();
-      if (this.lassoAnchors) {
+      if (this.lasso.isClosed()) {
         this.rmbgDecodeFromLasso();
       }
       return;
@@ -1249,12 +1248,11 @@ export class ArEditorAdvanced extends HTMLElement {
   }
 
   private onDblClick(e: MouseEvent): void {
-    if (this.tool !== 'lasso' || !this.lassoAnchors) return;
+    if (this.tool !== 'lasso' || !this.lasso.isClosed()) return;
     const [ix, iy] = this.eventToImageCoordsFromMouse(e);
     const idx = this.hitAnchor(ix, iy);
     if (idx === null) return;
-    if (this.lassoAnchors.length <= MIN_ANCHORS) return;
-    this.lassoAnchors.splice(idx, 1);
+    if (!this.lasso.removeAnchor(idx)) return;
     this.syncLassoActionsUI();
     this.redrawDisplay();
   }
@@ -1296,16 +1294,7 @@ export class ArEditorAdvanced extends HTMLElement {
   }
 
   private hitAnchor(ix: number, iy: number): number | null {
-    if (!this.lassoAnchors) return null;
-    const tol = this.anchorRadius() + 4;
-    const tolSq = tol * tol;
-    for (let i = 0; i < this.lassoAnchors.length; i++) {
-      const a = this.lassoAnchors[i];
-      const dx = a.x - ix;
-      const dy = a.y - iy;
-      if (dx * dx + dy * dy <= tolSq) return i;
-    }
-    return null;
+    return this.lasso.hitAnchor(ix, iy, this.anchorRadius() + 4);
   }
 
   private applyStrokeSegment(fromX: number, fromY: number, toX: number, toY: number): void {
@@ -1394,7 +1383,7 @@ export class ArEditorAdvanced extends HTMLElement {
     this.lastPinchDist = this.getPinchDist(e.touches);
     // Cancel any brush stroke that might have started on the first touch.
     this.drawing = false;
-    this.dragAnchorIndex = null;
+    this.lasso.endDragAnchor();
   }
 
   private onTouchMove(e: TouchEvent): void {
@@ -1539,10 +1528,7 @@ export class ArEditorAdvanced extends HTMLElement {
     const busy = this.shadowRoot?.getElementById('busy');
     const hint = this.shadowRoot?.getElementById('hint');
     if (!row || !previewRow) return;
-    const hasAnchors =
-      this.tool === 'lasso' &&
-      this.lassoAnchors !== null &&
-      this.lassoAnchors.length >= MIN_ANCHORS;
+    const hasAnchors = this.tool === 'lasso' && this.lasso.isClosed();
     const hasSelection = this.tool === 'lasso' && this.selectionMask !== null;
     const isPreviewing = this.pendingPreview !== null;
     row.classList.toggle('visible', (hasAnchors || hasSelection) && !isPreviewing);
@@ -1561,9 +1547,7 @@ export class ArEditorAdvanced extends HTMLElement {
   }
 
   private clearLasso(): void {
-    this.lassoRaw = null;
-    this.lassoAnchors = null;
-    this.dragAnchorIndex = null;
+    this.lasso.clear();
     this.pendingPreview = null;
     this.syncLassoActionsUI();
   }
@@ -1602,7 +1586,8 @@ export class ArEditorAdvanced extends HTMLElement {
     if (!this.ctx) return;
 
     // Raw in-progress path — open polyline. Always visible, even over Quick Mask.
-    if (this.lassoRaw && this.lassoRaw.length > 1) {
+    const rawPath = this.lasso.getRawPath();
+    if (rawPath && rawPath.length > 1) {
       this.ctx.save();
       const accentRgb =
         getComputedStyle(document.documentElement).getPropertyValue('--color-accent-rgb').trim() ||
@@ -1613,10 +1598,10 @@ export class ArEditorAdvanced extends HTMLElement {
       this.ctx.shadowBlur = 3;
       this.ctx.setLineDash([]);
       this.ctx.beginPath();
-      const p0 = this.lassoRaw[0];
+      const p0 = rawPath[0];
       this.ctx.moveTo(p0.x + this.padX, p0.y + this.padY);
-      for (let i = 1; i < this.lassoRaw.length; i++) {
-        this.ctx.lineTo(this.lassoRaw[i].x + this.padX, this.lassoRaw[i].y + this.padY);
+      for (let i = 1; i < rawPath.length; i++) {
+        this.ctx.lineTo(rawPath[i].x + this.padX, rawPath[i].y + this.padY);
       }
       this.ctx.stroke();
       this.ctx.restore();
@@ -1627,8 +1612,9 @@ export class ArEditorAdvanced extends HTMLElement {
     // handles intentionally omitted: anchors are not draggable, so showing
     // them just adds visual noise. Match cursor-preview line width (2) for
     // stroke consistency across tools.
-    if (!this.selectionMask && this.lassoAnchors && this.lassoAnchors.length >= MIN_ANCHORS) {
-      const pts = this.lassoAnchors;
+    const anchors = this.lasso.getAnchors();
+    if (!this.selectionMask && anchors && anchors.length >= MIN_ANCHORS) {
+      const pts = anchors;
       this.ctx.save();
       const accentRgb2 =
         getComputedStyle(document.documentElement).getPropertyValue('--color-accent-rgb').trim() ||
@@ -1680,7 +1666,8 @@ export class ArEditorAdvanced extends HTMLElement {
     // skips the preview/confirm pattern — inpainting is non-destructive
     // and any mistake is one Ctrl+Z away.
     if (this.busy) return;
-    const hasLasso = this.lassoAnchors !== null && this.lassoAnchors.length >= MIN_ANCHORS;
+    const hasLasso = this.lasso.isClosed();
+    const lassoAnchors = this.lasso.getAnchors();
     const hasMask = this.selectionMask !== null;
     if (!hasLasso && !hasMask) return;
     if (!this.working || !this.original || !this.current) return;
@@ -1712,7 +1699,7 @@ export class ArEditorAdvanced extends HTMLElement {
       let newAlpha: Uint8Array;
 
       if (kind === 'refine') {
-        const poly = this.lassoAnchors ?? this.selectionMaskToPolygon(w, h);
+        const poly = lassoAnchors ? [...lassoAnchors] : this.selectionMaskToPolygon(w, h);
         if (!poly || poly.length < MIN_ANCHORS) throw new Error('No region for refine');
         newAlpha = await this.refineWithSam(poly, prevAlpha, w, h, ac.signal);
       } else if (hasMask) {
@@ -1730,7 +1717,7 @@ export class ArEditorAdvanced extends HTMLElement {
       } else {
         const result = await processRoi({
           original: workingData,
-          polygon: this.lassoAnchors!,
+          polygon: [...lassoAnchors!],
           previousAlpha: prevAlpha,
           mode: kind,
           segment,
@@ -1848,11 +1835,12 @@ export class ArEditorAdvanced extends HTMLElement {
   private async removeWatermarkInLasso(): Promise<void> {
     if (this.busy) return;
     if (!this.working || !this.current) return;
-    if (!this.lassoAnchors || this.lassoAnchors.length < MIN_ANCHORS) return;
+    const lassoAnchors = this.lasso.getAnchors();
+    if (!lassoAnchors || lassoAnchors.length < MIN_ANCHORS) return;
 
     const w = this.current.width;
     const h = this.current.height;
-    const mask = rasterizePolygon(this.lassoAnchors, w, h);
+    const mask = rasterizePolygon([...lassoAnchors], w, h);
 
     this.busy = true;
     this.syncBusyUI();
@@ -2030,8 +2018,9 @@ export class ArEditorAdvanced extends HTMLElement {
   // ────────────────────── RMBG lasso selection ──────────────────────────
 
   private async rmbgDecodeFromLasso(): Promise<void> {
-    if (!this.current || !this.original || !this.lassoAnchors) return;
-    if (this.lassoAnchors.length < MIN_ANCHORS) return;
+    if (!this.current || !this.original) return;
+    const lassoAnchors = this.lasso.getAnchors();
+    if (!lassoAnchors || lassoAnchors.length < MIN_ANCHORS) return;
 
     const w = this.current.width;
     const h = this.current.height;
@@ -2055,7 +2044,7 @@ export class ArEditorAdvanced extends HTMLElement {
 
       const result = await processRoi({
         original: workingData,
-        polygon: this.lassoAnchors,
+        polygon: [...lassoAnchors],
         previousAlpha: null,
         mode: 'crop',
         segment,
@@ -2074,8 +2063,7 @@ export class ArEditorAdvanced extends HTMLElement {
           if (segMask[i] === 1) this.selectionMask[i] = 1;
         }
       }
-      this.lassoAnchors = null;
-      this.lassoRaw = null;
+      this.lasso.clear();
       this.rebuildSelectionOverlay();
       this.redrawDisplay();
     } catch (err) {

--- a/src/lib/lasso-model.ts
+++ b/src/lib/lasso-model.ts
@@ -1,0 +1,203 @@
+/**
+ * Lasso state machine for the advanced editor: tracks the raw freehand
+ * path the user is drawing, the simplified anchor polygon once they
+ * close it, and any in-flight anchor drag. Pure data + geometry — no
+ * DOM, canvas, or pipeline knowledge.
+ *
+ * Extracted from `ar-editor-advanced.ts` in #47/Phase-3a. The component
+ * used to carry four instance fields (`lassoRaw`, `lassoAnchors`,
+ * `dragAnchorIndex`, plus the simplification math inline) and call into
+ * `simplifyClosed()` directly. Pulling the state into its own class
+ * lets the host stay focused on input + render + pipeline wiring, and
+ * gives us a place to unit-test the geometry without spinning up a
+ * shadow DOM.
+ *
+ * Reuses `simplifyClosed()` from `../components/lasso-simplify.ts`
+ * (pure function, no DOM deps) for Douglas-Peucker reduction.
+ */
+import { simplifyClosed, type Point } from '../components/lasso-simplify';
+
+export type { Point };
+
+export class LassoModel {
+  /** Polygon must have at least this many anchors to be considered
+   *  closed. Below this, `close()` discards the path and stays empty. */
+  static readonly MIN_ANCHORS = 3;
+
+  /** Default min-distance gate for `addRawPoint()`. Avoids burying the
+   *  Douglas-Peucker step in noise from a single user gesture. */
+  static readonly DEFAULT_MIN_POINT_DIST = 2;
+
+  private rawPath: Point[] | null = null;
+  private anchors: Point[] | null = null;
+  private dragIndex: number | null = null;
+
+  constructor(private simplifyEpsilon: number = 1.5) {}
+
+  // ── Read accessors ─────────────────────────────────────────────────
+
+  /** In-progress freehand points, dense and unsimplified. Null while
+   *  the lasso is closed or empty. Returned as a defensive shallow copy
+   *  is unnecessary — callers should treat it as read-only. */
+  getRawPath(): readonly Point[] | null {
+    return this.rawPath;
+  }
+
+  /** Closed simplified polygon. Null until `close()` succeeds. */
+  getAnchors(): readonly Point[] | null {
+    return this.anchors;
+  }
+
+  /** Index of the anchor currently being dragged, or null. */
+  getDragAnchorIndex(): number | null {
+    return this.dragIndex;
+  }
+
+  isClosed(): boolean {
+    return this.anchors !== null && this.anchors.length >= LassoModel.MIN_ANCHORS;
+  }
+
+  isEmpty(): boolean {
+    return this.rawPath === null && this.anchors === null;
+  }
+
+  // ── Mutators ───────────────────────────────────────────────────────
+
+  /** Update the simplification epsilon. Call when the image dimensions
+   *  change so the tolerance scales with the canvas. */
+  setSimplifyEpsilon(eps: number): void {
+    this.simplifyEpsilon = eps;
+  }
+
+  /** Begin a fresh raw path. Wipes any prior state including a closed
+   *  polygon and any in-progress anchor drag. */
+  startAt(point: Point): void {
+    this.rawPath = [{ x: point.x, y: point.y }];
+    this.anchors = null;
+    this.dragIndex = null;
+  }
+
+  /** Append a point to the raw path if it sits at least `minDist` away
+   *  from the last raw point. Noop when no raw path is active. */
+  addRawPoint(point: Point, minDist: number = LassoModel.DEFAULT_MIN_POINT_DIST): void {
+    if (!this.rawPath) return;
+    const last = this.rawPath[this.rawPath.length - 1];
+    const dx = point.x - last.x;
+    const dy = point.y - last.y;
+    if (dx * dx + dy * dy < minDist * minDist) return;
+    this.rawPath.push({ x: point.x, y: point.y });
+  }
+
+  /** Close the lasso: run Douglas-Peucker on the raw path. If the
+   *  resulting polygon has fewer than MIN_ANCHORS vertices, both raw
+   *  path and anchors are cleared and 0 is returned. Otherwise the
+   *  raw path is dropped and the simplified polygon becomes the
+   *  active anchor set; returns the anchor count. */
+  close(): number {
+    if (!this.rawPath) return 0;
+    const simplified = simplifyClosed(this.rawPath, this.simplifyEpsilon);
+    this.rawPath = null;
+    if (simplified.length < LassoModel.MIN_ANCHORS) {
+      this.anchors = null;
+      return 0;
+    }
+    this.anchors = simplified;
+    return simplified.length;
+  }
+
+  /** Move the anchor at index `idx` to a new position. Noop if the
+   *  lasso isn't closed or `idx` is out of bounds. */
+  moveAnchor(idx: number, point: Point): void {
+    if (!this.anchors) return;
+    if (idx < 0 || idx >= this.anchors.length) return;
+    this.anchors[idx] = { x: point.x, y: point.y };
+  }
+
+  /** Mark `idx` as the anchor being dragged. Caller should subsequently
+   *  call `moveAnchor()` on each pointer-move and `endDragAnchor()` on
+   *  pointer-up. */
+  beginDragAnchor(idx: number): void {
+    if (!this.anchors) return;
+    if (idx < 0 || idx >= this.anchors.length) return;
+    this.dragIndex = idx;
+  }
+
+  /** Clear any drag state. Idempotent. */
+  endDragAnchor(): void {
+    this.dragIndex = null;
+  }
+
+  /** Remove the anchor at `idx`. Refuses to delete if it would leave
+   *  fewer than MIN_ANCHORS — caller should check `isClosed()` after
+   *  to know whether the polygon survived. Returns true if removed. */
+  removeAnchor(idx: number): boolean {
+    if (!this.anchors) return false;
+    if (idx < 0 || idx >= this.anchors.length) return false;
+    if (this.anchors.length <= LassoModel.MIN_ANCHORS) return false;
+    this.anchors.splice(idx, 1);
+    return true;
+  }
+
+  /** Wipe all lasso state. Equivalent to "user pressed Esc" or
+   *  "controller decided the selection is no longer relevant". */
+  clear(): void {
+    this.rawPath = null;
+    this.anchors = null;
+    this.dragIndex = null;
+  }
+
+  // ── Geometry queries ───────────────────────────────────────────────
+
+  /** Find the anchor closest to (ix, iy), within `tolerance` pixels.
+   *  Returns the index, or null if no anchor is in range. */
+  hitAnchor(ix: number, iy: number, tolerance: number): number | null {
+    if (!this.anchors) return null;
+    const tolSq = tolerance * tolerance;
+    let closest = -1;
+    let closestDistSq = Infinity;
+    for (let i = 0; i < this.anchors.length; i++) {
+      const dx = this.anchors[i].x - ix;
+      const dy = this.anchors[i].y - iy;
+      const distSq = dx * dx + dy * dy;
+      if (distSq <= tolSq && distSq < closestDistSq) {
+        closest = i;
+        closestDistSq = distSq;
+      }
+    }
+    return closest >= 0 ? closest : null;
+  }
+
+  /** Axis-aligned bounding box of the closed polygon, in image pixels.
+   *  Null if the lasso isn't closed. */
+  getBoundingBox(): { x: number; y: number; w: number; h: number } | null {
+    if (!this.anchors || this.anchors.length === 0) return null;
+    let minX = Infinity;
+    let minY = Infinity;
+    let maxX = -Infinity;
+    let maxY = -Infinity;
+    for (const p of this.anchors) {
+      if (p.x < minX) minX = p.x;
+      if (p.y < minY) minY = p.y;
+      if (p.x > maxX) maxX = p.x;
+      if (p.y > maxY) maxY = p.y;
+    }
+    return { x: minX, y: minY, w: maxX - minX, h: maxY - minY };
+  }
+
+  /** Even-odd ray-casting point-in-polygon test. Returns false if the
+   *  lasso isn't closed. */
+  containsPoint(p: Point): boolean {
+    const poly = this.anchors;
+    if (!poly || poly.length < LassoModel.MIN_ANCHORS) return false;
+    let inside = false;
+    for (let i = 0, j = poly.length - 1; i < poly.length; j = i++) {
+      const xi = poly[i].x;
+      const yi = poly[i].y;
+      const xj = poly[j].x;
+      const yj = poly[j].y;
+      const intersect = yi > p.y !== yj > p.y && p.x < ((xj - xi) * (p.y - yi)) / (yj - yi) + xi;
+      if (intersect) inside = !inside;
+    }
+    return inside;
+  }
+}

--- a/tests/lib/lasso-model.test.ts
+++ b/tests/lib/lasso-model.test.ts
@@ -1,0 +1,266 @@
+import { describe, it, expect } from 'vitest';
+import { LassoModel } from '../../src/lib/lasso-model';
+
+/**
+ * Behavioural tests for the LassoModel state machine extracted from
+ * ar-editor-advanced.ts in #47/Phase-3a.
+ */
+describe('LassoModel', () => {
+  describe('lifecycle: empty → drawing → closed → empty', () => {
+    it('starts empty', () => {
+      const m = new LassoModel();
+      expect(m.isEmpty()).toBe(true);
+      expect(m.isClosed()).toBe(false);
+      expect(m.getRawPath()).toBeNull();
+      expect(m.getAnchors()).toBeNull();
+    });
+
+    it('startAt seeds a single-point raw path', () => {
+      const m = new LassoModel();
+      m.startAt({ x: 10, y: 20 });
+      expect(m.isEmpty()).toBe(false);
+      expect(m.isClosed()).toBe(false);
+      expect(m.getRawPath()).toEqual([{ x: 10, y: 20 }]);
+    });
+
+    it('startAt wipes any prior closed lasso', () => {
+      const m = new LassoModel(0.5);
+      // Build a triangle (>= MIN_ANCHORS) and close.
+      m.startAt({ x: 0, y: 0 });
+      m.addRawPoint({ x: 100, y: 0 });
+      m.addRawPoint({ x: 50, y: 100 });
+      m.close();
+      expect(m.isClosed()).toBe(true);
+
+      m.startAt({ x: 5, y: 5 });
+      expect(m.isClosed()).toBe(false);
+      expect(m.getRawPath()).toEqual([{ x: 5, y: 5 }]);
+    });
+
+    it('addRawPoint respects min-distance gate', () => {
+      const m = new LassoModel();
+      m.startAt({ x: 0, y: 0 });
+      m.addRawPoint({ x: 1, y: 0 }); // distSq=1 < 4 → skipped
+      m.addRawPoint({ x: 5, y: 0 }); // distSq=25 ≥ 4 → kept
+      expect(m.getRawPath()).toEqual([
+        { x: 0, y: 0 },
+        { x: 5, y: 0 },
+      ]);
+    });
+
+    it('addRawPoint is a noop when no raw path is active', () => {
+      const m = new LassoModel();
+      m.addRawPoint({ x: 1, y: 1 });
+      expect(m.getRawPath()).toBeNull();
+    });
+  });
+
+  describe('close(): simplification', () => {
+    it('returns 0 and clears state if too few unique points', () => {
+      const m = new LassoModel(0.5);
+      m.startAt({ x: 0, y: 0 });
+      m.addRawPoint({ x: 10, y: 0 });
+      // Only 2 anchors → below MIN_ANCHORS=3 even before simplification.
+      const count = m.close();
+      expect(count).toBe(0);
+      expect(m.isClosed()).toBe(false);
+      expect(m.getRawPath()).toBeNull();
+    });
+
+    it('reduces a near-collinear path to a low-vertex polygon', () => {
+      const m = new LassoModel(2.0);
+      // Walk a noisy "square" — 16 points, but the simplifier should
+      // reduce to roughly the 4 corners.
+      m.startAt({ x: 0, y: 0 });
+      for (let i = 1; i <= 4; i++) m.addRawPoint({ x: i * 25, y: 0 });
+      for (let i = 1; i <= 4; i++) m.addRawPoint({ x: 100, y: i * 25 });
+      for (let i = 1; i <= 4; i++) m.addRawPoint({ x: 100 - i * 25, y: 100 });
+      for (let i = 1; i <= 3; i++) m.addRawPoint({ x: 0, y: 100 - i * 25 });
+
+      const count = m.close();
+      expect(count).toBeGreaterThanOrEqual(3);
+      expect(count).toBeLessThan(16);
+      expect(m.isClosed()).toBe(true);
+      expect(m.getAnchors()).toHaveLength(count);
+    });
+  });
+
+  describe('drag flow', () => {
+    function buildSquare(): LassoModel {
+      const m = new LassoModel(0.5);
+      m.startAt({ x: 0, y: 0 });
+      m.addRawPoint({ x: 100, y: 0 });
+      m.addRawPoint({ x: 100, y: 100 });
+      m.addRawPoint({ x: 0, y: 100 });
+      m.close();
+      return m;
+    }
+
+    it('beginDragAnchor sets the index and ignores out-of-range', () => {
+      const m = buildSquare();
+      m.beginDragAnchor(2);
+      expect(m.getDragAnchorIndex()).toBe(2);
+
+      // Out-of-range is ignored, leaves prior index intact.
+      m.beginDragAnchor(99);
+      expect(m.getDragAnchorIndex()).toBe(2);
+    });
+
+    it('endDragAnchor clears the index', () => {
+      const m = buildSquare();
+      m.beginDragAnchor(0);
+      m.endDragAnchor();
+      expect(m.getDragAnchorIndex()).toBeNull();
+    });
+
+    it('moveAnchor updates anchor coords', () => {
+      const m = buildSquare();
+      m.moveAnchor(0, { x: -5, y: -5 });
+      expect(m.getAnchors()![0]).toEqual({ x: -5, y: -5 });
+    });
+
+    it('moveAnchor is a noop on closed=false or out-of-range', () => {
+      const open = new LassoModel();
+      open.moveAnchor(0, { x: 1, y: 1 }); // no anchors → noop
+      expect(open.getAnchors()).toBeNull();
+
+      const m = buildSquare();
+      const before = JSON.stringify(m.getAnchors());
+      m.moveAnchor(99, { x: 1, y: 1 });
+      expect(JSON.stringify(m.getAnchors())).toBe(before);
+    });
+  });
+
+  describe('removeAnchor', () => {
+    it('removes when above the minimum count', () => {
+      const m = new LassoModel(0.5);
+      m.startAt({ x: 0, y: 0 });
+      m.addRawPoint({ x: 100, y: 0 });
+      m.addRawPoint({ x: 100, y: 100 });
+      m.addRawPoint({ x: 50, y: 50 });
+      m.addRawPoint({ x: 0, y: 100 });
+      m.close();
+      const before = m.getAnchors()!.length;
+      const ok = m.removeAnchor(2);
+      expect(ok).toBe(true);
+      expect(m.getAnchors()!.length).toBe(before - 1);
+    });
+
+    it('refuses when at MIN_ANCHORS exactly', () => {
+      const m = new LassoModel(0.5);
+      m.startAt({ x: 0, y: 0 });
+      m.addRawPoint({ x: 100, y: 0 });
+      m.addRawPoint({ x: 50, y: 100 });
+      m.close();
+      expect(m.getAnchors()!.length).toBe(3);
+      expect(m.removeAnchor(1)).toBe(false);
+      expect(m.getAnchors()!.length).toBe(3);
+    });
+  });
+
+  describe('hitAnchor', () => {
+    function square(): LassoModel {
+      const m = new LassoModel(0.5);
+      m.startAt({ x: 0, y: 0 });
+      m.addRawPoint({ x: 100, y: 0 });
+      m.addRawPoint({ x: 100, y: 100 });
+      m.addRawPoint({ x: 0, y: 100 });
+      m.close();
+      return m;
+    }
+
+    it('returns null when no anchor is within tolerance', () => {
+      const m = square();
+      expect(m.hitAnchor(50, 50, 5)).toBeNull();
+    });
+
+    it('returns the closest anchor index within tolerance', () => {
+      const m = square();
+      // (102, 1) is 2.236 from (100,0) and 99 from the next corner — pick 1.
+      expect(m.hitAnchor(102, 1, 5)).toBe(1);
+    });
+
+    it('returns null on an empty lasso', () => {
+      const m = new LassoModel();
+      expect(m.hitAnchor(0, 0, 100)).toBeNull();
+    });
+  });
+
+  describe('getBoundingBox', () => {
+    it('returns null when not closed', () => {
+      const m = new LassoModel();
+      expect(m.getBoundingBox()).toBeNull();
+    });
+
+    it('returns the AABB of the closed polygon', () => {
+      const m = new LassoModel(0.5);
+      m.startAt({ x: 10, y: 20 });
+      m.addRawPoint({ x: 110, y: 20 });
+      m.addRawPoint({ x: 110, y: 80 });
+      m.addRawPoint({ x: 10, y: 80 });
+      m.close();
+      expect(m.getBoundingBox()).toEqual({ x: 10, y: 20, w: 100, h: 60 });
+    });
+  });
+
+  describe('containsPoint', () => {
+    function square(): LassoModel {
+      const m = new LassoModel(0.5);
+      m.startAt({ x: 0, y: 0 });
+      m.addRawPoint({ x: 100, y: 0 });
+      m.addRawPoint({ x: 100, y: 100 });
+      m.addRawPoint({ x: 0, y: 100 });
+      m.close();
+      return m;
+    }
+
+    it('returns true for an interior point', () => {
+      expect(square().containsPoint({ x: 50, y: 50 })).toBe(true);
+    });
+
+    it('returns false for an exterior point', () => {
+      expect(square().containsPoint({ x: 200, y: 50 })).toBe(false);
+    });
+
+    it('returns false on an empty lasso', () => {
+      expect(new LassoModel().containsPoint({ x: 0, y: 0 })).toBe(false);
+    });
+  });
+
+  describe('clear', () => {
+    it('wipes all state', () => {
+      const m = new LassoModel(0.5);
+      m.startAt({ x: 0, y: 0 });
+      m.addRawPoint({ x: 100, y: 0 });
+      m.addRawPoint({ x: 50, y: 100 });
+      m.close();
+      m.beginDragAnchor(0);
+
+      m.clear();
+      expect(m.isEmpty()).toBe(true);
+      expect(m.isClosed()).toBe(false);
+      expect(m.getDragAnchorIndex()).toBeNull();
+    });
+  });
+
+  describe('setSimplifyEpsilon', () => {
+    it('influences a subsequent close()', () => {
+      // Same path simplified at two different tolerances should yield
+      // different anchor counts.
+      function pathInto(m: LassoModel) {
+        m.startAt({ x: 0, y: 0 });
+        for (let i = 1; i <= 9; i++) m.addRawPoint({ x: i * 10, y: i * 0.4 });
+        m.addRawPoint({ x: 100, y: 100 });
+        m.addRawPoint({ x: 0, y: 100 });
+      }
+      const tight = new LassoModel(0.5);
+      pathInto(tight);
+      tight.close();
+      const loose = new LassoModel(0.5);
+      pathInto(loose);
+      loose.setSimplifyEpsilon(20);
+      loose.close();
+      expect(loose.getAnchors()?.length ?? 0).toBeLessThanOrEqual(tight.getAnchors()?.length ?? 0);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Phase 3a of #47. Pulls the lasso state machine out of `ar-editor-advanced.ts` (the 2185 LOC monster) into a pure `src/lib/lasso-model.ts`. First slice of Phase 3 — three more (history reuse, SAM controller, shrink) follow.

## What moved

`src/lib/lasso-model.ts` (203 LOC) owns:
- **State**: `rawPath`, `anchors`, `dragIndex` (was 3 separate fields on the component)
- **Lifecycle**: `startAt()` → `addRawPoint()` → `close()` → drag/move/remove → `clear()`
- **Geometry**: `hitAnchor()`, `getBoundingBox()`, `containsPoint()` (even-odd ray casting)

Reuses `simplifyClosed()` from existing `src/components/lasso-simplify.ts` — no algorithm change. The model just packages the state + transitions that used to live as 3 fields + inline math in the component.

## What stayed in the component

- Render to canvas (`drawLassoOverlay`)
- Pointer-event plumbing + coordinate conversion
- Action call sites (`processRoi`, `rasterizePolygon`, `refineWithSam`) — they now read via `lasso.getAnchors()` and `[...anchors]` to get a mutable copy for downstream APIs

## Tests

23 new tests in `tests/lib/lasso-model.test.ts` covering the state machine end-to-end: lifecycle, simplification, drag flow, removeAnchor with MIN_ANCHORS guard, hitAnchor with tolerance, bounding box, containsPoint, clear, setSimplifyEpsilon.

| Behaviour | Before this PR | After |
|-----------|----------------|-------|
| Lasso anchor add / drag / close | not covered (audit-#98) | **23 unit tests in lib** |
| Polygon simplification | not covered | **2 tests** |
| Hit-test (`hitAnchor`) | not covered | **3 tests** |
| Anchor removal at MIN_ANCHORS | not covered | **2 tests** |

## Validation gates

| Gate | Before | After |
|------|--------|-------|
| `npm test` | 851/851 | **874/874** ✅ (+23 new) |
| `npm run typecheck` | clean | **clean** ✅ |
| `npm run build` | success | **success** ✅ |
| `index-*.js` bundle | 468.55 kB / 126.33 gzip | 470.05 kB / 126.96 gzip |
| Bundle delta vs Phase-2 | — | **+1.50 kB raw / +0.63 kB gzip** (+0.32% / +0.50%) |
| Bundle delta vs pre-split-baseline (cumulative) | — | +3.14 kB raw / +1.30 kB gzip (**+0.67% / +1.03%**) |

Still well under the 5% gate.

## Phase trajectory

| Stage | Component | LOC delta |
|-------|-----------|-----------|
| Phase 1a | ar-app.ts | −125 |
| Phase 1b | ar-app.ts | −84 |
| Phase 2 | ar-editor.ts | −29 |
| **Phase 3a (this PR)** | **ar-editor-advanced.ts** | **−63 (raw); −12 net after wiring** |

## Test plan

- [x] Local typecheck + 874/874 vitest green.
- [x] `npm run build` success.
- [ ] Manual smoke (`npm run dev`):
  - [ ] Drop image → Advanced editor → lasso tool draws a freehand path → release → polygon shows simplified anchors.
  - [ ] Drag an anchor — moves correctly.
  - [ ] Double-click anchor (with > 3 anchors) — anchor disappears.
  - [ ] Esc clears the lasso.
  - [ ] After SAM/refine action, lasso clears.

## Roll-back

`git reset --hard pre-split-baseline` returns dev to pre-Phase-1 state. This Phase 3a PR can be reverted alone too.

Refs #47.