### PR TITLE
fix(i18n): prune 19 dead keys (-114 LOC, -5.48 kB bundle) (#193)

### DIFF
--- a/scripts/find-unused-i18n.mjs
+++ b/scripts/find-unused-i18n.mjs
@@ -1,0 +1,107 @@
+#!/usr/bin/env node
+/**
+ * Find i18n keys defined in src/i18n/index.ts that are never referenced
+ * by a literal t('key') or t("key") call across src/. False positives are
+ * possible when a key is built with template-literal interpolation (e.g.
+ * t(`reactor.cat.${b.key}`)) — those need manual triage before delete.
+ *
+ * Usage: node scripts/find-unused-i18n.mjs
+ *
+ * Exit code is always 0 — this is a triage tool, not a CI gate. Pipe to
+ * `wc -l` or `tee` if you want to process the output.
+ *
+ * Closes #193.
+ */
+import { readFileSync, readdirSync, statSync } from 'node:fs';
+import { join, resolve } from 'node:path';
+
+const ROOT = resolve(import.meta.dirname, '..');
+const I18N_FILE = join(ROOT, 'src/i18n/index.ts');
+const SRC_DIR = join(ROOT, 'src');
+
+// Pull keys from the `en` locale block — assume any locale defines the
+// full key set. Cheap regex parse: only `'key': '...'` lines we care
+// about. We look at all locales actually so the union is comprehensive.
+function extractKeys() {
+  const text = readFileSync(I18N_FILE, 'utf8');
+  const KEY_RE = /^\s+['"]([\w.-]+)['"]\s*:/gm;
+  const keys = new Set();
+  let m;
+  while ((m = KEY_RE.exec(text)) !== null) {
+    keys.add(m[1]);
+  }
+  return [...keys];
+}
+
+function listSourceFiles(dir) {
+  const out = [];
+  for (const name of readdirSync(dir)) {
+    const full = join(dir, name);
+    const s = statSync(full);
+    if (s.isDirectory()) out.push(...listSourceFiles(full));
+    else if (/\.(ts|tsx|js|mjs|html)$/.test(name)) out.push(full);
+  }
+  return out;
+}
+
+function buildHaystack() {
+  // Exclude i18n/index.ts itself — it defines keys, doesn't consume them.
+  return listSourceFiles(SRC_DIR)
+    .filter((p) => !p.endsWith(join('i18n', 'index.ts')))
+    .map((p) => readFileSync(p, 'utf8'))
+    .join('\n');
+}
+
+function findUnused(keys, haystack) {
+  const escape = (s) => s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  const unused = [];
+  // A key counts as referenced if ANY of these match the haystack:
+  //   1. literal `t('key')` / `t("key")` / t(`key`)
+  //   2. template-interpolation prefix: `t(\`prefix.${...}` for any prefix
+  //      path of the key
+  //   3. concatenation prefix: `t('prefix.' +` (any prefix path)
+  //   4. bare string literal anywhere — covers `t(key)` where `key` is a
+  //      variable bound to one of a fixed set of literals (the cmdbar
+  //      ternary pattern) or any other indirect lookup.
+  // Heuristic 4 is broad, but false positives (key string appearing in
+  // something unrelated) are safer than false negatives (deleting a key
+  // that's actually used).
+  for (const k of keys) {
+    const esc = escape(k);
+
+    if (new RegExp(`t\\(\\s*[\\'"\\\`]${esc}[\\'"\\\`]`).test(haystack)) continue;
+
+    let prefixHit = false;
+    const parts = k.split('.');
+    for (let i = 1; i < parts.length; i++) {
+      const prefix = escape(parts.slice(0, i).join('.'));
+      // Template: t(`prefix.${...}`)
+      if (new RegExp(`t\\(\\s*[\\\`]${prefix}\\.\\$\\{`).test(haystack)) {
+        prefixHit = true;
+        break;
+      }
+      // Concatenation: t('prefix.' + ...)  or  t("prefix." +
+      if (new RegExp(`t\\(\\s*['"]${prefix}\\.['"]\\s*\\+`).test(haystack)) {
+        prefixHit = true;
+        break;
+      }
+    }
+    if (prefixHit) continue;
+
+    // Bare string literal — quoted occurrence anywhere.
+    if (new RegExp(`['"\\\`]${esc}['"\\\`]`).test(haystack)) continue;
+
+    unused.push(k);
+  }
+  return unused.sort();
+}
+
+const keys = extractKeys();
+const haystack = buildHaystack();
+const unused = findUnused(keys, haystack);
+
+console.log(`# i18n: ${keys.length} keys defined, ${unused.length} candidate-unused`);
+console.log(`# Run from repo root. Triage manually — interpolated keys may slip through`);
+console.log(`# the prefix heuristic. False positives are safer than false negatives here.`);
+console.log('');
+for (const k of unused) console.log(k);

--- a/src/i18n/index.ts
+++ b/src/i18n/index.ts
@@ -18,10 +18,8 @@ const translations: Translations = {
 
     // Dropzone
     'dropzone.title': 'Drop your image here',
-    'dropzone.subtitle': "or click to browse. We'll nuke the background",
     'dropzone.hint': '# or click to browse · paste with Ctrl+V',
     'dropzone.formats': 'PNG, JPG, WebP up to 32 MP / 80 MB',
-    'dropzone.clipboard': 'Ctrl+V to paste from clipboard',
     'dropzone.dragover': 'Drop to process',
     'dropzone.ariaLabel': 'Upload image for background removal',
     'dropzone.errorFormat': 'Unsupported format. Use PNG, JPG, or WebP.',
@@ -30,19 +28,11 @@ const translations: Translations = {
     'progress.detectBg': 'Scanning image...',
     'progress.watermarkScan': 'Checking for watermarks',
     'progress.inpaint': 'Removing watermark',
-    'progress.bgRemoval': 'Removing background',
-    'progress.bgRemovalCV': 'Removing background [CV]',
     'progress.bgRemovalML': 'Removing background [ML]',
     'progress.initAI': 'Initializing AI engine...',
-    'progress.cancel': 'Cancel',
-    'progress.total': 'Total:',
     'progress.downscaled': 'Large image: processing at {w}\u00D7{h} to fit memory (output at original {ow}\u00D7{oh}).',
 
     // Download
-    'download.btn': '\u2193 Download Clean PNG',
-    'download.btnWebp': '\u2193 Download Clean WebP',
-    'download.formatPng': 'PNG',
-    'download.formatWebp': 'WebP',
     'download.copy': '\uD83D\uDCCB Copy',
     'download.copied': '\u2713 Copied!',
     'download.copyFailed': 'Copy not supported',
@@ -162,13 +152,6 @@ const translations: Translations = {
     'privacy.tooltip.line3': 'Verify: check Network tab in DevTools.',
 
     // Features
-    'features.srTitle': 'Background Removal That Never Uploads Your Images',
-    'features.bgRemoval.title': 'Your Images Never Leave.',
-    'features.bgRemoval.desc': 'Zero uploads. Zero tracking. The ML model runs in your browser via WebAssembly. Don\'t trust us. Open DevTools and check the Network tab.',
-    'features.aiArtifacts.title': 'It Knows What You Dropped.',
-    'features.aiArtifacts.desc': 'Photo, illustration, signature, icon. We classify it and pick the right algorithm. Not one model blindly applied to everything.',
-    'features.private.title': 'No Account. No Paywall. No Catch.',
-    'features.private.desc': 'Unlimited uses, no watermarks on output, no credit system. GPL-3.0. Go read the code.',
     'features.disclaimer': 'We\'re <s>perfect</s> honest. Sometimes we miss. Fix it with the editor or <a href="https://github.com/yocreoquesi/nukebg/issues" target="_blank" rel="noopener">yell at the repo</a>.',
     'support.kofi': 'The reactor stays online while caffeine flows. <a href="https://ko-fi.com/yocreoquesi" target="_blank" rel="noopener">Fuel it on Ko-fi</a>.',
     'features.limitations': '\u2192 <strong>Works best with:</strong> clear subjects on contrasting backgrounds, photos, logos, signatures.<br>\u2192 <strong>May struggle with:</strong> hair on busy backgrounds, semi-transparent objects, very complex poses.<br>\u2192 <strong>Tip:</strong> use the manual editor to fix any rough spots. The eraser gives you pixel-level control.',
@@ -263,12 +246,10 @@ const translations: Translations = {
     'batch.done': 'Done',
     'batch.discarded': 'Discarded',
     'batch.completed': '{done}/{total} ready, {failed} failed',
-    'batch.emptyZip': 'No completed images to download',
     'batch.cancel': 'Cancel batch',
     'dropzone.multi': 'Drop up to 12 images for batch mode',
 
     // Language selector
-    'lang.label': 'Language',
   },
   es: {
     // Hero
@@ -281,10 +262,8 @@ const translations: Translations = {
 
     // Dropzone
     'dropzone.title': 'Arrastra tu imagen aqu\u00ED',
-    'dropzone.subtitle': 'o haz clic para buscar. Nukearemos el fondo',
     'dropzone.hint': '# o clic para buscar · pega con Ctrl+V',
     'dropzone.formats': 'PNG, JPG, WebP hasta 32 MP / 80 MB',
-    'dropzone.clipboard': 'Ctrl+V para pegar del portapapeles',
     'dropzone.dragover': 'Suelta para procesar',
     'dropzone.ariaLabel': 'Subir imagen para eliminar fondo',
     'dropzone.errorFormat': 'Formato no soportado. Usa PNG, JPG o WebP.',
@@ -293,19 +272,11 @@ const translations: Translations = {
     'progress.detectBg': 'Analizando imagen...',
     'progress.watermarkScan': 'Buscando marcas de agua',
     'progress.inpaint': 'Eliminando marca de agua',
-    'progress.bgRemoval': 'Eliminando fondo',
-    'progress.bgRemovalCV': 'Eliminando fondo [CV]',
     'progress.bgRemovalML': 'Eliminando fondo [ML]',
     'progress.initAI': 'Inicializando motor IA...',
-    'progress.cancel': 'Cancelar',
-    'progress.total': 'Total:',
     'progress.downscaled': 'Imagen grande: procesando en {w}\u00D7{h} para ahorrar memoria (salida a {ow}\u00D7{oh} original).',
 
     // Download
-    'download.btn': '\u2193 Descargar PNG limpio',
-    'download.btnWebp': '\u2193 Descargar WebP limpio',
-    'download.formatPng': 'PNG',
-    'download.formatWebp': 'WebP',
     'download.copy': '\uD83D\uDCCB Copiar',
     'download.copied': '\u2713 \u00A1Copiado!',
     'download.copyFailed': 'Copia no soportada',
@@ -425,13 +396,6 @@ const translations: Translations = {
     'privacy.tooltip.line3': 'Verifica: revisa la pesta\u00F1a Red en DevTools.',
 
     // Features
-    'features.srTitle': 'Eliminador de fondos que nunca sube tus im\u00E1genes',
-    'features.bgRemoval.title': 'Tus im\u00E1genes no salen.',
-    'features.bgRemoval.desc': 'Cero subidas. Cero rastreo. El modelo de IA corre en tu navegador via WebAssembly. No conf\u00EDes en nosotros. Abre DevTools y revisa la pesta\u00F1a Red.',
-    'features.aiArtifacts.title': 'Sabe qu\u00E9 le tiraste.',
-    'features.aiArtifacts.desc': 'Foto, ilustraci\u00F3n, firma, icono. Lo clasificamos y elegimos el algoritmo correcto. No un modelo aplicado a ciegas a todo.',
-    'features.private.title': 'Sin cuenta. Sin muro de pago. Sin trampa.',
-    'features.private.desc': 'Usos ilimitados, sin marca de agua en el resultado, sin sistema de cr\u00E9ditos. Es GPL-3.0. Lee el c\u00F3digo.',
     'features.disclaimer': 'Somos <s>perfectos</s> honestos. A veces fallamos. Arr\u00E9glalo con el editor o <a href="https://github.com/yocreoquesi/nukebg/issues" target="_blank" rel="noopener">grita en el repo</a>.',
     'support.kofi': 'El reactor sigue prendido mientras haya caf\u00E9. <a href="https://ko-fi.com/yocreoquesi" target="_blank" rel="noopener">Dale combustible en Ko-fi</a>.',
     'features.limitations': '\u2192 <strong>Funciona mejor con:</strong> sujetos claros sobre fondos contrastados, fotos, logos, firmas.<br>\u2192 <strong>Puede fallar con:</strong> pelo sobre fondos complejos, objetos semitransparentes, poses muy complejas.<br>\u2192 <strong>Consejo:</strong> usa el editor manual para corregir las zonas que no queden bien. El borrador te da control pixel a pixel.',
@@ -526,12 +490,10 @@ const translations: Translations = {
     'batch.done': 'Listo',
     'batch.discarded': 'Descartada',
     'batch.completed': '{done}/{total} listas, {failed} fallidas',
-    'batch.emptyZip': 'No hay im\u00E1genes procesadas para descargar',
     'batch.cancel': 'Cancelar lote',
     'dropzone.multi': 'Suelta hasta 12 im\u00E1genes para procesarlas juntas',
 
     // Language selector
-    'lang.label': 'Idioma',
   },
   fr: {
     // Hero
@@ -544,10 +506,8 @@ const translations: Translations = {
 
     // Dropzone
     'dropzone.title': 'D\u00E9pose ton image ici',
-    'dropzone.subtitle': 'ou clique pour parcourir. On atomise le fond',
     'dropzone.hint': '# ou cliquez pour parcourir · collez avec Ctrl+V',
     'dropzone.formats': 'PNG, JPG, WebP jusqu\u2019\u00E0 32 MP / 80 Mo',
-    'dropzone.clipboard': 'Ctrl+V pour coller depuis le presse-papiers',
     'dropzone.dragover': 'L\u00E2che pour traiter',
     'dropzone.ariaLabel': "Charger une image pour supprimer l'arri\u00E8re-plan",
     'dropzone.errorFormat': 'Format non support\u00E9. Utilise PNG, JPG ou WebP.',
@@ -556,19 +516,11 @@ const translations: Translations = {
     'progress.detectBg': 'Analyse en cours...',
     'progress.watermarkScan': 'V\u00E9rification des filigranes',
     'progress.inpaint': 'Suppression du filigrane',
-    'progress.bgRemoval': "Suppression de l'arri\u00E8re-plan",
-    'progress.bgRemovalCV': "Suppression de l'arri\u00E8re-plan [CV]",
     'progress.bgRemovalML': "Suppression de l'arri\u00E8re-plan [ML]",
     'progress.initAI': "Initialisation du moteur IA...",
-    'progress.cancel': 'Annuler',
-    'progress.total': 'Total :',
     'progress.downscaled': 'Grande image : traitement en {w}\u00D7{h} pour la m\u00E9moire (sortie en {ow}\u00D7{oh} d\u2019origine).',
 
     // Download
-    'download.btn': '\u2193 T\u00E9l\u00E9charger PNG propre',
-    'download.btnWebp': '\u2193 T\u00E9l\u00E9charger WebP propre',
-    'download.formatPng': 'PNG',
-    'download.formatWebp': 'WebP',
     'download.copy': '\uD83D\uDCCB Copier',
     'download.copied': '\u2713 Copi\u00E9 !',
     'download.copyFailed': 'Copie non support\u00E9e',
@@ -688,13 +640,6 @@ const translations: Translations = {
     'privacy.tooltip.line3': "V\u00E9rifie : ouvre l'onglet R\u00E9seau dans DevTools.",
 
     // Features
-    'features.srTitle': "D\u00E9tourage qui n'uploade jamais tes images",
-    'features.bgRemoval.title': 'Tes images ne sortent pas.',
-    'features.bgRemoval.desc': "Z\u00E9ro upload. Z\u00E9ro tracking. Le mod\u00E8le IA tourne dans ton navigateur via WebAssembly. Ne nous fais pas confiance. Ouvre DevTools et v\u00E9rifie l'onglet R\u00E9seau.",
-    'features.aiArtifacts.title': 'Il sait ce que tu lui as fil\u00E9.',
-    'features.aiArtifacts.desc': "Photo, illustration, signature, ic\u00F4ne. On classifie et on choisit le bon algorithme. Pas un mod\u00E8le appliqu\u00E9 \u00E0 l'aveugle sur tout.",
-    'features.private.title': 'Ni compte. Ni paywall. Ni entourloupe.',
-    'features.private.desc': "Utilisations illimit\u00E9es, pas de filigrane sur le r\u00E9sultat, pas de syst\u00E8me de cr\u00E9dits. GPL-3.0. Va lire le code.",
     'features.disclaimer': "On est <s>parfaits</s> honn\u00EAtes. Parfois on rate. Corrige avec l'\u00E9diteur ou <a href=\"https://github.com/yocreoquesi/nukebg/issues\" target=\"_blank\" rel=\"noopener\">gueule sur le repo</a>.",
     'features.limitations': "\u2192 <strong>Marche mieux avec :</strong> sujets nets sur fond contrast\u00E9, photos, logos, signatures.<br>\u2192 <strong>Peut galérer avec :</strong> cheveux sur fonds charg\u00E9s, objets semi-transparents, poses tr\u00E8s complexes.<br>\u2192 <strong>Astuce :</strong> utilise l'\u00E9diteur manuel pour corriger les zones approximatives. La gomme te donne le contr\u00F4le au pixel.",
     'status.reactor.offline': 'r\u00E9acteur inactif',
@@ -789,12 +734,10 @@ const translations: Translations = {
     'batch.done': 'Termin\u00E9',
     'batch.discarded': 'Supprim\u00E9e',
     'batch.completed': '{done}/{total} pr\u00EAtes, {failed} \u00E9chou\u00E9es',
-    'batch.emptyZip': 'Aucune image pr\u00EAte \u00E0 t\u00E9l\u00E9charger',
     'batch.cancel': 'Annuler le lot',
     'dropzone.multi': 'D\u00E9pose jusqu\u2019\u00E0 12 images pour le mode lot',
 
     // Language selector
-    'lang.label': 'Langue',
   },
   de: {
     // Hero
@@ -807,10 +750,8 @@ const translations: Translations = {
 
     // Dropzone
     'dropzone.title': 'Bild hier ablegen',
-    'dropzone.subtitle': 'oder klicken zum Ausw\u00E4hlen. Wir nuken den Hintergrund',
     'dropzone.hint': '# oder klicken · Strg+V zum Einf\u00FCgen',
     'dropzone.formats': 'PNG, JPG, WebP bis 32 MP / 80 MB',
-    'dropzone.clipboard': 'Strg+V zum Einf\u00FCgen aus Zwischenablage',
     'dropzone.dragover': 'Loslassen zum Verarbeiten',
     'dropzone.ariaLabel': 'Bild hochladen zur Hintergrundentfernung',
     'dropzone.errorFormat': 'Format nicht unterst\u00FCtzt. Nutze PNG, JPG oder WebP.',
@@ -819,19 +760,11 @@ const translations: Translations = {
     'progress.detectBg': 'Bild wird gescannt...',
     'progress.watermarkScan': 'Wasserzeichen-Check',
     'progress.inpaint': 'Wasserzeichen entfernen',
-    'progress.bgRemoval': 'Hintergrund entfernen',
-    'progress.bgRemovalCV': 'Hintergrund entfernen [CV]',
     'progress.bgRemovalML': 'Hintergrund entfernen [ML]',
     'progress.initAI': 'KI-Engine wird initialisiert...',
-    'progress.cancel': 'Abbrechen',
-    'progress.total': 'Gesamt:',
     'progress.downscaled': 'Gro\u00DFes Bild: Verarbeitung bei {w}\u00D7{h} zur Speicherschonung (Ausgabe in Original {ow}\u00D7{oh}).',
 
     // Download
-    'download.btn': '\u2193 Sauberes PNG laden',
-    'download.btnWebp': '\u2193 Sauberes WebP laden',
-    'download.formatPng': 'PNG',
-    'download.formatWebp': 'WebP',
     'download.copy': '\uD83D\uDCCB Kopieren',
     'download.copied': '\u2713 Kopiert!',
     'download.copyFailed': 'Kopieren nicht m\u00F6glich',
@@ -951,13 +884,6 @@ const translations: Translations = {
     'privacy.tooltip.line3': 'Pr\u00FCfe selbst: Netzwerk-Tab in DevTools \u00F6ffnen.',
 
     // Features
-    'features.srTitle': 'Hintergrundentfernung, die deine Bilder nie hochl\u00E4dt',
-    'features.bgRemoval.title': 'Deine Bilder bleiben bei dir.',
-    'features.bgRemoval.desc': 'Null Uploads. Null Tracking. Das KI-Modell l\u00E4uft im Browser via WebAssembly. Vertrau uns nicht. \u00D6ffne DevTools und check den Netzwerk-Tab.',
-    'features.aiArtifacts.title': 'Erkennt, was du reingeworfen hast.',
-    'features.aiArtifacts.desc': 'Foto, Illustration, Unterschrift, Icon. Wir klassifizieren und w\u00E4hlen den richtigen Algorithmus. Kein Modell, das blind auf alles losgelassen wird.',
-    'features.private.title': 'Kein Konto. Keine Paywall. Kein Haken.',
-    'features.private.desc': 'Unbegrenzt nutzbar, kein Wasserzeichen, kein Credit-System. GPL-3.0. Lies den Code.',
     'features.disclaimer': 'Wir sind <s>perfekt</s> ehrlich. Manchmal daneben. Nachbessern im Editor oder <a href="https://github.com/yocreoquesi/nukebg/issues" target="_blank" rel="noopener">im Repo meckern</a>.',
     'support.kofi': 'Der Reaktor l\u00E4uft, solange der Kaffee flie\u00DFt. <a href="https://ko-fi.com/yocreoquesi" target="_blank" rel="noopener">F\u00FCttere ihn auf Ko-fi</a>.',
     'features.limitations': '\u2192 <strong>Funktioniert am besten mit:</strong> klare Motive vor kontrastreichem Hintergrund, Fotos, Logos, Unterschriften.<br>\u2192 <strong>Kann Probleme haben mit:</strong> Haare vor unruhigem Hintergrund, halbtransparente Objekte, sehr komplexe Posen.<br>\u2192 <strong>Tipp:</strong> nutze den manuellen Editor f\u00FCr unsaubere Stellen. Der Radierer gibt dir Kontrolle auf Pixelebene.',
@@ -1052,12 +978,10 @@ const translations: Translations = {
     'batch.done': 'Fertig',
     'batch.discarded': 'Verworfen',
     'batch.completed': '{done}/{total} fertig, {failed} fehlgeschlagen',
-    'batch.emptyZip': 'Keine fertigen Bilder zum Herunterladen',
     'batch.cancel': 'Stapel abbrechen',
     'dropzone.multi': 'Bis zu 12 Bilder f\u00FCr den Stapelmodus ablegen',
 
     // Language selector
-    'lang.label': 'Sprache',
   },
   pt: {
     // Hero
@@ -1070,10 +994,8 @@ const translations: Translations = {
 
     // Dropzone
     'dropzone.title': 'Solta a imagem aqui',
-    'dropzone.subtitle': 'ou clica pra escolher. A gente nukeia o fundo',
     'dropzone.hint': '# ou clique pra escolher · cole com Ctrl+V',
     'dropzone.formats': 'PNG, JPG, WebP at\u00E9 32 MP / 80 MB',
-    'dropzone.clipboard': 'Ctrl+V pra colar da \u00E1rea de transfer\u00EAncia',
     'dropzone.dragover': 'Solta pra processar',
     'dropzone.ariaLabel': 'Enviar imagem para remover fundo',
     'dropzone.errorFormat': 'Formato n\u00E3o suportado. Usa PNG, JPG ou WebP.',
@@ -1082,19 +1004,11 @@ const translations: Translations = {
     'progress.detectBg': 'Escaneando imagem...',
     'progress.watermarkScan': 'Procurando marcas d\u2019\u00E1gua',
     'progress.inpaint': 'Removendo marca d\u2019\u00E1gua',
-    'progress.bgRemoval': 'Removendo fundo',
-    'progress.bgRemovalCV': 'Removendo fundo [CV]',
     'progress.bgRemovalML': 'Removendo fundo [ML]',
     'progress.initAI': 'Inicializando motor de IA...',
-    'progress.cancel': 'Cancelar',
-    'progress.total': 'Total:',
     'progress.downscaled': 'Imagem grande: processando em {w}\u00D7{h} para economizar mem\u00F3ria (sa\u00EDda em {ow}\u00D7{oh} original).',
 
     // Download
-    'download.btn': '\u2193 Baixar PNG limpo',
-    'download.btnWebp': '\u2193 Baixar WebP limpo',
-    'download.formatPng': 'PNG',
-    'download.formatWebp': 'WebP',
     'download.copy': '\uD83D\uDCCB Copiar',
     'download.copied': '\u2713 Copiado!',
     'download.copyFailed': 'C\u00F3pia n\u00E3o suportada',
@@ -1214,13 +1128,6 @@ const translations: Translations = {
     'privacy.tooltip.line3': 'Confere: abre a aba Rede no DevTools.',
 
     // Features
-    'features.srTitle': 'Removedor de fundo que nunca sobe suas imagens',
-    'features.bgRemoval.title': 'Suas imagens n\u00E3o saem daqui.',
-    'features.bgRemoval.desc': 'Zero uploads. Zero rastreamento. O modelo de IA roda no seu navegador via WebAssembly. N\u00E3o confia na gente? Abre o DevTools e confere a aba Rede.',
-    'features.aiArtifacts.title': 'Ele sabe o que voc\u00EA jogou.',
-    'features.aiArtifacts.desc': 'Foto, ilustra\u00E7\u00E3o, assinatura, \u00EDcone. A gente classifica e escolhe o algoritmo certo. Nada de um modelo cego aplicado em tudo.',
-    'features.private.title': 'Sem conta. Sem paywall. Sem pegadinha.',
-    'features.private.desc': 'Uso ilimitado, sem marca d\u2019\u00E1gua no resultado, sem sistema de cr\u00E9ditos. GPL-3.0. Vai ler o c\u00F3digo.',
     'features.disclaimer': 'Somos <s>perfeitos</s> honestos. \u00C0s vezes erramos. Arruma no editor ou <a href="https://github.com/yocreoquesi/nukebg/issues" target="_blank" rel="noopener">xinga no repo</a>.',
     'support.kofi': 'O reator s\u00F3 fica ligado enquanto tiver caf\u00E9. <a href="https://ko-fi.com/yocreoquesi" target="_blank" rel="noopener">Abastece no Ko-fi</a>.',
     'features.limitations': '\u2192 <strong>Funciona melhor com:</strong> sujeitos n\u00EDtidos em fundos contrastados, fotos, logos, assinaturas.<br>\u2192 <strong>Pode penar com:</strong> cabelo em fundos complexos, objetos semitransparentes, poses muito complicadas.<br>\u2192 <strong>Dica:</strong> usa o editor manual pra corrigir as partes que ficaram estranhas. A borracha d\u00E1 controle pixel a pixel.',
@@ -1315,12 +1222,10 @@ const translations: Translations = {
     'batch.done': 'Pronto',
     'batch.discarded': 'Descartada',
     'batch.completed': '{done}/{total} prontas, {failed} falharam',
-    'batch.emptyZip': 'Sem imagens prontas para baixar',
     'batch.cancel': 'Cancelar lote',
     'dropzone.multi': 'Solta at\u00E9 12 imagens pra modo em lote',
 
     // Language selector
-    'lang.label': 'Idioma',
   },
   zh: {
     // Hero
@@ -1333,10 +1238,8 @@ const translations: Translations = {
 
     // Dropzone
     'dropzone.title': '\u628A\u56FE\u7247\u4E22\u8FD9\u91CC',
-    'dropzone.subtitle': '\u6216\u8005\u70B9\u51FB\u9009\u62E9\uFF0C\u6211\u4EEC\u6765\u6838\u7206\u80CC\u666F',
     'dropzone.hint': '# \u70B9\u51FB\u9009\u62E9 · Ctrl+V \u7C98\u8D34',
     'dropzone.formats': 'PNG, JPG, WebP \u6700\u5927 32 MP / 80 MB',
-    'dropzone.clipboard': 'Ctrl+V \u4ECE\u526A\u8D34\u677F\u7C98\u8D34',
     'dropzone.dragover': '\u677E\u624B\u5F00\u59CB\u5904\u7406',
     'dropzone.ariaLabel': '\u4E0A\u4F20\u56FE\u7247\u4EE5\u53BB\u9664\u80CC\u666F',
     'dropzone.errorFormat': '\u4E0D\u652F\u6301\u7684\u683C\u5F0F\u3002\u8BF7\u7528 PNG\u3001JPG \u6216 WebP\u3002',
@@ -1345,19 +1248,11 @@ const translations: Translations = {
     'progress.detectBg': '\u626B\u63CF\u56FE\u7247\u4E2D...',
     'progress.watermarkScan': '\u68C0\u67E5\u6C34\u5370',
     'progress.inpaint': '\u6E05\u9664\u6C34\u5370',
-    'progress.bgRemoval': '\u53BB\u9664\u80CC\u666F',
-    'progress.bgRemovalCV': '\u53BB\u9664\u80CC\u666F [CV]',
     'progress.bgRemovalML': '\u53BB\u9664\u80CC\u666F [ML]',
     'progress.initAI': 'AI \u5F15\u64CE\u521D\u59CB\u5316\u4E2D...',
-    'progress.cancel': '\u53D6\u6D88',
-    'progress.total': '\u603B\u8BA1:',
     'progress.downscaled': '\u5927\u56FE\u50CF\uFF1A\u4EE5 {w}\u00D7{h} \u5904\u7406\u4EE5\u8282\u7701\u5185\u5B58\uFF08\u8F93\u51FA\u4F4D\u539F\u59CB {ow}\u00D7{oh}\uFF09\u3002',
 
     // Download
-    'download.btn': '\u2193 \u4E0B\u8F7D\u5E72\u51C0 PNG',
-    'download.btnWebp': '\u2193 \u4E0B\u8F7D\u5E72\u51C0 WebP',
-    'download.formatPng': 'PNG',
-    'download.formatWebp': 'WebP',
     'download.copy': '\uD83D\uDCCB \u590D\u5236',
     'download.copied': '\u2713 \u5DF2\u590D\u5236\uFF01',
     'download.copyFailed': '\u4E0D\u652F\u6301\u590D\u5236',
@@ -1477,13 +1372,6 @@ const translations: Translations = {
     'privacy.tooltip.line3': '\u9A8C\u8BC1\uFF1A\u6253\u5F00 DevTools \u67E5\u770B\u7F51\u7EDC\u9762\u677F\u3002',
 
     // Features
-    'features.srTitle': '\u6C38\u8FDC\u4E0D\u4F1A\u4E0A\u4F20\u4F60\u56FE\u7247\u7684\u80CC\u666F\u53BB\u9664\u5DE5\u5177',
-    'features.bgRemoval.title': '\u4F60\u7684\u56FE\u7247\u54EA\u513F\u4E5F\u4E0D\u53BB\u3002',
-    'features.bgRemoval.desc': '\u96F6\u4E0A\u4F20\u3002\u96F6\u8FFD\u8E2A\u3002AI\u6A21\u578B\u901A\u8FC7 WebAssembly \u5728\u4F60\u7684\u6D4F\u89C8\u5668\u91CC\u8FD0\u884C\u3002\u522B\u4FE1\u6211\u4EEC\u7684\u8BDD\u3002\u6253\u5F00 DevTools \u81EA\u5DF1\u770B\u7F51\u7EDC\u9762\u677F\u3002',
-    'features.aiArtifacts.title': '\u5B83\u77E5\u9053\u4F60\u4E22\u4E86\u4EC0\u4E48\u3002',
-    'features.aiArtifacts.desc': '\u7167\u7247\u3001\u63D2\u753B\u3001\u7B7E\u540D\u3001\u56FE\u6807\u3002\u6211\u4EEC\u5148\u5206\u7C7B\uFF0C\u518D\u9009\u7B97\u6CD5\u3002\u4E0D\u662F\u4E00\u4E2A\u6A21\u578B\u65E0\u8111\u5957\u5728\u6240\u6709\u4E1C\u897F\u4E0A\u3002',
-    'features.private.title': '\u4E0D\u7528\u6CE8\u518C\u3002\u4E0D\u7528\u4ED8\u8D39\u3002\u6CA1\u6709\u5957\u8DEF\u3002',
-    'features.private.desc': '\u65E0\u9650\u4F7F\u7528\uFF0C\u8F93\u51FA\u65E0\u6C34\u5370\uFF0C\u6CA1\u6709\u79EF\u5206\u5236\u3002GPL-3.0\u3002\u53BB\u770B\u6E90\u7801\u3002',
     'features.disclaimer': '\u6211\u4EEC<s>\u5B8C\u7F8E</s>\u8BDA\u5B9E\u3002\u6709\u65F6\u7FFB\u8F66\u3002\u7528\u7F16\u8F91\u5668\u4FEE\uFF0C\u6216<a href="https://github.com/yocreoquesi/nukebg/issues" target="_blank" rel="noopener">\u53BB repo \u5410\u69FD</a>\u3002',
     'support.kofi': '\u53CD\u5E94\u5806\u9760\u5496\u5561\u8FD0\u8F6C\u3002<a href="https://ko-fi.com/yocreoquesi" target="_blank" rel="noopener">\u5728 Ko-fi \u4E0A\u52A0\u6CB9</a>\u3002',
     'features.limitations': '\u2192 <strong>\u6700\u9002\u5408\uFF1A</strong>\u6E05\u6670\u4E3B\u4F53\u914D\u5BF9\u6BD4\u660E\u663E\u7684\u80CC\u666F\u3001\u7167\u7247\u3001logo\u3001\u7B7E\u540D\u3002<br>\u2192 <strong>\u53EF\u80FD\u7FFB\u8F66\uFF1A</strong>\u590D\u6742\u80CC\u666F\u4E0A\u7684\u5934\u53D1\u3001\u534A\u900F\u660E\u7269\u4F53\u3001\u975E\u5E38\u590D\u6742\u7684\u59FF\u52BF\u3002<br>\u2192 <strong>\u5C0F\u8D34\u58EB\uFF1A</strong>\u7528\u624B\u52A8\u7F16\u8F91\u5668\u4FEE\u590D\u4E0D\u5B8C\u7F8E\u7684\u5730\u65B9\u3002\u6A61\u76AE\u64E6\u7ED9\u4F60\u50CF\u7D20\u7EA7\u7684\u63A7\u5236\u3002',
@@ -1578,12 +1466,10 @@ const translations: Translations = {
     'batch.done': '\u5B8C\u6210',
     'batch.discarded': '\u5DF2\u4E22\u5F03',
     'batch.completed': '{done}/{total} \u5B8C\u6210\uFF0C{failed} \u5931\u8D25',
-    'batch.emptyZip': '\u6CA1\u6709\u5DF2\u5904\u7406\u7684\u56FE\u7247\u53EF\u4E0B\u8F7D',
     'batch.cancel': '\u53D6\u6D88\u6279\u91CF',
     'dropzone.multi': '\u62D6\u5165\u6700\u591A 12 \u5F20\u56FE\u7247\u8FDB\u5165\u6279\u91CF\u6A21\u5F0F',
 
     // Language selector
-    'lang.label': '\u8BED\u8A00',
   },
 };
 


### PR DESCRIPTION
## Summary

First PR of the refactor stretch that *shrinks* the bundle. Adds a triage script + deletes 19 confirmed-unused i18n keys across all 6 locales.

## Triage

- **Tool**: \`scripts/find-unused-i18n.mjs\` — loads every key, applies four heuristics (literal \`t('k')\`, template-prefix \`t(\\`prefix.\${...}\\`)\`, concat-prefix \`t('prefix.' + ...)\`, and bare-string fallback for the cmdbar-ternary pattern).
- **Initial output**: 35 candidates → improved heuristic → 20 candidates.
- **Manual verification**: greppped for each candidate as a quoted literal anywhere in \`src/\`. Only \`src/i18n/index.ts\` had them — confirmed dead.
- **Kept 1 of 20**: \`status.model.cached\` is pinned by \`tests/components/ar-landing-redesign.test.ts\` (PR #69 placeholder for a future state). Removing it breaks that invariant test.

## What got pruned

\`batch.emptyZip\`, \`download.btn\`, \`download.btnWebp\`, \`download.formatPng\`, \`download.formatWebp\`, \`dropzone.clipboard\`, \`dropzone.subtitle\`, \`features.aiArtifacts.{desc,title}\`, \`features.bgRemoval.{desc,title}\`, \`features.private.{desc,title}\`, \`features.srTitle\`, \`lang.label\`, \`progress.bgRemoval\`, \`progress.bgRemovalCV\`, \`progress.cancel\`, \`progress.total\`.

19 keys × 6 locales = **114 lines removed**.

## Bundle delta

| Metric | Phase-3c end | After this PR | Δ |
|--------|--------------|---------------|---|
| index.js raw | 470.66 kB | **465.18 kB** | −5.48 kB / −1.16% |
| index.js gzip | 127.20 kB | **125.60 kB** | −1.60 kB / −1.26% |

vs the original pre-split-baseline: bundle is now back **below** baseline by 1.73 kB raw / 0.06 kB gzip. The whole refactor stretch nets out to bundle-neutral or slightly better.

## Why CRLF-aware pruning

Repo uses \`core.autocrlf=true\` and \`src/i18n/index.ts\` is committed with CRLF. A naive Python/sd one-liner would normalize to LF and produce a 2900-line diff (every line "changed" by line-ending swap). Used a Node script that splits on \`\r\n\` and rejoins — diff stays at 114 deletions.

## Validation

| Gate | Result |
|------|--------|
| \`npm run typecheck\` | ✅ green |
| \`npm test\` | ✅ **914/914** |
| \`npm run build\` | ✅ green, bundle shrinks |

Closes #193.