### PR TITLE
ci(security): add OSV-Scanner job alongside npm audit + CodeQL (#192)

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -57,3 +57,23 @@ jobs:
         uses: github/codeql-action/analyze@v4
         with:
           category: '/language:${{ matrix.language }}'
+
+  # OSV-Scanner cross-references multiple vuln databases (OSV.dev, GHSA,
+  # PyPA, Go vuln DB, etc.) and tends to surface advisories before they
+  # reach the GHSA feed npm-audit reads. Closes #192.
+  osv-scanner:
+    name: OSV-Scanner
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Run OSV-Scanner
+        uses: google/osv-scanner-action/osv-scanner-action@v2.0.2
+        with:
+          scan-args: |-
+            --recursive
+            --skip-git
+            ./


### PR DESCRIPTION
## Summary

Adds a third job to \`.github/workflows/security.yml\`. OSV-Scanner cross-references multiple vuln databases (OSV.dev, GHSA, PyPA, Go vuln DB, RUSTSEC, etc.) and tends to surface advisories before they reach the GHSA feed that \`npm audit\` reads.

For a project shipping a binary-heavy ML pipeline (onnxruntime-web, @huggingface/transformers, sharp), broader coverage is worth the ~1 minute of CI time.

## Trigger

Same as the existing \`audit\` + \`codeql\` jobs:
- Push to \`main\` / \`dev\`
- Pull requests
- Weekly cron Monday 06:00 UTC

## What's NOT in this PR

- Failure threshold tuning. The action's defaults already match the policy: any vuln above LOW fails the job. If we ever want \`--config=osv-scanner.toml\` to allowlist specific findings, that's a follow-up.
- A separate workflow file. Adding to \`security.yml\` keeps the security surface in one place.

## Test plan

After merge, the next push or scheduled cron will run the new job. First scan should be clean (or any findings need to be triaged in a follow-up issue).

Closes #192.