### PR TITLE
ci: auto-merge Dependabot patch+minor PRs when CI is green (#191)

### DIFF
--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -1,0 +1,39 @@
+name: Dependabot auto-merge
+
+# Auto-merge Dependabot PRs that are patch + minor only and have CI green.
+# Closes #191. Major-version bumps still require manual review (the
+# `update-type` filter on the merge step rejects them).
+#
+# We use `pull_request_target` so the workflow runs with the perms of the
+# *base* branch's workflow file, not the PR's. That means a malicious
+# dependency update can't escalate by editing this workflow inside the PR
+# itself — the version of this file on `dev` is what runs.
+
+on:
+  pull_request_target:
+    types: [opened, reopened, synchronize]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  automerge:
+    name: Auto-merge patch+minor
+    runs-on: ubuntu-latest
+    if: github.actor == 'dependabot[bot]'
+    steps:
+      - name: Fetch Dependabot metadata
+        id: meta
+        uses: dependabot/fetch-metadata@v2
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Enable auto-merge for patch + minor updates
+        if: |
+          steps.meta.outputs.update-type == 'version-update:semver-patch' ||
+          steps.meta.outputs.update-type == 'version-update:semver-minor'
+        run: gh pr merge --auto --squash "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

Adds `.github/workflows/dependabot-automerge.yml`. After this lands, Dependabot patch + minor PRs merge themselves once CI is green. Major bumps still need a human.

## How it works

- Triggers on `pull_request_target` (Dependabot events)
- Runs only when actor is `dependabot[bot]`
- Calls `dependabot/fetch-metadata@v2` to read the update type
- If `version-update:semver-patch` or `semver-minor`, runs `gh pr merge --auto --squash`
- Auto-merge waits for required checks (lint+format, typecheck+tests, e2e chromium) before merging

## Why `pull_request_target` and not `pull_request`

`pull_request_target` runs the workflow file from the **base** branch, not the PR's branch. That means a malicious Dependabot patch can't escalate privileges by editing this workflow file inside the PR itself — the version of the file on `dev` is what runs. The trade-off is that the workflow gets `secrets.GITHUB_TOKEN` write perms; we mitigate by limiting what the workflow does (one `gh pr merge` call, no checkout of PR code).

## What stays manual

- Major-version Dependabot PRs (the metadata condition filters them out)
- The two ignored majors in `dependabot.yml` (`@huggingface/transformers` v4 and `onnxruntime-web`) — Dependabot won't even open PRs for them

## Test plan

After merge:
- [ ] Wait for next Monday 06:00 UTC Dependabot run, or trigger one manually
- [ ] Verify the workflow runs on the PR
- [ ] Verify `gh pr merge --auto` is invoked for patch+minor
- [ ] Verify a hand-crafted "fake major" Dependabot-style PR is NOT auto-merged

(The first two are the only realistic verification — manually faking Dependabot metadata is fiddly.)

Closes #191.