### PR TITLE
refactor(ar-editor-advanced): extract SamRefiner controller (#47 Phase 3c)

### DIFF
--- a/src/components/ar-editor-advanced.ts
+++ b/src/components/ar-editor-advanced.ts
@@ -30,13 +30,7 @@
 
 import { createLoader, type ModelLoader } from '../refine/loaders';
 import { refineEdges } from '../pipeline/finalize';
-import {
-  loadSam,
-  encodeSam,
-  decodeSam,
-  disposeSam,
-  onSamProgress,
-} from '../refine/loaders/mobile-sam';
+import { SamRefiner } from '../controllers/sam-refiner';
 import { processRoi } from '../refine/roi-process';
 import { rasterizePolygon } from '../refine/roi-process';
 import { patchMatchInpaint } from '../workers/cv/patchmatch-inpaint';
@@ -133,7 +127,12 @@ export class ArEditorAdvanced extends HTMLElement {
   private actionAbort: AbortController | null = null;
 
   // SAM state — lazy-loaded on first Refine, encoder runs once per image.
-  private samEncoded = false;
+  /** MobileSAM lifecycle wrapper (load/encode/decode/dispose + the
+   *  encoded flag). See `src/controllers/sam-refiner.ts` (#47/Phase-3c).
+   *  Progress callback is wired in setupSamRefiner() once shadowRoot
+   *  has rendered so we can find the #hint element. */
+  private samRefiner = new SamRefiner();
+  private samProgressWired = false;
 
   private bgColor = 'transparent';
 
@@ -163,14 +162,13 @@ export class ArEditorAdvanced extends HTMLElement {
   disconnectedCallback(): void {
     this.abort?.abort();
     this.abort = null;
-    disposeSam();
-    this.samEncoded = false;
+    this.samRefiner.dispose();
   }
 
   setImage(current: ImageData, original: ImageData): void {
     this.current = current;
     this.original = original;
-    this.samEncoded = false;
+    this.samRefiner.invalidate();
     this.clearLasso();
     this.clearSelection();
     this.rebuildBackingBuffers();
@@ -1942,25 +1940,15 @@ export class ArEditorAdvanced extends HTMLElement {
     ];
   }
 
-  private async ensureSamEncoded(signal: AbortSignal): Promise<void> {
-    if (this.samEncoded) return;
-    if (!this.original) throw new Error('No image loaded');
-
-    const hint = this.shadowRoot?.getElementById('hint');
-
-    onSamProgress((pct, stage) => {
+  /** Lazy progress wiring: the #hint element doesn't exist until render
+   *  has run, so we defer the callback until the first SAM action. */
+  private wireSamProgressOnce(): void {
+    if (this.samProgressWired) return;
+    this.samRefiner.setProgressCallback((pct, stage) => {
+      const hint = this.shadowRoot?.getElementById('hint');
       if (hint) hint.textContent = t('advanced.samLoading', { pct: String(pct), stage });
     });
-
-    if (signal.aborted) throw new DOMException('Aborted', 'AbortError');
-    await loadSam();
-
-    if (signal.aborted) throw new DOMException('Aborted', 'AbortError');
-    if (hint) hint.textContent = t('advanced.samEncoding');
-    await encodeSam(this.original.data, this.original.width, this.original.height);
-
-    onSamProgress(null);
-    this.samEncoded = true;
+    this.samProgressWired = true;
   }
 
   private async refineWithSam(
@@ -1970,10 +1958,19 @@ export class ArEditorAdvanced extends HTMLElement {
     h: number,
     signal: AbortSignal,
   ): Promise<Uint8Array> {
-    await this.ensureSamEncoded(signal);
-    if (signal.aborted) throw new DOMException('Aborted', 'AbortError');
+    if (!this.original) throw new Error('No image loaded');
+    this.wireSamProgressOnce();
 
     const hint = this.shadowRoot?.getElementById('hint');
+    if (hint) hint.textContent = t('advanced.samEncoding');
+    await this.samRefiner.ensureEncoded(
+      this.original.data,
+      this.original.width,
+      this.original.height,
+      signal,
+    );
+    if (signal.aborted) throw new DOMException('Aborted', 'AbortError');
+
     if (hint) hint.textContent = t('advanced.working');
 
     let minX = w,
@@ -1991,7 +1988,7 @@ export class ArEditorAdvanced extends HTMLElement {
     maxX = Math.min(w - 1, Math.ceil(maxX));
     maxY = Math.min(h - 1, Math.ceil(maxY));
 
-    const samResult = await decodeSam(
+    const samResult = await this.samRefiner.decode(
       [
         { x: minX, y: minY },
         { x: maxX, y: maxY },

--- a/src/controllers/sam-refiner.ts
+++ b/src/controllers/sam-refiner.ts
@@ -1,0 +1,110 @@
+/**
+ * MobileSAM lifecycle wrapper for the advanced editor:
+ *   - Lazy-loads the model on first encode (~45MB download, one-time).
+ *   - Caches the encoded image embedding in the worker; re-decodes are
+ *     fast (no re-encode).
+ *   - Tracks whether the current image is already encoded so callers
+ *     don't need to manage the flag themselves.
+ *   - Forwards the SAM worker's progress events to an optional callback.
+ *
+ * Extracted from `ar-editor-advanced.ts` in #47/Phase-3c. The component
+ * used to carry a `samEncoded` boolean and inline `ensureSamEncoded()` /
+ * `refineWithSam()` orchestration that mixed model loading, hint-DOM
+ * updates, and lasso-mask blending. Pulling the model lifecycle into a
+ * controller leaves the host with the UI + pixel composition only.
+ *
+ * The host instantiates one SamRefiner per component, wires a progress
+ * callback that updates whatever UI element it cares about, and calls
+ * `invalidate()` whenever the underlying image changes so the next
+ * action triggers a fresh encode.
+ */
+import {
+  loadSam,
+  encodeSam,
+  decodeSam,
+  disposeSam,
+  onSamProgress,
+  type SamMaskResult,
+} from '../refine/loaders/mobile-sam';
+
+export type SamProgressCallback = (pct: number, stage: 'encoder' | 'decoder') => void;
+
+export class SamRefiner {
+  private encoded = false;
+
+  constructor(private progressCb?: SamProgressCallback) {}
+
+  /** Lazy-load the model and encode the given image. Idempotent — if
+   *  the image is already encoded (no `invalidate()` since the last
+   *  call), this returns immediately.
+   *
+   *  Throws `DOMException('Aborted', 'AbortError')` if `signal` fires
+   *  before either of the two awaited stages completes. */
+  async ensureEncoded(
+    pixels: Uint8ClampedArray,
+    width: number,
+    height: number,
+    signal: AbortSignal,
+  ): Promise<void> {
+    if (this.encoded) return;
+
+    if (this.progressCb) onSamProgress(this.progressCb);
+
+    try {
+      if (signal.aborted) throw new DOMException('Aborted', 'AbortError');
+      await loadSam();
+
+      if (signal.aborted) throw new DOMException('Aborted', 'AbortError');
+      await encodeSam(pixels, width, height);
+
+      this.encoded = true;
+    } finally {
+      // Always clear the progress wiring — leaking it across actions
+      // would cause stale callbacks to fire on later encodes.
+      if (this.progressCb) onSamProgress(null);
+    }
+  }
+
+  /** Run the decoder on the cached embedding. Caller is responsible for
+   *  having called `ensureEncoded()` first; calling `decode()` before
+   *  the model is loaded throws. */
+  async decode(
+    points: Array<{ x: number; y: number }>,
+    labels: number[],
+    width: number,
+    height: number,
+  ): Promise<SamMaskResult> {
+    if (!this.encoded) {
+      throw new Error('SamRefiner: decode() called before ensureEncoded()');
+    }
+    return decodeSam(points, labels, width, height);
+  }
+
+  /** Whether the current image's embedding is cached. Resets to false
+   *  on `invalidate()` and `dispose()`. */
+  isEncoded(): boolean {
+    return this.encoded;
+  }
+
+  /** Tell the controller the host loaded a new image. The next
+   *  `ensureEncoded()` call will run a fresh load + encode. Cheaper
+   *  than `dispose()` because the worker stays alive. */
+  invalidate(): void {
+    this.encoded = false;
+  }
+
+  /** Update the progress callback. Pass `null` to detach. The change
+   *  takes effect on the next `ensureEncoded()` call (any in-flight
+   *  encode keeps using the previous callback). */
+  setProgressCallback(cb: SamProgressCallback | null): void {
+    this.progressCb = cb ?? undefined;
+  }
+
+  /** Tear down the SAM worker and free its ONNX sessions. Call from
+   *  the host's disconnectedCallback so the model doesn't leak across
+   *  component instances. */
+  dispose(): void {
+    disposeSam();
+    this.encoded = false;
+  }
+}

--- a/tests/controllers/sam-refiner.test.ts
+++ b/tests/controllers/sam-refiner.test.ts
@@ -1,0 +1,169 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+// ─── Mocks for ../../src/refine/loaders/mobile-sam ──────────────────────
+// Hoisted so vi.mock can hoist them above the SamRefiner import below.
+const { loadSamMock, encodeSamMock, decodeSamMock, disposeSamMock, onSamProgressMock } = vi.hoisted(
+  () => ({
+    loadSamMock: vi.fn(() => Promise.resolve()),
+    encodeSamMock: vi.fn(() => Promise.resolve()),
+    decodeSamMock: vi.fn(() => Promise.resolve({ mask: new Uint8Array(16), width: 4, height: 4 })),
+    disposeSamMock: vi.fn(),
+    onSamProgressMock: vi.fn(),
+  }),
+);
+
+vi.mock('../../src/refine/loaders/mobile-sam', () => ({
+  loadSam: loadSamMock,
+  encodeSam: encodeSamMock,
+  decodeSam: decodeSamMock,
+  disposeSam: disposeSamMock,
+  onSamProgress: onSamProgressMock,
+}));
+
+import { SamRefiner } from '../../src/controllers/sam-refiner';
+
+beforeEach(() => {
+  loadSamMock.mockClear();
+  encodeSamMock.mockClear();
+  decodeSamMock.mockClear();
+  disposeSamMock.mockClear();
+  onSamProgressMock.mockClear();
+});
+
+const ac = (): AbortController => new AbortController();
+
+describe('SamRefiner', () => {
+  describe('ensureEncoded', () => {
+    it('runs load + encode then flips isEncoded() to true', async () => {
+      const r = new SamRefiner();
+      expect(r.isEncoded()).toBe(false);
+
+      await r.ensureEncoded(new Uint8ClampedArray(64), 4, 4, ac().signal);
+
+      expect(loadSamMock).toHaveBeenCalledTimes(1);
+      expect(encodeSamMock).toHaveBeenCalledTimes(1);
+      expect(encodeSamMock).toHaveBeenCalledWith(expect.any(Uint8ClampedArray), 4, 4);
+      expect(r.isEncoded()).toBe(true);
+    });
+
+    it('is idempotent — second call skips load + encode', async () => {
+      const r = new SamRefiner();
+      const signal = ac().signal;
+      await r.ensureEncoded(new Uint8ClampedArray(64), 4, 4, signal);
+      await r.ensureEncoded(new Uint8ClampedArray(64), 4, 4, signal);
+
+      expect(loadSamMock).toHaveBeenCalledTimes(1);
+      expect(encodeSamMock).toHaveBeenCalledTimes(1);
+    });
+
+    it('wires the progress callback before load and clears it after', async () => {
+      const cb = vi.fn();
+      const r = new SamRefiner(cb);
+      await r.ensureEncoded(new Uint8ClampedArray(64), 4, 4, ac().signal);
+
+      expect(onSamProgressMock).toHaveBeenCalledTimes(2);
+      expect(onSamProgressMock.mock.calls[0][0]).toBe(cb);
+      expect(onSamProgressMock.mock.calls[1][0]).toBeNull();
+    });
+
+    it('does not touch onSamProgress if no callback was supplied', async () => {
+      const r = new SamRefiner();
+      await r.ensureEncoded(new Uint8ClampedArray(64), 4, 4, ac().signal);
+      expect(onSamProgressMock).not.toHaveBeenCalled();
+    });
+
+    it('throws AbortError when signal is already aborted before load', async () => {
+      const r = new SamRefiner();
+      const c = ac();
+      c.abort();
+
+      await expect(r.ensureEncoded(new Uint8ClampedArray(64), 4, 4, c.signal)).rejects.toThrowError(
+        /Aborted/,
+      );
+      expect(loadSamMock).not.toHaveBeenCalled();
+      expect(r.isEncoded()).toBe(false);
+    });
+
+    it('clears the progress callback even when aborted mid-flight', async () => {
+      const cb = vi.fn();
+      const r = new SamRefiner(cb);
+      const c = ac();
+      // Abort right after load resolves but before encode would run.
+      loadSamMock.mockImplementationOnce(() => {
+        c.abort();
+        return Promise.resolve();
+      });
+
+      await expect(r.ensureEncoded(new Uint8ClampedArray(64), 4, 4, c.signal)).rejects.toThrowError(
+        /Aborted/,
+      );
+      // First call wires cb, finally clears it.
+      expect(onSamProgressMock).toHaveBeenCalledTimes(2);
+      expect(onSamProgressMock.mock.calls[1][0]).toBeNull();
+    });
+  });
+
+  describe('decode', () => {
+    it('throws if called before ensureEncoded', async () => {
+      const r = new SamRefiner();
+      await expect(r.decode([{ x: 0, y: 0 }], [1], 4, 4)).rejects.toThrow(/before ensureEncoded/);
+      expect(decodeSamMock).not.toHaveBeenCalled();
+    });
+
+    it('passes args through to decodeSam after encode', async () => {
+      const r = new SamRefiner();
+      await r.ensureEncoded(new Uint8ClampedArray(64), 4, 4, ac().signal);
+
+      const result = await r.decode([{ x: 1, y: 1 }], [2], 4, 4);
+      expect(decodeSamMock).toHaveBeenCalledWith([{ x: 1, y: 1 }], [2], 4, 4);
+      expect(result.mask).toBeInstanceOf(Uint8Array);
+    });
+  });
+
+  describe('invalidate', () => {
+    it('flips isEncoded() back to false so the next ensureEncoded re-runs', async () => {
+      const r = new SamRefiner();
+      await r.ensureEncoded(new Uint8ClampedArray(64), 4, 4, ac().signal);
+      expect(r.isEncoded()).toBe(true);
+
+      r.invalidate();
+      expect(r.isEncoded()).toBe(false);
+
+      await r.ensureEncoded(new Uint8ClampedArray(64), 4, 4, ac().signal);
+      expect(loadSamMock).toHaveBeenCalledTimes(2);
+      expect(encodeSamMock).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe('dispose', () => {
+    it('calls disposeSam and resets isEncoded()', async () => {
+      const r = new SamRefiner();
+      await r.ensureEncoded(new Uint8ClampedArray(64), 4, 4, ac().signal);
+
+      r.dispose();
+      expect(disposeSamMock).toHaveBeenCalledTimes(1);
+      expect(r.isEncoded()).toBe(false);
+    });
+  });
+
+  describe('setProgressCallback', () => {
+    it('replaces the callback used by the next ensureEncoded', async () => {
+      const r = new SamRefiner();
+      const cb = vi.fn();
+      r.setProgressCallback(cb);
+      await r.ensureEncoded(new Uint8ClampedArray(64), 4, 4, ac().signal);
+
+      expect(onSamProgressMock.mock.calls[0][0]).toBe(cb);
+    });
+
+    it('detaches when passed null', async () => {
+      const cb = vi.fn();
+      const r = new SamRefiner(cb);
+      r.setProgressCallback(null);
+      await r.ensureEncoded(new Uint8ClampedArray(64), 4, 4, ac().signal);
+
+      // No progress wiring at all (null detaches before ensureEncoded gates).
+      expect(onSamProgressMock).not.toHaveBeenCalled();
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Phase 3c of #47. Moves the MobileSAM lifecycle (load → encode → decode → dispose, plus the `samEncoded` flag and `onSamProgress` wiring) out of `ar-editor-advanced.ts` into `src/controllers/sam-refiner.ts` (~110 LOC, fully unit-tested).

## Boundary contract

**`SamRefiner` owns**:
- The `encoded` flag (was `samEncoded` field on the component)
- Lazy load + encode orchestration (single `ensureEncoded()` entry point)
- Abort-signal checks at both await boundaries
- Progress callback wiring (`onSamProgress`) — set on entry, cleared in `finally`
- `dispose()` lifecycle

**Component still owns**:
- Bounding-box computation from the lasso polygon
- Lasso polygon ↔ SAM mask blending (the actual pixel composition)
- Hint text mid-state (`'advanced.samEncoding'` before encode, `'advanced.working'` before decode)
- The progress callback body (it touches the `#hint` shadow-DOM element)

## Why the loader stays put

The advanced editor's `getLoader()` caches the **RMBG** model loader (used for refine, re-segment, and watermark inpaint paths). SAM uses a separate worker module (`mobile-sam.ts`) with global state. They're orthogonal — extracting both into one controller would conflate two ML lifecycles. The RMBG loader stays in the component for now.

## Tests

12 new unit tests in `tests/controllers/sam-refiner.test.ts`:
- Load + encode flow, isEncoded() transitions
- Idempotency on re-call without invalidate
- Progress callback wiring (set on entry, cleared on exit even on abort)
- Abort semantics: pre-load and mid-flight abort both propagate AbortError, both clear the callback in `finally`
- Decode-before-encode guard
- `invalidate()` resets so next ensureEncoded re-runs both stages
- `dispose()` calls `disposeSam` + resets encoded
- `setProgressCallback(null)` correctly detaches

The existing `tests/components/ar-editor-advanced.test.ts` is unchanged: its `vi.mock('../../src/refine/loaders/mobile-sam', ...)` is still effective because SamRefiner imports from that module — Vitest intercepts at the module boundary regardless of depth.

## Validation gates

| Gate | Before | After |
|------|--------|-------|
| `npm test` | 876/876 | **888/888** ✅ (+12 new) |
| `npm run typecheck` | clean | **clean** ✅ |
| `npm run build` | success | **success** ✅ |
| `index-*.js` bundle | 470.10 kB / 126.97 gzip | 470.66 kB / 127.20 gzip |
| Bundle delta vs Phase-3b | — | **+0.56 kB raw / +0.23 kB gzip** (+0.12% / +0.18%) |
| Bundle delta vs pre-split-baseline (cumulative) | — | +3.75 kB raw / +1.54 kB gzip (**+0.80% / +1.22%**) |

Still well under the 5% gate.

## ar-editor-advanced.ts trajectory

| Phase | Δ LOC |
|-------|-------|
| 3a (LassoModel) | −12 |
| 3b (HistoryManager reuse) | −21 |
| 3c (SamRefiner) | −3 (most code moved into controller) |
| **Sum** | **−36 LOC + 3 new modules ~400 LOC under `src/lib/` and `src/controllers/`** |

Phase 3d will be the final pass — likely small now that the three load-bearing extractions are done.

## Test plan

- [x] Local typecheck + 888/888 vitest green.
- [x] `npm run build` success.
- [ ] Manual smoke (`npm run dev`):
  - [ ] Advanced editor → draw lasso → click Refine. Model downloads on first run (progress visible in hint), encodes, then decodes.
  - [ ] Refine again on same image — instant decode, no re-load (encoded cache hits).
  - [ ] Drop new image → refine — re-encodes (invalidate fires in setImage).
  - [ ] Cancel mid-encode — progress hint clears, no zombie callback.

## Roll-back

`git reset --hard pre-split-baseline` returns dev to pre-Phase-1 state. Phase 3c is independently revertable.

Refs #47.