### PR TITLE
fix(pipeline): explicit clamp255 helper for float→Uint8 writes (#194)

### DIFF
--- a/src/workers/cv/clamp.ts
+++ b/src/workers/cv/clamp.ts
@@ -1,0 +1,18 @@
+/**
+ * Clamp a number into the byte range [0, 255] and round to integer.
+ *
+ * Float→Uint8ClampedArray writes auto-clamp + round under the hood, so
+ * skipping this helper does NOT corrupt output today. We use it where
+ * the pixel arithmetic produces floats (bilinear interpolation, alpha
+ * blending with noise) so the intent is explicit at the call site and
+ * a NaN doesn't silently become 0 if upstream math ever drifts.
+ *
+ * Extracted from `foreground-estimation.ts` and applied in
+ * `inpaint-blend.ts` + `lama-crop.ts` per #194.
+ */
+export function clamp255(v: number): number {
+  if (Number.isNaN(v)) return 0;
+  if (v <= 0) return 0;
+  if (v >= 255) return 255;
+  return Math.round(v);
+}

--- a/src/workers/cv/inpaint-blend.ts
+++ b/src/workers/cv/inpaint-blend.ts
@@ -18,6 +18,7 @@
  * Kept as a pure, standalone function so the inpaint worker stays
  * testable and the orchestrator can wire it independently.
  */
+import { clamp255 } from './clamp';
 
 export interface FeatherOptions {
   /** Pixels of soft transition from inpainted to original. */
@@ -143,9 +144,13 @@ export function compositeWithFeather(
     }
 
     const inv = 255 - a;
-    out[p] = (ir * a + original[p] * inv) / 255;
-    out[p + 1] = (ig * a + original[p + 1] * inv) / 255;
-    out[p + 2] = (ib * a + original[p + 2] * inv) / 255;
+    // Explicit clamp + round (#194). Uint8ClampedArray would clamp anyway,
+    // but writing it out documents intent and traps a NaN before it
+    // becomes a silent 0 (would happen only if upstream math drifts —
+    // gauss() is currently NaN-safe via Math.max(u1, 1e-12)).
+    out[p] = clamp255((ir * a + original[p] * inv) / 255);
+    out[p + 1] = clamp255((ig * a + original[p + 1] * inv) / 255);
+    out[p + 2] = clamp255((ib * a + original[p + 2] * inv) / 255);
     // Alpha channel: always 255 (opaque). Inpaint output may have garbage
     // here; the original is guaranteed opaque for loaded images.
     out[p + 3] = 255;

--- a/src/workers/cv/lama-crop.ts
+++ b/src/workers/cv/lama-crop.ts
@@ -1,4 +1,5 @@
 import { LAMA_PARAMS } from '../../pipeline/constants';
+import { clamp255 } from './clamp';
 
 export interface LamaCropRect {
   x: number;
@@ -174,7 +175,10 @@ export function spliceLamaOutput(
       for (let c = 0; c < 3; c++) {
         const top = lamaOutput[i00 + c] * (1 - fx) + lamaOutput[i01 + c] * fx;
         const bot = lamaOutput[i10 + c] * (1 - fx) + lamaOutput[i11 + c] * fx;
-        out[di + c] = top * (1 - fy) + bot * fy;
+        // Explicit clamp + round (#194). Uint8ClampedArray clamps and
+        // rounds on assign, but stating it makes the intent visible and
+        // traps NaN before it becomes a silent 0.
+        out[di + c] = clamp255(top * (1 - fy) + bot * fy);
       }
       // out[di + 3] left untouched — preserves the original alpha.
     }

--- a/tests/workers/cv/clamp.test.ts
+++ b/tests/workers/cv/clamp.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect } from 'vitest';
+import { clamp255 } from '../../../src/workers/cv/clamp';
+
+describe('clamp255 (#194)', () => {
+  it('passes integers in range through unchanged', () => {
+    expect(clamp255(0)).toBe(0);
+    expect(clamp255(128)).toBe(128);
+    expect(clamp255(255)).toBe(255);
+  });
+
+  it('rounds floats to nearest integer', () => {
+    expect(clamp255(127.4)).toBe(127);
+    expect(clamp255(127.6)).toBe(128);
+    expect(clamp255(0.4)).toBe(0);
+    expect(clamp255(0.6)).toBe(1);
+  });
+
+  it('clamps below 0 to 0', () => {
+    expect(clamp255(-1)).toBe(0);
+    expect(clamp255(-1000)).toBe(0);
+    expect(clamp255(-Infinity)).toBe(0);
+  });
+
+  it('clamps above 255 to 255', () => {
+    expect(clamp255(256)).toBe(255);
+    expect(clamp255(1000)).toBe(255);
+    expect(clamp255(Infinity)).toBe(255);
+  });
+
+  it('returns 0 for NaN (defensive — upstream math should not produce NaN)', () => {
+    expect(clamp255(NaN)).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary

Pulls a tiny \`clamp255(v)\` helper out into \`src/workers/cv/clamp.ts\` and applies it at the two pixel-arithmetic sites the audit-#95 flagged:

- \`inpaint-blend.ts\` \`compositeWithFeather()\` — alpha blend with optional Gaussian noise (3 channels per masked pixel).
- \`lama-crop.ts\` \`spliceLamaOutput()\` — bilinear interpolation over the LaMa output rectangle (3 channels per dest pixel).

## Why this isn't a correctness fix

\`Uint8ClampedArray\` auto-clamps to [0, 255] and rounds on assign — that's its whole purpose. So today, skipping the helper produces identical pixel output. The value here is twofold:

1. **Intent is explicit at the call site.** A future reader doesn't have to remember TypedArray semantics to know the math is bounded.
2. **NaN now traps to 0 visibly.** If upstream math ever drifts (the Box-Muller \`gauss()\` in inpaint-blend is currently NaN-safe via \`Math.max(u1, 1e-12)\`, but that could regress), \`clamp255\` returns 0 for NaN where \`Uint8ClampedArray\` would silently coerce.

## Tests

5 new tests in \`tests/workers/cv/clamp.test.ts\`:
- Integer in-range passthrough
- Float rounding (banker's-style not used; standard \`Math.round\`)
- Clamp below 0 → 0
- Clamp above 255 → 255 (incl. ±Infinity)
- NaN → 0

## Validation

| Gate | Result |
|------|--------|
| \`npm run typecheck\` | ✅ green |
| \`npm test\` | ✅ **914/914** (909 + 5 new) |

Closes #194.