### PR TITLE
fix(a11y): add :focus-visible rules to focusable shadow-DOM elements (#186)

### DIFF
--- a/src/components/ar-editor-advanced.ts
+++ b/src/components/ar-editor-advanced.ts
@@ -641,6 +641,13 @@ export class ArEditorAdvanced extends HTMLElement {
         }
         canvas.disabled { cursor: not-allowed; pointer-events: none; }
         canvas.panning { cursor: grabbing; }
+        /* Keyboard focus ring (#186). Canvas is focusable via
+           tabindex="0"; without an explicit rule, shadow-DOM scope
+           hides the document-level :focus-visible style. */
+        canvas:focus-visible {
+          outline: 2px solid var(--color-accent-primary, #00ff41);
+          outline-offset: 2px;
+        }
         .zoom-group {
           display: inline-flex;
           border: 1px solid var(--color-accent-primary, #00ff41);

--- a/src/components/ar-editor.ts
+++ b/src/components/ar-editor.ts
@@ -488,6 +488,13 @@ export class ArEditor extends HTMLElement {
         canvas {
           image-rendering: pixelated;
         }
+        /* Keyboard focus ring (#186). Canvas is focusable via
+           tabindex="0"; without an explicit rule, shadow-DOM scope
+           hides the document-level :focus-visible style. */
+        canvas:focus-visible {
+          outline: 2px solid var(--color-accent-primary, #00ff41);
+          outline-offset: 2px;
+        }
         .editor-footer {
           display: flex;
           justify-content: flex-end;

--- a/src/components/ar-viewer.ts
+++ b/src/components/ar-viewer.ts
@@ -119,6 +119,14 @@ export class ArViewer extends HTMLElement {
           color: var(--color-bg-primary, #000);
           box-shadow: 0 0 10px rgba(var(--color-accent-rgb, 0, 255, 65), 0.4);
         }
+        /* Keyboard focus ring (#186). Slider handle is the before/after
+           split control — focusable for accessibility. Without an
+           explicit rule, shadow-DOM scope hides the document-level
+           :focus-visible style. */
+        .slider-handle:focus-visible {
+          outline: 2px solid var(--color-accent-primary, #00ff41);
+          outline-offset: 2px;
+        }
         /* Viewer chips per design #71 — solid black fill + status dot
            + accent border on the active (result) side.
            Pre-existing UX had rgba(0,0,0,0.85) which washed out over the


### PR DESCRIPTION
## Summary

Three focusable elements inside shadow roots had no visible focus ring, leaving keyboard users without a reliable indicator of where focus is. The document-level \`:focus-visible\` rule in \`src/styles/main.css\` doesn't cross the shadow-DOM boundary.

## Patched

| Component | Element |
|-----------|---------|
| \`ar-editor.ts\` | \`<canvas tabindex="0">\` (basic eraser/restore canvas) |
| \`ar-editor-advanced.ts\` | \`<canvas tabindex="0">\` (lasso + brush + SAM canvas) |
| \`ar-viewer.ts\` | \`.slider-handle\` (before/after split control) |

Each component now declares its own rule using \`var(--color-accent-primary)\` so the ring follows the active power-mode theme.

## Audit correction

The audit-#96 entry that originated this issue mentioned **theme swatches** as also missing focus rings. Verified by grep: theme swatches live in **light DOM** (rendered by \`main.ts\` against \`document.body\`), so the existing \`main.css\` \`.theme-swatch:focus-visible\` rules already cover them. Issue body updated accordingly.

## Validation

| Gate | Result |
|------|--------|
| \`npm run typecheck\` | ✅ green |
| \`npm test\` | ✅ 907/907 |
| \`npm run build\` | ✅ success |

## Test plan (manual)

- [ ] Tab through the basic editor canvas → green outline appears
- [ ] Tab through the advanced editor canvas → green outline appears
- [ ] Tab to the viewer slider handle → green outline appears
- [ ] Outline color follows current theme (switch to amber, repeat — should be amber)

Closes #186.