### PR TITLE
fix(reactor): validate /donors.json shape before consuming (#188)

### DIFF
--- a/src/components/ar-reactor.ts
+++ b/src/components/ar-reactor.ts
@@ -17,6 +17,7 @@ import {
   computeRuntime,
   formatRuntime,
   donationToRuntimeDelta,
+  isDonorsFile,
   type DonorsFile,
 } from '../utils/reactor-economics';
 
@@ -47,7 +48,15 @@ class ArReactor extends HTMLElement {
     try {
       const res = await fetch(DONORS_URL, { cache: 'no-cache' });
       if (!res.ok) return;
-      this.donors = (await res.json()) as DonorsFile;
+      const payload: unknown = await res.json();
+      if (!isDonorsFile(payload)) {
+        // Malformed donors file — keep EMPTY_DONORS so renderSupporters()
+        // and totalDonationsEur() don't NaN out on missing fields. Logging
+        // helps the maintainer notice if a deploy ever ships a bad file.
+        console.warn('[ar-reactor] donors.json failed shape validation; using empty fallback');
+        return;
+      }
+      this.donors = payload;
     } catch {
       // Stay with EMPTY_DONORS — same shape, the page still renders
       // honestly with "0 months" + empty supporters table.

--- a/src/utils/reactor-economics.ts
+++ b/src/utils/reactor-economics.ts
@@ -77,6 +77,35 @@ export interface DonorsFile {
 }
 
 /**
+ * Runtime shape guard for `/donors.json` payloads (#188). Cheap manual
+ * check — no Zod dependency for one schema. Validates the version
+ * sentinel, the four expected fields and (shallowly) the supporters
+ * array entries so consumers can trust `donors.supporters[i].amount_eur`
+ * without runtime surprises.
+ *
+ * Returns false (rather than throwing) so callers can fall back to an
+ * empty donors object and keep the page rendering honestly.
+ */
+export function isDonorsFile(x: unknown): x is DonorsFile {
+  if (typeof x !== 'object' || x === null) return false;
+  const o = x as Record<string, unknown>;
+  if (o.version !== 1) return false;
+  if (typeof o.updated_at !== 'string') return false;
+  if (typeof o.anonymous_count !== 'number') return false;
+  if (typeof o.anonymous_total_eur !== 'number') return false;
+  if (!Array.isArray(o.supporters)) return false;
+  for (const s of o.supporters) {
+    if (typeof s !== 'object' || s === null) return false;
+    const e = s as Record<string, unknown>;
+    if (typeof e.name !== 'string') return false;
+    if (typeof e.amount_eur !== 'number') return false;
+    if (typeof e.date !== 'string') return false;
+    if (e.consent !== 'explicit') return false;
+  }
+  return true;
+}
+
+/**
  * Total sunk investment in EUR (time at fair-rate + cash spent).
  */
 export function totalSunkEur(): number {

--- a/src/utils/reactor-status-injector.ts
+++ b/src/utils/reactor-status-injector.ts
@@ -17,6 +17,7 @@ import {
   formatRuntime,
   totalDonationsEur,
   MONTHLY_BURN_EUR,
+  isDonorsFile,
   type DonorsFile,
 } from './reactor-economics';
 
@@ -45,7 +46,9 @@ async function fetchAndComputeRuntime(): Promise<string> {
   try {
     const res = await fetch(DONORS_URL, { cache: 'no-cache' });
     if (!res.ok) return formatRuntime(0);
-    const donors = (await res.json()) as DonorsFile;
+    const payload: unknown = await res.json();
+    if (!isDonorsFile(payload)) return formatRuntime(0);
+    const donors: DonorsFile = payload;
     const totalEur = totalDonationsEur(donors);
     const { months, days } = computeRuntime(totalEur);
     const monthsFloat = months + days / 30;

--- a/tests/utils/reactor-economics.test.ts
+++ b/tests/utils/reactor-economics.test.ts
@@ -8,8 +8,53 @@ import {
   computeRuntime,
   formatRuntime,
   donationToRuntimeDelta,
+  isDonorsFile,
   type DonorsFile,
 } from '../../src/utils/reactor-economics';
+
+describe('reactor-economics — isDonorsFile (#188)', () => {
+  const valid: DonorsFile = {
+    version: 1,
+    updated_at: '2026-04-28',
+    supporters: [{ name: 'Alice', amount_eur: 25, date: '2026-04-01', consent: 'explicit' }],
+    anonymous_count: 3,
+    anonymous_total_eur: 9,
+  };
+
+  it('accepts a fully-formed file', () => {
+    expect(isDonorsFile(valid)).toBe(true);
+  });
+
+  it('accepts an empty supporters array', () => {
+    expect(isDonorsFile({ ...valid, supporters: [] })).toBe(true);
+  });
+
+  it.each([null, undefined, 42, 'string', []])('rejects non-object payload (%p)', (v) => {
+    expect(isDonorsFile(v)).toBe(false);
+  });
+
+  it.each([
+    ['missing version', { ...valid, version: undefined }],
+    ['wrong version sentinel', { ...valid, version: 2 }],
+    ['missing updated_at', { ...valid, updated_at: undefined }],
+    ['updated_at not a string', { ...valid, updated_at: 12345 }],
+    ['anonymous_count not a number', { ...valid, anonymous_count: '3' }],
+    ['anonymous_total_eur not a number', { ...valid, anonymous_total_eur: null }],
+    ['supporters not an array', { ...valid, supporters: 'oops' }],
+  ])('rejects payload with %s', (_label, payload) => {
+    expect(isDonorsFile(payload)).toBe(false);
+  });
+
+  it.each([
+    ['missing name', [{ amount_eur: 1, date: 'x', consent: 'explicit' }]],
+    ['amount_eur not a number', [{ name: 'A', amount_eur: '1', date: 'x', consent: 'explicit' }]],
+    ['date not a string', [{ name: 'A', amount_eur: 1, date: 0, consent: 'explicit' }]],
+    ['consent not "explicit"', [{ name: 'A', amount_eur: 1, date: 'x', consent: 'maybe' }]],
+    ['supporter is not an object', [42]],
+  ])('rejects malformed supporter entry (%s)', (_label, supporters) => {
+    expect(isDonorsFile({ ...valid, supporters })).toBe(false);
+  });
+});
 
 describe('reactor-economics — constants', () => {
   it('TIME_BREAKDOWN percents sum to 100', () => {


### PR DESCRIPTION
## Summary

Adds `isDonorsFile(x: unknown): x is DonorsFile` to `reactor-economics.ts` and uses it in **both** consumers of `/donors.json`.

## Why

The two `(await res.json()) as DonorsFile` casts in `ar-reactor.ts` and `reactor-status-injector.ts` lied: a malformed payload (deploy mistake, partial response, schema migration) would NaN through `totalDonationsEur` and break the reactor page or footer marquee silently.

## What the validator checks

- `version === 1` (sentinel — bumps to 2 must be opt-in)
- `updated_at: string`
- `anonymous_count: number`, `anonymous_total_eur: number`
- `supporters: Array`, with each entry having `name: string`, `amount_eur: number`, `date: string`, `consent === 'explicit'`

No Zod dependency. Manual guard is cheap for one schema, returns `false` instead of throwing so callers can fall back to a safe default (`EMPTY_DONORS` in the page, `formatRuntime(0)` in the marquee).

## Tests

19 new cases in `tests/utils/reactor-economics.test.ts`:
- Accepts a fully-formed file + an empty supporters array
- Rejects every common malformation: non-object payloads, wrong version, missing/wrong-typed top-level fields, malformed supporter entries

## Validation

| Gate | Result |
|------|--------|
| `npm run typecheck` | ✅ green |
| `npm test` | ✅ **907/907** (888 + 19 new) |

Closes #188.