### PR TITLE
fix(security): add e.origin guard to worker onmessage handlers (#187)

### DIFF
--- a/src/workers/cv.worker.ts
+++ b/src/workers/cv.worker.ts
@@ -9,6 +9,10 @@ import { estimateForeground } from './cv/foreground-estimation';
 import type { CvWorkerRequest } from '../types/worker-messages';
 
 self.onmessage = (e: MessageEvent<CvWorkerRequest>) => {
+  // Reject cross-origin postMessage (CodeQL js/missing-origin-check, #187).
+  // Empty-origin events are allowed: dedicated Workers receive '' in some
+  // browsers; same-origin spawning is enforced by the page's CSP.
+  if (e.origin && e.origin !== self.location.origin) return;
   const { id, type, payload } = e.data;
 
   try {

--- a/src/workers/inpaint.worker.ts
+++ b/src/workers/inpaint.worker.ts
@@ -35,6 +35,10 @@ async function inpaint(
 }
 
 self.onmessage = async (e: MessageEvent<InpaintWorkerRequest>) => {
+  // Reject cross-origin postMessage (CodeQL js/missing-origin-check, #187).
+  // Empty-origin events are allowed: dedicated Workers receive '' in some
+  // browsers; same-origin spawning is enforced by the page's CSP.
+  if (e.origin && e.origin !== self.location.origin) return;
   const msg = e.data;
   try {
     switch (msg.type) {

--- a/src/workers/lama.worker.ts
+++ b/src/workers/lama.worker.ts
@@ -234,6 +234,10 @@ async function runInpaint(
 }
 
 self.onmessage = async (e: MessageEvent<LamaWorkerRequest>) => {
+  // Reject cross-origin postMessage (CodeQL js/missing-origin-check, #187).
+  // Empty-origin events are allowed: dedicated Workers receive '' in some
+  // browsers; same-origin spawning is enforced by the page's CSP.
+  if (e.origin && e.origin !== self.location.origin) return;
   const msg = e.data;
   try {
     switch (msg.type) {

--- a/src/workers/ml.worker.ts
+++ b/src/workers/ml.worker.ts
@@ -546,6 +546,10 @@ async function segment(
 }
 
 self.onmessage = async (e: MessageEvent<MlWorkerRequest>) => {
+  // Reject cross-origin postMessage (CodeQL js/missing-origin-check, #187).
+  // Empty-origin events are allowed: dedicated Workers receive '' in some
+  // browsers; same-origin spawning is enforced by the page's CSP.
+  if (e.origin && e.origin !== self.location.origin) return;
   const msg = e.data;
   try {
     switch (msg.type) {

--- a/src/workers/sam.worker.ts
+++ b/src/workers/sam.worker.ts
@@ -316,6 +316,10 @@ function dispose(): void {
 // ────────────────────────────── Message router ─────────────────────────────
 
 self.addEventListener('message', async (e: MessageEvent<SamWorkerRequest>) => {
+  // Reject cross-origin postMessage (CodeQL js/missing-origin-check, #187).
+  // Empty-origin events are allowed: dedicated Workers receive '' in some
+  // browsers; same-origin spawning is enforced by the page's CSP.
+  if (e.origin && e.origin !== self.location.origin) return;
   const msg = e.data;
   try {
     switch (msg.type) {


### PR DESCRIPTION
## Summary

Closes 5 CodeQL alerts of `js/missing-origin-check`. Adds the same one-line guard at the top of every worker `onmessage` handler:

```ts
if (e.origin && e.origin !== self.location.origin) return;
```

## Why the `e.origin && ` short-circuit

Dedicated Workers receive an **empty string** for `e.origin` in some browsers (per the HTML spec). The short-circuit lets legitimate same-origin traffic through; without it, the guard would reject every message and the app would freeze.

## Workers patched

- `src/workers/cv.worker.ts`
- `src/workers/inpaint.worker.ts`
- `src/workers/lama.worker.ts`
- `src/workers/ml.worker.ts`
- `src/workers/sam.worker.ts` (uses `addEventListener('message', ...)` rather than `onmessage =`, otherwise identical)

## Real risk

The page CSP already enforces same-origin worker spawning, so the practical attack surface is "compromised page injects a cross-origin worker reference and tries to drive it" — narrow. This is defense-in-depth and noise reduction on CodeQL, not a fix for an exploitable bug.

## Validation

- [x] `npm run typecheck` — green
- [x] `npm test` — 888/888 green
- [x] Manual: same-origin postMessage flow unchanged

Closes #187.