### PR TITLE
fix(image-io): validate WebP RIFF size field against file length (#189)

### DIFF
--- a/src/utils/image-io.ts
+++ b/src/utils/image-io.ts
@@ -39,7 +39,12 @@ async function sniffImageFormat(file: File): Promise<SupportedFormat | null> {
   if (head[0] === 0xff && head[1] === 0xd8 && head[2] === 0xff) {
     return 'image/jpeg';
   }
-  // WebP: "RIFF" <size> "WEBP"
+  // WebP: "RIFF" <size: LE uint32> "WEBP"
+  // The size field at bytes 4-7 (little-endian uint32) declares the byte
+  // count of everything after the size itself, so it must equal
+  // file.size - 8. Validating this guards against polyglot files that
+  // pass the magic-byte check but carry trailing/truncated content
+  // (#189).
   if (
     head[0] === 0x52 &&
     head[1] === 0x49 &&
@@ -50,6 +55,8 @@ async function sniffImageFormat(file: File): Promise<SupportedFormat | null> {
     head[10] === 0x42 &&
     head[11] === 0x50
   ) {
+    const declaredSize = (head[4] | (head[5] << 8) | (head[6] << 16) | (head[7] << 24)) >>> 0;
+    if (declaredSize + 8 !== file.size) return null;
     return 'image/webp';
   }
   return null;

--- a/tests/utils/image-io.test.ts
+++ b/tests/utils/image-io.test.ts
@@ -9,8 +9,10 @@ const PNG_MAGIC = new Uint8Array([
 const JPEG_MAGIC = new Uint8Array([
   0xff, 0xd8, 0xff, 0xe0, 0x00, 0x10, 0x4a, 0x46, 0x49, 0x46, 0x00, 0x01,
 ]);
+// Size field (bytes 4-7, LE uint32) must equal file.size - 8 — for the
+// 12-byte stub below that's 4 (#189).
 const WEBP_MAGIC = new Uint8Array([
-  0x52, 0x49, 0x46, 0x46, 0x00, 0x00, 0x00, 0x00, 0x57, 0x45, 0x42, 0x50,
+  0x52, 0x49, 0x46, 0x46, 0x04, 0x00, 0x00, 0x00, 0x57, 0x45, 0x42, 0x50,
 ]);
 
 function fileFrom(bytes: Uint8Array, name: string, type: string): File {
@@ -52,5 +54,36 @@ describe('loadImage magic-byte sniffing', () => {
   it('passes the magic-byte gate for a valid WebP header', async () => {
     const webpStub = fileFrom(WEBP_MAGIC, 'img.webp', 'image/webp');
     await expect(loadImage(webpStub)).rejects.not.toThrow(/does not match|not a valid/i);
+  });
+
+  describe('WebP RIFF size validation (#189)', () => {
+    it('rejects a WebP whose declared RIFF size does not match file length', async () => {
+      // Magic bytes valid, but declaredSize=999 + 8 ≠ 12. Sniff should fail.
+      const bogus = new Uint8Array([
+        0x52,
+        0x49,
+        0x46,
+        0x46,
+        0xe7,
+        0x03,
+        0x00,
+        0x00, // 999 little-endian
+        0x57,
+        0x45,
+        0x42,
+        0x50,
+      ]);
+      const file = fileFrom(bogus, 'polyglot.webp', 'image/webp');
+      await expect(loadImage(file)).rejects.toThrow(/not a valid PNG, JPG, or WebP/i);
+    });
+
+    it('rejects a WebP whose declared RIFF size is zero', async () => {
+      // Common malformed pattern: encoder writes 0 instead of file.size - 8.
+      const bogus = new Uint8Array([
+        0x52, 0x49, 0x46, 0x46, 0x00, 0x00, 0x00, 0x00, 0x57, 0x45, 0x42, 0x50,
+      ]);
+      const file = fileFrom(bogus, 'zerosize.webp', 'image/webp');
+      await expect(loadImage(file)).rejects.toThrow(/not a valid PNG, JPG, or WebP/i);
+    });
   });
 });


### PR DESCRIPTION
## Summary

The WebP sniff in \`sniffImageFormat()\` checked the magic bytes at the corners (\`RIFF\` at 0-3, \`WEBP\` at 8-11) but ignored bytes 4-7, which encode the file size as little-endian uint32. A polyglot file with valid magic but a truncated/inflated size field would slip through and only fail at Canvas decode.

This PR adds the size check: \`declaredSize + 8 === file.size\` (the RIFF size excludes the leading \`RIFF\` tag + the size field itself).

## Strict equality

The fixture \`tests/fixtures/football.webp\` encodes its size correctly. Verified — \`declaredSize + 8\` exactly equals file size. Strict comparison is the right fit; relaxing to \`<=\` would let truncated/padded polyglot files through.

## Tests

| Case | Before | After |
|------|--------|-------|
| Valid WebP with correct size | passes sniff (no validation) | **passes** sniff |
| WebP with declaredSize=999 but file size=12 | accepted, fails at decode | **rejected at sniff** |
| WebP with declaredSize=0 (common encoder bug) | accepted, fails at decode | **rejected at sniff** |

The pre-existing 'passes the magic-byte gate for a valid WebP header' test was updated to use a correct size field — its 12-byte stub now has \`declaredSize=4\` baked in.

## Validation

| Gate | Result |
|------|--------|
| \`npm run typecheck\` | ✅ green |
| \`npm test\` | ✅ **909/909** (907 + 2 new) |

Closes #189.