### PR TITLE
refactor(ar-editor-advanced): reuse HistoryManager for working canvas (#47 Phase 3b)

### DIFF
--- a/src/components/ar-editor-advanced.ts
+++ b/src/components/ar-editor-advanced.ts
@@ -44,6 +44,7 @@ import { PATCHMATCH_PARAMS } from '../pipeline/constants';
 import { t } from '../i18n';
 import { type Point } from './lasso-simplify';
 import { LassoModel } from '../lib/lasso-model';
+import { HistoryManager } from '../lib/history-manager';
 
 const PAD_RATIO = 0.25;
 const DEFAULT_BRUSH = 24;
@@ -147,13 +148,11 @@ export class ArEditorAdvanced extends HTMLElement {
   private selectionOverlay: HTMLCanvasElement | null = null;
   private selectionHistory: Uint8Array[] = [];
 
-  // Undo/redo stacks of full RGBA snapshots (Uint8ClampedArray, image size).
+  // Undo/redo of full RGBA snapshots (Uint8ClampedArray, image size).
   // Full snapshots match ar-editor's pattern — simple, robust, and still
   // cheap to swap in. Depth is budget-capped per-image so we don't OOM on
   // 20-100MP payloads; see `computeMaxHistory`.
-  private undoStack: Uint8ClampedArray[] = [];
-  private redoStack: Uint8ClampedArray[] = [];
-  private maxHistory = 8;
+  private workingHistory = new HistoryManager<Uint8ClampedArray>(8);
 
   private abort: AbortController | null = null;
 
@@ -190,10 +189,11 @@ export class ArEditorAdvanced extends HTMLElement {
   }
 
   private resetHistory(): void {
-    this.undoStack = [];
-    this.redoStack = [];
+    this.workingHistory.clear();
     if (this.current) {
-      this.maxHistory = this.computeMaxHistory(this.current.width, this.current.height);
+      this.workingHistory.setMaxEntries(
+        this.computeMaxHistory(this.current.width, this.current.height),
+      );
     }
     this.syncHistoryUI();
   }
@@ -217,19 +217,16 @@ export class ArEditorAdvanced extends HTMLElement {
   private pushUndo(): void {
     const snap = this.snapshotWorking();
     if (!snap) return;
-    this.undoStack.push(snap);
-    if (this.undoStack.length > this.maxHistory) this.undoStack.shift();
-    // Any new action invalidates the redo branch.
-    this.redoStack = [];
+    this.workingHistory.push(snap);
     this.syncHistoryUI();
   }
 
   private undo(): void {
     if (this.tool === 'lasso' && this.undoSelection()) return;
-    if (this.undoStack.length === 0) return;
-    const before = this.undoStack.pop()!;
-    const after = this.snapshotWorking();
-    if (after) this.redoStack.push(after);
+    const current = this.snapshotWorking();
+    if (!current) return;
+    const before = this.workingHistory.undo(current);
+    if (!before) return;
     this.restoreWorking(before);
     this.clearLasso();
     this.redrawDisplay();
@@ -237,10 +234,10 @@ export class ArEditorAdvanced extends HTMLElement {
   }
 
   private redo(): void {
-    if (this.redoStack.length === 0) return;
-    const next = this.redoStack.pop()!;
     const current = this.snapshotWorking();
-    if (current) this.undoStack.push(current);
+    if (!current) return;
+    const next = this.workingHistory.redo(current);
+    if (!next) return;
     this.restoreWorking(next);
     this.clearLasso();
     this.redrawDisplay();
@@ -250,8 +247,8 @@ export class ArEditorAdvanced extends HTMLElement {
   private syncHistoryUI(): void {
     const undoBtn = this.shadowRoot?.getElementById('undo') as HTMLButtonElement | null;
     const redoBtn = this.shadowRoot?.getElementById('redo') as HTMLButtonElement | null;
-    if (undoBtn) undoBtn.disabled = this.busy || this.undoStack.length === 0;
-    if (redoBtn) redoBtn.disabled = this.busy || this.redoStack.length === 0;
+    if (undoBtn) undoBtn.disabled = this.busy || !this.workingHistory.canUndo();
+    if (redoBtn) redoBtn.disabled = this.busy || !this.workingHistory.canRedo();
   }
 
   private syncBusyUI(): void {

--- a/src/lib/history-manager.ts
+++ b/src/lib/history-manager.ts
@@ -18,8 +18,21 @@
 export class HistoryManager<T> {
   private undoStack: T[] = [];
   private redoStack: T[] = [];
+  private maxEntries: number;
 
-  constructor(private readonly maxEntries: number = 12) {}
+  constructor(maxEntries: number = 12) {
+    this.maxEntries = maxEntries;
+  }
+
+  /** Adjust the cap. Useful when the underlying state changes size and
+   *  the memory budget needs re-tuning (e.g. ar-editor-advanced computes
+   *  cap from image dimensions). Trims existing stacks to fit so we
+   *  don't carry stale entries beyond the new budget. */
+  setMaxEntries(n: number): void {
+    this.maxEntries = n;
+    while (this.undoStack.length > this.maxEntries) this.undoStack.shift();
+    while (this.redoStack.length > this.maxEntries) this.redoStack.shift();
+  }
 
   /** Push a new state. Drops the oldest entry once we exceed the cap.
    *  Pushing always wipes the redo stack — once the user starts a fresh

--- a/tests/lib/history-manager.test.ts
+++ b/tests/lib/history-manager.test.ts
@@ -121,6 +121,44 @@ describe('HistoryManager', () => {
     });
   });
 
+  describe('setMaxEntries', () => {
+    it('trims existing entries when shrinking the cap', () => {
+      const h = new HistoryManager<number>(10);
+      for (let i = 0; i < 8; i++) h.push(i);
+      h.setMaxEntries(3);
+
+      // 8 pushed, cap shrunk to 3 → only [5, 6, 7] should remain
+      const seen: number[] = [];
+      let cur = 99;
+      while (h.canUndo()) {
+        const v = h.undo(cur)!;
+        seen.push(v);
+        cur = v;
+      }
+      expect(seen).toEqual([7, 6, 5]);
+    });
+
+    it('lets future pushes grow up to the new cap', () => {
+      const h = new HistoryManager<number>(2);
+      h.push(1);
+      h.push(2);
+      h.setMaxEntries(5);
+      h.push(3);
+      h.push(4);
+      h.push(5);
+
+      // 5 entries, cap 5 → all preserved
+      const seen: number[] = [];
+      let cur = 99;
+      while (h.canUndo()) {
+        const v = h.undo(cur)!;
+        seen.push(v);
+        cur = v;
+      }
+      expect(seen).toEqual([5, 4, 3, 2, 1]);
+    });
+  });
+
   describe('works with non-trivial state types', () => {
     it('handles Uint8ClampedArray snapshots without issue', () => {
       const h = new HistoryManager<Uint8ClampedArray>();


### PR DESCRIPTION
## Summary

Phase 3b of #47. Retires the bespoke `undoStack` / `redoStack` / `maxHistory` triplet on `ar-editor-advanced.ts` and replaces them with the `HistoryManager<Uint8ClampedArray>` primitive that already powers `ar-editor.ts` since Phase 2.

This is the cleanest payoff in the whole refactor — it deletes a duplicate, no new abstraction, just centralization.

## What moved

- 3 instance fields → 1 `HistoryManager<Uint8ClampedArray>(8)`
- 4 methods rewritten as thin delegates: `pushUndo`, `undo`, `redo`, `resetHistory`, plus `syncHistoryUI`'s queries

`HistoryManager` gains `setMaxEntries(n)` so the cap can be re-tuned per image. Advanced editor uses this in `resetHistory()` after computing budget from image dimensions (`computeMaxHistory`: `floor(200MB / bytesPerSnapshot)` clamped to `[2, 8]`).

## What stayed

`selectionHistory` (the SAM/RMBG mask stack) keeps its own raw array. It's:
- **Undo-only** (no redo branch)
- **Fixed cap** of 20
- Different state type (`Uint8Array`, not `Uint8ClampedArray`)

Forcing it into `HistoryManager` would push useless redo copies onto an unused stack or require a parallel undo-only abstraction. Not worth Phase-3b scope.

## Subtle behavior tweak

In the new `undo()` / `redo()`, if `snapshotWorking()` returns null (working/current is null), the code bails before touching history. The old code would still pop the stack but skip the redo-push when snapshot was null — slightly worse than no-op (lost entry).

Net effect: no observable change in normal use, slightly safer in degenerate states (race with image teardown).

## Validation gates

| Gate | Before | After |
|------|--------|-------|
| `npm test` | 874/874 | **876/876** ✅ (+2 new for setMaxEntries) |
| `npm run typecheck` | clean | **clean** ✅ |
| `npm run build` | success | **success** ✅ |
| `index-*.js` bundle | 470.05 kB / 126.96 gzip | 470.10 kB / 126.97 gzip |
| Bundle delta vs Phase-3a | — | **+0.05 kB raw / +0.01 kB gzip** (negligible) |
| Bundle delta vs pre-split-baseline (cumulative) | — | +3.19 kB raw / +1.31 kB gzip (**+0.68% / +1.04%**) |

## Test plan

- [x] Local `npm test` 876/876 green.
- [x] Local typecheck + build green.
- [ ] Manual smoke (`npm run dev`):
  - [ ] Advanced editor: brush stroke → undo → state matches before stroke.
  - [ ] Brush A → Brush B → Undo → Brush A state restored. Redo brings back B.
  - [ ] Pile up > 8 actions on a smallish image, oldest gets evicted (8 max).
  - [ ] Drop a giant image (e.g. 4096×4096); history depth shrinks per `computeMaxHistory`.
  - [ ] Lasso undo still falls back to selectionHistory before working stack (preserved branch in `undo()`).

## Roll-back

`git reset --hard pre-split-baseline` returns dev to pre-Phase-1 state. This Phase 3b PR is independently revertable.

Refs #47.