### PR TITLE
release: v2.10.0 — internal refactor + audit cleanup

### DIFF
--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -1,0 +1,39 @@
+name: Dependabot auto-merge
+
+# Auto-merge Dependabot PRs that are patch + minor only and have CI green.
+# Closes #191. Major-version bumps still require manual review (the
+# `update-type` filter on the merge step rejects them).
+#
+# We use `pull_request_target` so the workflow runs with the perms of the
+# *base* branch's workflow file, not the PR's. That means a malicious
+# dependency update can't escalate by editing this workflow inside the PR
+# itself — the version of this file on `dev` is what runs.
+
+on:
+  pull_request_target:
+    types: [opened, reopened, synchronize]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  automerge:
+    name: Auto-merge patch+minor
+    runs-on: ubuntu-latest
+    if: github.actor == 'dependabot[bot]'
+    steps:
+      - name: Fetch Dependabot metadata
+        id: meta
+        uses: dependabot/fetch-metadata@v2
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Enable auto-merge for patch + minor updates
+        if: |
+          steps.meta.outputs.update-type == 'version-update:semver-patch' ||
+          steps.meta.outputs.update-type == 'version-update:semver-minor'
+        run: gh pr merge --auto --squash "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -57,3 +57,23 @@ jobs:
         uses: github/codeql-action/analyze@v4
         with:
           category: '/language:${{ matrix.language }}'
+
+  # OSV-Scanner cross-references multiple vuln databases (OSV.dev, GHSA,
+  # PyPA, Go vuln DB, etc.) and tends to surface advisories before they
+  # reach the GHSA feed npm-audit reads. Closes #192.
+  osv-scanner:
+    name: OSV-Scanner
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Run OSV-Scanner
+        uses: google/osv-scanner-action/osv-scanner-action@v2.0.2
+        with:
+          scan-args: |-
+            --recursive
+            --skip-git
+            ./

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,148 @@ Unreleased entries accumulate on the `dev` branch. When we cut a release we copy
 
 ## [Unreleased]
 
+## [2.10.0] — 2026-04-28
+
+Internal architecture refactor + audit cleanup. No new features; user-
+visible polish on accessibility, validation, and load size.
+
+### Fixed
+
+- **Amber theme — tertiary text on black is readable again.** Previous
+  `#995300` measured 3.59:1 contrast, failing WCAG AA (needs 4.5:1).
+  Bumped to `#b06400` (≈ 4.67:1) while staying dimmer than amber
+  secondary so the primary > secondary > tertiary luminance ramp is
+  preserved. Audit had also flagged yellow tertiary and amber secondary
+  as failing — recomputation showed they actually pass; only amber
+  tertiary needed the fix
+  ([#197](https://github.com/yocreoquesi/nukebg/pull/197),
+  [#185](https://github.com/yocreoquesi/nukebg/issues/185)).
+- **Keyboard focus is visible inside the editor again.** Three
+  `tabindex="0"` elements (basic editor canvas, advanced editor canvas,
+  before/after slider handle in the viewer) live inside shadow roots
+  and the document-level `:focus-visible` rule didn't cross the
+  boundary, so tabbing to them produced no visible ring. Each component
+  now declares its own rule using `--color-accent-primary` so the ring
+  follows the active theme
+  ([#206](https://github.com/yocreoquesi/nukebg/pull/206),
+  [#186](https://github.com/yocreoquesi/nukebg/issues/186)).
+- **WebP magic-byte sniff also validates the RIFF size field.** Polyglot
+  files with valid magic at the corners but a truncated/inflated size
+  field at bytes 4-7 used to slip through and only fail at Canvas
+  decode. Now `declaredSize + 8 === file.size` is asserted at sniff
+  time. No legitimate WebP is rejected — the existing
+  `tests/fixtures/football.webp` matches strict equality
+  ([#208](https://github.com/yocreoquesi/nukebg/pull/208),
+  [#189](https://github.com/yocreoquesi/nukebg/issues/189)).
+- **Reactor page tolerates a malformed `donors.json`.** `ar-reactor.ts`
+  used to do `(await res.json()) as DonorsFile` without checking the
+  shape; a deploy mistake would NaN through `totalDonationsEur` and
+  break the page. New `isDonorsFile()` runtime guard validates the
+  schema (version, supporters array, per-supporter fields) and falls
+  back to `EMPTY_DONORS` with a console warning on mismatch
+  ([#205](https://github.com/yocreoquesi/nukebg/pull/205),
+  [#188](https://github.com/yocreoquesi/nukebg/issues/188)).
+- **Reactor methodology section drops the pre-emptive contact line.**
+  Removed `reactor.removalNotice` ("if you appear on this page and want
+  to be removed, email …") from all 6 locales. The `/reactor` page has
+  no public supporter names today, so inviting removal requests was
+  noise; we'll add a removal channel only when somebody actually
+  appears or complains
+  ([#184](https://github.com/yocreoquesi/nukebg/pull/184)).
+- **Capability detector reports a consistent tier across devices.** The
+  previous logic mixed UA-based shortcuts with memory-signal probes,
+  producing different tiers on the same hardware between Chrome and
+  Safari. Now purely memory-driven; Safari/iOS no longer gets force-
+  downgraded to `low` based on UA strings alone
+  ([709d254](https://github.com/yocreoquesi/nukebg/commit/709d254)).
+
+### Changed
+
+- **Pruned 19 dead i18n keys across all 6 locales — bundle index.js
+  shrinks 5.48 kB raw / 1.60 kB gzip.** Keys like `download.btn`,
+  `features.aiArtifacts.*`, `progress.cancel`, `progress.bgRemoval*`
+  (legacy CV variants), `dropzone.subtitle`, `lang.label`, etc., were
+  defined for code paths that no longer exist. New triage helper at
+  `scripts/find-unused-i18n.mjs` finds candidates; `status.model.cached`
+  is intentionally kept (pinned by an invariant test in the landing
+  redesign suite as a placeholder for a future state)
+  ([#211](https://github.com/yocreoquesi/nukebg/pull/211),
+  [#193](https://github.com/yocreoquesi/nukebg/issues/193)).
+- **Pipeline pixel writes are explicitly clamped.** New
+  `src/workers/cv/clamp.ts` exports `clamp255(v)` which rounds + clamps
+  to [0, 255] and traps NaN. Applied at the alpha-blend site in
+  `inpaint-blend.ts` and the bilinear interpolation in `lama-crop.ts`.
+  `Uint8ClampedArray` already auto-clamps on assign, so this is not a
+  correctness fix today — value is making intent explicit and trapping
+  a NaN before it silently coerces to 0 if upstream math ever drifts
+  ([#209](https://github.com/yocreoquesi/nukebg/pull/209),
+  [#194](https://github.com/yocreoquesi/nukebg/issues/194)).
+- **Internal architecture: monolith components split into pure
+  modules.** `ar-app.ts` shrank from 2178 → 1969 LOC across two phases:
+  - Batch queue → `src/controllers/batch-orchestrator.ts` (talks to
+    host through a `BatchHost` interface — no direct field reaches)
+    ([#198](https://github.com/yocreoquesi/nukebg/pull/198))
+  - PWA install button + guide → `src/controllers/app-install.ts`
+    (AbortSignal-based cleanup, drops the manual `removeEventListener`
+    in `disconnectedCallback`)
+    ([#199](https://github.com/yocreoquesi/nukebg/pull/199))
+
+  `ar-editor.ts`: pulled the brush stamp + undo/redo out into pure libs:
+  - `src/lib/brush-stroke.ts` (immutable stroke record + `apply()`)
+  - `src/lib/history-manager.ts` (generic `<T>` undo/redo with FIFO cap)
+    ([#200](https://github.com/yocreoquesi/nukebg/pull/200))
+
+  `ar-editor-advanced.ts`: three sub-extractions:
+  - Lasso geometry + state → `src/lib/lasso-model.ts`
+    ([#201](https://github.com/yocreoquesi/nukebg/pull/201))
+  - Working-canvas undo/redo reuses `HistoryManager<Uint8ClampedArray>`
+    instead of carrying its own copy
+    ([#202](https://github.com/yocreoquesi/nukebg/pull/202))
+  - SAM lifecycle (load/encode/decode/dispose) → `src/controllers/sam-refiner.ts`
+    ([#203](https://github.com/yocreoquesi/nukebg/pull/203))
+
+  Tracked under [#47](https://github.com/yocreoquesi/nukebg/issues/47).
+  No public-event-surface changes — all `ar:*` and `batch:*` events
+  fire identically.
+
+### Added
+
+- **Worker `e.origin` guard at every postMessage entry.** All five
+  workers (cv, ml, lama, sam, inpaint) reject cross-origin messages.
+  Closes 5 CodeQL `js/missing-origin-check` alerts. Real attack surface
+  was already minimal (CSP enforces same-origin worker spawning); this
+  is defense-in-depth + alert-noise reduction
+  ([#204](https://github.com/yocreoquesi/nukebg/pull/204),
+  [#187](https://github.com/yocreoquesi/nukebg/issues/187)).
+- **Dependabot patch + minor PRs auto-merge once CI is green.** New
+  workflow at `.github/workflows/dependabot-automerge.yml`. Major-
+  version bumps still require manual review (`update-type` filter
+  rejects them). Uses `pull_request_target` so a malicious patch can't
+  escalate by editing the workflow file in the PR
+  ([#207](https://github.com/yocreoquesi/nukebg/pull/207),
+  [#191](https://github.com/yocreoquesi/nukebg/issues/191)).
+- **OSV-Scanner job alongside `npm audit` + CodeQL.** Cross-references
+  multiple vuln databases (OSV.dev, GHSA, PyPA, Go vuln DB, RUSTSEC)
+  and tends to surface advisories before they reach the GHSA feed
+  ([#210](https://github.com/yocreoquesi/nukebg/pull/210),
+  [#192](https://github.com/yocreoquesi/nukebg/issues/192)).
+- **80 new tests across 6 new test files**, locking the contracts of
+  the extracted modules: brush-stroke (10 cases), history-manager (13
+  with set-max-entries), lasso-model (23), sam-refiner (12), clamp
+  (5), donors-file shape (19). Vitest count: 834 → 914.
+
+### Notes
+
+- Bundle `index.js` ended this stretch at 465.18 kB raw / 125.60 kB
+  gzip — slightly **below** the v2.9.5 baseline despite the larger
+  module surface, thanks to the i18n key prune in #193. Net:
+  refactor + cleanups paid for themselves.
+- Audit corrections worth flagging: yellow tertiary contrast was fine
+  (audit had bad math), the predicted "lazy snapshot for >4k images"
+  optimization in `ar-editor.ts` never existed (audit was speculative),
+  and the CSP-hash CI gate from #190 was already implemented as a
+  vitest test (`tests/csp-hashes.test.ts`) — closed as already-fixed.
+
 ## [2.9.5] — 2026-04-27
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,7 @@ Unreleased entries accumulate on the `dev` branch. When we cut a release we copy
   the funding status line (the top marquee already carries the same
   message rotating), and brought back the `☕ Ko-fi` tip link in the
   position GitHub used to occupy. Final order: `NukeBG vX.Y.Z | GitHub
-  | Ko-fi | # /sys/reactor | ☢ Clear cache | # theme`.
+| Ko-fi | # /sys/reactor | ☢ Clear cache | # theme`.
 
 ## [2.9.3] — 2026-04-27
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 > Nuke backgrounds from any image. 100% client-side. Zero uploads. Zero BS.
 
-[![Version](https://img.shields.io/badge/version-2.9.5-brightgreen.svg)](https://github.com/yocreoquesi/nukebg/releases)
+[![Version](https://img.shields.io/badge/version-2.10.0-brightgreen.svg)](https://github.com/yocreoquesi/nukebg/releases)
 [![License: GPL-3.0](https://img.shields.io/badge/License-GPL%20v3-blue.svg)](https://www.gnu.org/licenses/gpl-3.0)
 [![Client-Side](https://img.shields.io/badge/Processing-100%25%20Client--Side-green.svg)](#-privacy)
 

--- a/index.html
+++ b/index.html
@@ -151,7 +151,7 @@
           "PNG export with true alpha transparency"
         ],
         "screenshot": "https://nukebg.app/og-image.png",
-        "softwareVersion": "2.9.5",
+        "softwareVersion": "2.10.0",
         "license": "https://www.gnu.org/licenses/gpl-3.0.html",
         "isAccessibleForFree": true,
         "creator": {
@@ -487,7 +487,7 @@
     <!-- <ar-post-cta id="post-cta"></ar-post-cta> -->
 
     <footer class="footer hazard-border-top" role="contentinfo">
-      <span>NukeBG <span style="color: var(--color-text-tertiary)">v2.9.5</span></span>
+      <span>NukeBG <span style="color: var(--color-text-tertiary)">v2.10.0</span></span>
       <span class="footer-sep">|</span>
       <a href="https://github.com/yocreoquesi/nukebg" target="_blank" rel="noopener noreferrer"
         >GitHub</a

--- a/infra/nginx.conf
+++ b/infra/nginx.conf
@@ -31,7 +31,7 @@ server {
     #   new Function() WASM bootstrap.
     # - sha256 hashes cover the 3 inline JSON-LD blocks in index.html.
     #   Regenerate with `node scripts/compute-csp-hashes.mjs` after edits.
-    add_header Content-Security-Policy "default-src 'self'; script-src 'self' blob: 'wasm-unsafe-eval' 'unsafe-eval' 'sha256-IXQVuOnxdkBKocKSROs6U9wyANi/pxU4kFIn4YynwP0=' 'sha256-uZm4Xh9FxR3B7WjPHL5pbehtSMYTCy9JWzQzl3/UKA0=' 'sha256-o1DLxvGFHY9H1AG6Sro58slSTxU3T7zb020gfyqbFwM=' https://cdn.jsdelivr.net; worker-src 'self' blob:; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; connect-src 'self' https://huggingface.co https://cdn-lfs.huggingface.co https://cdn-lfs-us-1.huggingface.co https://cdn.jsdelivr.net https://cas-bridge.xethub.hf.co; font-src 'self'; object-src 'none'; base-uri 'self'; form-action 'none'" always;
+    add_header Content-Security-Policy "default-src 'self'; script-src 'self' blob: 'wasm-unsafe-eval' 'unsafe-eval' 'sha256-ZDTev8tjytyskB+TfpLJpp6O1/B8dCnmwRQRbxsh6ws=' 'sha256-uZm4Xh9FxR3B7WjPHL5pbehtSMYTCy9JWzQzl3/UKA0=' 'sha256-o1DLxvGFHY9H1AG6Sro58slSTxU3T7zb020gfyqbFwM=' https://cdn.jsdelivr.net; worker-src 'self' blob:; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; connect-src 'self' https://huggingface.co https://cdn-lfs.huggingface.co https://cdn-lfs-us-1.huggingface.co https://cdn.jsdelivr.net https://cas-bridge.xethub.hf.co; font-src 'self'; object-src 'none'; base-uri 'self'; form-action 'none'" always;
 
     # Cache static assets
     # Note: add_header in location blocks replaces parent headers in nginx,
@@ -46,7 +46,7 @@ server {
         add_header Strict-Transport-Security "max-age=63072000; includeSubDomains; preload" always;
         add_header Cross-Origin-Opener-Policy "same-origin" always;
         add_header X-DNS-Prefetch-Control "off" always;
-        add_header Content-Security-Policy "default-src 'self'; script-src 'self' blob: 'wasm-unsafe-eval' 'unsafe-eval' 'sha256-IXQVuOnxdkBKocKSROs6U9wyANi/pxU4kFIn4YynwP0=' 'sha256-uZm4Xh9FxR3B7WjPHL5pbehtSMYTCy9JWzQzl3/UKA0=' 'sha256-o1DLxvGFHY9H1AG6Sro58slSTxU3T7zb020gfyqbFwM=' https://cdn.jsdelivr.net; worker-src 'self' blob:; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; connect-src 'self' https://huggingface.co https://cdn-lfs.huggingface.co https://cdn-lfs-us-1.huggingface.co https://cdn.jsdelivr.net https://cas-bridge.xethub.hf.co; font-src 'self'; object-src 'none'; base-uri 'self'; form-action 'none'" always;
+        add_header Content-Security-Policy "default-src 'self'; script-src 'self' blob: 'wasm-unsafe-eval' 'unsafe-eval' 'sha256-ZDTev8tjytyskB+TfpLJpp6O1/B8dCnmwRQRbxsh6ws=' 'sha256-uZm4Xh9FxR3B7WjPHL5pbehtSMYTCy9JWzQzl3/UKA0=' 'sha256-o1DLxvGFHY9H1AG6Sro58slSTxU3T7zb020gfyqbFwM=' https://cdn.jsdelivr.net; worker-src 'self' blob:; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; connect-src 'self' https://huggingface.co https://cdn-lfs.huggingface.co https://cdn-lfs-us-1.huggingface.co https://cdn.jsdelivr.net https://cas-bridge.xethub.hf.co; font-src 'self'; object-src 'none'; base-uri 'self'; form-action 'none'" always;
     }
 
     # ONNX model files — cache aggressively, same-origin so CORP is fine
@@ -60,7 +60,7 @@ server {
         add_header Strict-Transport-Security "max-age=63072000; includeSubDomains; preload" always;
         add_header Cross-Origin-Opener-Policy "same-origin" always;
         add_header X-DNS-Prefetch-Control "off" always;
-        add_header Content-Security-Policy "default-src 'self'; script-src 'self' blob: 'wasm-unsafe-eval' 'unsafe-eval' 'sha256-IXQVuOnxdkBKocKSROs6U9wyANi/pxU4kFIn4YynwP0=' 'sha256-uZm4Xh9FxR3B7WjPHL5pbehtSMYTCy9JWzQzl3/UKA0=' 'sha256-o1DLxvGFHY9H1AG6Sro58slSTxU3T7zb020gfyqbFwM=' https://cdn.jsdelivr.net; worker-src 'self' blob:; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; connect-src 'self' https://huggingface.co https://cdn-lfs.huggingface.co https://cdn-lfs-us-1.huggingface.co https://cdn.jsdelivr.net https://cas-bridge.xethub.hf.co; font-src 'self'; object-src 'none'; base-uri 'self'; form-action 'none'" always;
+        add_header Content-Security-Policy "default-src 'self'; script-src 'self' blob: 'wasm-unsafe-eval' 'unsafe-eval' 'sha256-ZDTev8tjytyskB+TfpLJpp6O1/B8dCnmwRQRbxsh6ws=' 'sha256-uZm4Xh9FxR3B7WjPHL5pbehtSMYTCy9JWzQzl3/UKA0=' 'sha256-o1DLxvGFHY9H1AG6Sro58slSTxU3T7zb020gfyqbFwM=' https://cdn.jsdelivr.net; worker-src 'self' blob:; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; connect-src 'self' https://huggingface.co https://cdn-lfs.huggingface.co https://cdn-lfs-us-1.huggingface.co https://cdn.jsdelivr.net https://cas-bridge.xethub.hf.co; font-src 'self'; object-src 'none'; base-uri 'self'; form-action 'none'" always;
     }
 
     # SPA fallback

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,13 +1,13 @@
 {
   "name": "nukebg",
-  "version": "2.9.5",
+  "version": "2.10.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "nukebg",
-      "version": "2.9.5",
-      "license": "GPL-3.0",
+      "version": "2.10.0",
+      "license": "GPL-3.0-only",
       "dependencies": {
         "@huggingface/transformers": "^3.8.1",
         "jszip": "^3.10.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "nukebg",
   "private": true,
-  "version": "2.9.5",
+  "version": "2.10.0",
   "type": "module",
   "description": "NukeBG: Nuke AI backgrounds, checkerboard patterns, and watermarks. 100% client-side. Zero uploads. Zero BS.",
   "license": "GPL-3.0-only",

--- a/public/_headers
+++ b/public/_headers
@@ -7,7 +7,7 @@
   Cross-Origin-Resource-Policy: same-origin
   X-DNS-Prefetch-Control: off
   Strict-Transport-Security: max-age=63072000; includeSubDomains; preload
-  Content-Security-Policy: default-src 'self'; script-src 'self' blob: 'wasm-unsafe-eval' 'unsafe-eval' 'sha256-IXQVuOnxdkBKocKSROs6U9wyANi/pxU4kFIn4YynwP0=' 'sha256-uZm4Xh9FxR3B7WjPHL5pbehtSMYTCy9JWzQzl3/UKA0=' 'sha256-o1DLxvGFHY9H1AG6Sro58slSTxU3T7zb020gfyqbFwM=' https://cdn.jsdelivr.net; worker-src 'self' blob:; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; connect-src 'self' https://huggingface.co https://cdn-lfs.huggingface.co https://cdn-lfs-us-1.huggingface.co https://cdn.jsdelivr.net https://cas-bridge.xethub.hf.co; font-src 'self'; object-src 'none'; base-uri 'self'; form-action 'none'
+  Content-Security-Policy: default-src 'self'; script-src 'self' blob: 'wasm-unsafe-eval' 'unsafe-eval' 'sha256-ZDTev8tjytyskB+TfpLJpp6O1/B8dCnmwRQRbxsh6ws=' 'sha256-uZm4Xh9FxR3B7WjPHL5pbehtSMYTCy9JWzQzl3/UKA0=' 'sha256-o1DLxvGFHY9H1AG6Sro58slSTxU3T7zb020gfyqbFwM=' https://cdn.jsdelivr.net; worker-src 'self' blob:; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; connect-src 'self' https://huggingface.co https://cdn-lfs.huggingface.co https://cdn-lfs-us-1.huggingface.co https://cdn.jsdelivr.net https://cas-bridge.xethub.hf.co; font-src 'self'; object-src 'none'; base-uri 'self'; form-action 'none'
 
 /assets/*
   Cache-Control: public, max-age=31536000, immutable

--- a/scripts/find-unused-i18n.mjs
+++ b/scripts/find-unused-i18n.mjs
@@ -1,0 +1,107 @@
+#!/usr/bin/env node
+/**
+ * Find i18n keys defined in src/i18n/index.ts that are never referenced
+ * by a literal t('key') or t("key") call across src/. False positives are
+ * possible when a key is built with template-literal interpolation (e.g.
+ * t(`reactor.cat.${b.key}`)) — those need manual triage before delete.
+ *
+ * Usage: node scripts/find-unused-i18n.mjs
+ *
+ * Exit code is always 0 — this is a triage tool, not a CI gate. Pipe to
+ * `wc -l` or `tee` if you want to process the output.
+ *
+ * Closes #193.
+ */
+import { readFileSync, readdirSync, statSync } from 'node:fs';
+import { join, resolve } from 'node:path';
+
+const ROOT = resolve(import.meta.dirname, '..');
+const I18N_FILE = join(ROOT, 'src/i18n/index.ts');
+const SRC_DIR = join(ROOT, 'src');
+
+// Pull keys from the `en` locale block — assume any locale defines the
+// full key set. Cheap regex parse: only `'key': '...'` lines we care
+// about. We look at all locales actually so the union is comprehensive.
+function extractKeys() {
+  const text = readFileSync(I18N_FILE, 'utf8');
+  const KEY_RE = /^\s+['"]([\w.-]+)['"]\s*:/gm;
+  const keys = new Set();
+  let m;
+  while ((m = KEY_RE.exec(text)) !== null) {
+    keys.add(m[1]);
+  }
+  return [...keys];
+}
+
+function listSourceFiles(dir) {
+  const out = [];
+  for (const name of readdirSync(dir)) {
+    const full = join(dir, name);
+    const s = statSync(full);
+    if (s.isDirectory()) out.push(...listSourceFiles(full));
+    else if (/\.(ts|tsx|js|mjs|html)$/.test(name)) out.push(full);
+  }
+  return out;
+}
+
+function buildHaystack() {
+  // Exclude i18n/index.ts itself — it defines keys, doesn't consume them.
+  return listSourceFiles(SRC_DIR)
+    .filter((p) => !p.endsWith(join('i18n', 'index.ts')))
+    .map((p) => readFileSync(p, 'utf8'))
+    .join('\n');
+}
+
+function findUnused(keys, haystack) {
+  const escape = (s) => s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  const unused = [];
+  // A key counts as referenced if ANY of these match the haystack:
+  //   1. literal `t('key')` / `t("key")` / t(`key`)
+  //   2. template-interpolation prefix: `t(\`prefix.${...}` for any prefix
+  //      path of the key
+  //   3. concatenation prefix: `t('prefix.' +` (any prefix path)
+  //   4. bare string literal anywhere — covers `t(key)` where `key` is a
+  //      variable bound to one of a fixed set of literals (the cmdbar
+  //      ternary pattern) or any other indirect lookup.
+  // Heuristic 4 is broad, but false positives (key string appearing in
+  // something unrelated) are safer than false negatives (deleting a key
+  // that's actually used).
+  for (const k of keys) {
+    const esc = escape(k);
+
+    if (new RegExp(`t\\(\\s*[\\'"\\\`]${esc}[\\'"\\\`]`).test(haystack)) continue;
+
+    let prefixHit = false;
+    const parts = k.split('.');
+    for (let i = 1; i < parts.length; i++) {
+      const prefix = escape(parts.slice(0, i).join('.'));
+      // Template: t(`prefix.${...}`)
+      if (new RegExp(`t\\(\\s*[\\\`]${prefix}\\.\\$\\{`).test(haystack)) {
+        prefixHit = true;
+        break;
+      }
+      // Concatenation: t('prefix.' + ...)  or  t("prefix." +
+      if (new RegExp(`t\\(\\s*['"]${prefix}\\.['"]\\s*\\+`).test(haystack)) {
+        prefixHit = true;
+        break;
+      }
+    }
+    if (prefixHit) continue;
+
+    // Bare string literal — quoted occurrence anywhere.
+    if (new RegExp(`['"\\\`]${esc}['"\\\`]`).test(haystack)) continue;
+
+    unused.push(k);
+  }
+  return unused.sort();
+}
+
+const keys = extractKeys();
+const haystack = buildHaystack();
+const unused = findUnused(keys, haystack);
+
+console.log(`# i18n: ${keys.length} keys defined, ${unused.length} candidate-unused`);
+console.log(`# Run from repo root. Triage manually — interpolated keys may slip through`);
+console.log(`# the prefix heuristic. False positives are safer than false negatives here.`);
+console.log('');
+for (const k of unused) console.log(k);

--- a/src/components/ar-app.ts
+++ b/src/components/ar-app.ts
@@ -9,8 +9,7 @@ import type { ArDownload } from './ar-download';
 import type { ArEditor } from './ar-editor';
 import type { ArDropzone } from './ar-dropzone';
 import type { ArBatchGrid } from './ar-batch-grid';
-import type { BatchItem, StageSnapshot } from '../types/batch';
-import { createZip, safeZipEntryName, downloadBlob } from '../utils/zip';
+import { BatchOrchestrator, type BatchStageCallback } from '../controllers/batch-orchestrator';
 import {
   refineEdges,
   dropOrphanBlobs,
@@ -46,13 +45,9 @@ export class ArApp extends HTMLElement {
   private boundPwaInstallableHandler: (() => void) | null = null;
   private abortController: AbortController | null = null;
   private batchGrid: ArBatchGrid | null = null;
-  private batchItems: BatchItem[] = [];
-  private batchMode: 'off' | 'grid' | 'detail' = 'off';
-  private batchDetailId: string | null = null;
-  private batchAborted = false;
-  /** Item currently being processed by the batch queue. The pipeline stage
-   * callback reads this to append snapshots to the right item's history. */
-  private batchCurrentProcessingItem: BatchItem | null = null;
+  /** Owns batch queue state + per-item processing loop. Wired up in
+   *  setupComponents() once UI refs are resolved. See #47/Phase-1. */
+  private batch!: BatchOrchestrator;
 
   constructor() {
     super();
@@ -1049,6 +1044,37 @@ export class ArApp extends HTMLElement {
     this.editor = this.shadowRoot!.querySelector('ar-editor')!;
     this.dropzone = this.shadowRoot!.querySelector('ar-dropzone')! as ArDropzone;
     this.batchGrid = this.shadowRoot!.querySelector('#batch-grid') as ArBatchGrid;
+
+    // Batch orchestrator owns queue state + per-item processing. Host
+    // (this component) keeps the pipeline + AbortController + thumbnail
+    // helper + UI swap, exposed through the BatchHost interface.
+    this.batch = new BatchOrchestrator(
+      {
+        viewer: this.viewer,
+        progress: this.progress,
+        download: this.download,
+        batchGrid: this.batchGrid,
+      },
+      {
+        installBatchStageCallback: (cb: BatchStageCallback) => {
+          if (!this.pipeline) {
+            this.pipeline = new PipelineOrchestrator(cb);
+          } else {
+            this.pipeline.setStageCallback(cb);
+          }
+          return this.pipeline;
+        },
+        setProcessingAbortController: (c) => {
+          this.processingAbortController = c;
+        },
+        makeThumbnail: (img, maxSide) => this.makeThumbnail(img, maxSide),
+        enterGridMode: () => this.setBatchUiMode('grid'),
+      },
+    );
+    // When an item finishes mid-processing AND the user is watching its
+    // detail view, re-render so they see the result/error without going
+    // back to the grid.
+    this.batch.setOnItemRefreshed((id) => this.openBatchDetail(id));
   }
 
   /** Actualiza textos sin re-renderizar todo el componente */
@@ -1164,8 +1190,8 @@ export class ArApp extends HTMLElement {
         if (this.processingAbortController && !this.processingAbortController.signal.aborted) {
           this.processingAbortController.abort('user cancelled');
         }
-        if (this.batchMode !== 'off') {
-          this.batchAborted = true;
+        if (this.batch.isInBatchMode()) {
+          this.batch.abort();
         }
       },
       { signal },
@@ -1320,7 +1346,7 @@ export class ArApp extends HTMLElement {
           this.isProcessing = false;
           this.enableWorkspaceButtons();
         }
-        await this.startBatch(detail.images);
+        await this.batch.start(detail.images);
       },
       { signal },
     );
@@ -1337,7 +1363,7 @@ export class ArApp extends HTMLElement {
     this.shadowRoot!.addEventListener(
       'batch:download-zip',
       async () => {
-        await this.downloadBatchZip();
+        await this.batch.downloadZip();
       },
       { signal },
     );
@@ -1847,145 +1873,13 @@ export class ArApp extends HTMLElement {
       single.style.display = 'flex';
       detailBar.style.display = 'flex';
     }
-    this.batchMode = mode;
-  }
-
-  private async startBatch(
-    images: Array<{
-      file: File;
-      imageData: ImageData;
-      originalImageData: ImageData;
-      originalWidth: number;
-      originalHeight: number;
-      wasDownsampled: boolean;
-    }>,
-  ): Promise<void> {
-    this.batchAborted = false;
-    this.batchItems = images.map((img, i) => ({
-      id: `batch-${Date.now()}-${i}`,
-      originalName: img.file.name || `image-${i + 1}.png`,
-      file: img.file,
-      imageData: img.imageData,
-      originalImageData: img.originalImageData ?? img.imageData,
-      state: 'pending',
-      result: null,
-      finalImageData: null,
-      thumbnailUrl: this.makeThumbnail(img.originalImageData ?? img.imageData),
-      stageHistory: [],
-    }));
-
-    // setBatchUiMode handles hero/workspace/dropzone visibility for grid mode.
-    this.setBatchUiMode('grid');
-
-    if (this.batchGrid) {
-      this.batchGrid.setItems(this.batchItems);
-      this.batchGrid.setCurrentIndex(0);
-    }
-
-    // Stage callback: drives the live progress console AND records the
-    // event into the item being processed so we can replay the exact
-    // sequence (running → done / skipped / error) if the user reopens
-    // that item's detail later.
-    const batchStageCallback = (
-      stage: PipelineStage,
-      status: StageStatus,
-      message?: string,
-    ): void => {
-      this.progress.setStage(stage, status, message);
-      const current = this.batchCurrentProcessingItem;
-      if (current) current.stageHistory.push({ stage, status, message });
-    };
-
-    if (!this.pipeline) {
-      this.pipeline = new PipelineOrchestrator(batchStageCallback);
-    } else {
-      this.pipeline.setStageCallback(batchStageCallback);
-    }
-
-    await this.runBatchQueue();
-  }
-
-  private async runBatchQueue(): Promise<void> {
-    for (let i = 0; i < this.batchItems.length; i++) {
-      if (this.batchAborted) return;
-      const item = this.batchItems[i];
-      if (item.state === 'done' || item.state === 'discarded') continue;
-      if (this.batchGrid) this.batchGrid.setCurrentIndex(i);
-      item.state = 'processing';
-      // Fresh slate for this item: empty history, empty live console.
-      item.stageHistory = [];
-      this.progress.reset();
-      this.progress.setRunning(true);
-      this.batchCurrentProcessingItem = item;
-      if (this.batchGrid) this.batchGrid.updateItem(item.id, 'processing');
-      // One signal per batch item so cancelling the batch aborts the
-      // in-flight one promptly without waiting for the current stage.
-      this.processingAbortController = new AbortController();
-      try {
-        const result = await this.pipeline!.process(
-          item.imageData,
-          ArApp.MODEL_ID,
-          'high-power',
-          this.processingAbortController.signal,
-        );
-        if (this.batchAborted) return;
-        const composed = composeAtOriginal({
-          originalRgba: item.originalImageData.data,
-          originalWidth: item.originalImageData.width,
-          originalHeight: item.originalImageData.height,
-          workingRgba: result.workingPixels,
-          workingWidth: result.workingWidth,
-          workingHeight: result.workingHeight,
-          workingAlpha: result.workingAlpha,
-          inpaintMask: result.watermarkMask,
-        });
-        const finalImageData =
-          result.contentType === 'PHOTO' || result.contentType === 'ILLUSTRATION'
-            ? promoteSpeckleAlpha(fillSubjectHoles(dropOrphanBlobs(composed)))
-            : composed;
-        item.result = result;
-        item.finalImageData = finalImageData;
-        item.thumbnailUrl = this.makeThumbnail(finalImageData);
-        item.state = 'done';
-        if (this.batchGrid) this.batchGrid.updateItem(item.id, 'done', item.thumbnailUrl);
-        // If the user is currently watching this item's live detail view,
-        // swap it to the done view so they see the result without going back.
-        if (this.batchDetailId === item.id) {
-          await this.openBatchDetail(item.id);
-        }
-      } catch (err) {
-        // Abort during batch = user cancelled. Don't mark the item as
-        // failed; the outer batchAborted check will return on next tick.
-        if (err instanceof PipelineAbortError || this.batchAborted) {
-          this.progress.setRunning(false);
-          return;
-        }
-        item.errorMessage = err instanceof Error ? err.message : String(err);
-        item.state = 'failed';
-        if (this.batchGrid) this.batchGrid.updateItem(item.id, 'failed');
-        if (this.batchDetailId === item.id) {
-          await this.openBatchDetail(item.id);
-        }
-      }
-    }
-    this.progress.setRunning(false);
-    this.batchCurrentProcessingItem = null;
-  }
-
-  /** Replay a finished item's captured stage events into the shared
-   * progress console. Resets first so no stale state from the previous
-   * item leaks through, then reapplies each snapshot in order. */
-  private replayStageHistory(history: StageSnapshot[]): void {
-    this.progress.reset();
-    for (const snap of history) {
-      this.progress.setStage(snap.stage, snap.status, snap.message);
-    }
+    this.batch.setMode(mode);
   }
 
   private async openBatchDetail(id: string): Promise<void> {
-    const item = this.batchItems.find((i) => i.id === id);
+    const item = this.batch.findItem(id);
     if (!item) return;
-    this.batchDetailId = id;
+    this.batch.setDetailId(id);
 
     const failedBar = this.shadowRoot!.querySelector('#batch-failed-bar') as HTMLElement;
     const retryBtn = this.shadowRoot!.querySelector('#batch-retry-btn') as HTMLElement;
@@ -2031,7 +1925,7 @@ export class ArApp extends HTMLElement {
       // Fallback for edge cases where nothing was captured: synthesize a
       // single error stage so the user still sees what went wrong.
       if (item.stageHistory.length > 0) {
-        this.replayStageHistory(item.stageHistory);
+        this.batch.replayStageHistory(item.stageHistory);
       } else {
         this.progress.reset();
         this.progress.setStage(
@@ -2066,7 +1960,7 @@ export class ArApp extends HTMLElement {
       // Replay per-item stage history so each finished image shows its own
       // icons (done/skipped) and timings — previously we just reset(),
       // which left every stage 'pending' and blanked out every icon.
-      this.replayStageHistory(item.stageHistory);
+      this.batch.replayStageHistory(item.stageHistory);
       this.download.reset();
       const finalImageData = item.finalImageData ?? item.result.imageData;
       const blob = await exportPng(finalImageData);
@@ -2087,7 +1981,7 @@ export class ArApp extends HTMLElement {
   }
 
   private closeBatchDetail(): void {
-    this.batchDetailId = null;
+    this.batch.setDetailId(null);
     this.preEditResult = null;
     this.cachedEditResult = null;
     this.lastResultImageData = null;
@@ -2104,37 +1998,17 @@ export class ArApp extends HTMLElement {
   }
 
   private async retryBatchItem(): Promise<void> {
-    if (!this.batchDetailId) return;
-    const item = this.batchItems.find((i) => i.id === this.batchDetailId);
-    if (!item) return;
-    item.state = 'pending';
-    item.errorMessage = undefined;
-    item.stageHistory = [];
-    if (this.batchGrid) this.batchGrid.updateItem(item.id, 'pending');
+    const id = this.batch.getDetailId();
+    if (!id) return;
     this.closeBatchDetail();
-    await this.runBatchQueue();
+    await this.batch.retry(id);
   }
 
   private discardBatchItem(): void {
-    if (!this.batchDetailId) return;
-    const item = this.batchItems.find((i) => i.id === this.batchDetailId);
-    if (!item) return;
-    item.state = 'discarded';
-    if (this.batchGrid) this.batchGrid.updateItem(item.id, 'discarded');
+    const id = this.batch.getDetailId();
+    if (!id) return;
+    this.batch.markDiscarded(id);
     this.closeBatchDetail();
-  }
-
-  private async downloadBatchZip(): Promise<void> {
-    const done = this.batchItems.filter((i) => i.state === 'done' && i.result);
-    if (done.length === 0) return;
-    const files = await Promise.all(
-      done.map(async (item, idx) => ({
-        name: safeZipEntryName(idx + 1, done.length, item.originalName),
-        blob: await exportPng(item.finalImageData ?? item.result!.imageData),
-      })),
-    );
-    const zip = await createZip(files);
-    downloadBlob(zip, `nukebg-batch-${Date.now()}.zip`);
   }
 
   private resetToIdle(): void {
@@ -2162,14 +2036,12 @@ export class ArApp extends HTMLElement {
     this.currentImageData = null;
     this.currentOriginalImageData = null;
 
-    if (this.batchMode !== 'off') {
-      this.batchAborted = true;
+    if (this.batch.isInBatchMode()) {
+      this.batch.abort();
       // Stop the in-flight pipeline run too — otherwise workers keep
       // processing the current item until its natural stage boundary.
       this.processingAbortController?.abort('batch aborted');
-      this.batchItems = [];
-      this.batchDetailId = null;
-      this.batchMode = 'off';
+      this.batch.reset();
     }
     // Keep pipeline alive for next image (model stays loaded)
   }

--- a/src/components/ar-app.ts
+++ b/src/components/ar-app.ts
@@ -2,7 +2,8 @@ import { PipelineOrchestrator, PipelineAbortError } from '../pipeline/orchestrat
 import type { PipelineStage, StageStatus } from '../types/pipeline';
 import type { ModelId } from '../types/worker-messages';
 import { t } from '../i18n';
-import { installApp, isAppInstalled } from '../sw-register';
+import { isAppInstalled } from '../sw-register';
+import { AppInstaller } from '../controllers/app-install';
 import type { ArViewer } from './ar-viewer';
 import type { ArProgress } from './ar-progress';
 import type { ArDownload } from './ar-download';
@@ -42,8 +43,11 @@ export class ArApp extends HTMLElement {
   private preEditResult: ImageData | null = null;
   private cachedEditResult: ImageData | null = null;
   private boundLocaleHandler: (() => void) | null = null;
-  private boundPwaInstallableHandler: (() => void) | null = null;
   private abortController: AbortController | null = null;
+  /** Owns PWA install button + guide wiring. Initialized in
+   *  setupComponents() once the install-btn / install-guide nodes
+   *  exist. See #47/Phase-1b. */
+  private installer!: AppInstaller;
   private batchGrid: ArBatchGrid | null = null;
   /** Owns batch queue state + per-item processing loop. Wired up in
    *  setupComponents() once UI refs are resolved. See #47/Phase-1. */
@@ -137,8 +141,6 @@ export class ArApp extends HTMLElement {
   disconnectedCallback(): void {
     if (this.boundLocaleHandler)
       document.removeEventListener('nukebg:locale-changed', this.boundLocaleHandler);
-    if (this.boundPwaInstallableHandler)
-      document.removeEventListener('nukebg:pwa-installable', this.boundPwaInstallableHandler);
     this.abortController?.abort();
     this.abortController = null;
   }
@@ -1045,6 +1047,12 @@ export class ArApp extends HTMLElement {
     this.dropzone = this.shadowRoot!.querySelector('ar-dropzone')! as ArDropzone;
     this.batchGrid = this.shadowRoot!.querySelector('#batch-grid') as ArBatchGrid;
 
+    // PWA install button + guide controller. Lifetime tied to ar-app
+    // via the AbortSignal handed to attach() in setupEvents().
+    const installBtn = this.shadowRoot!.querySelector('#install-btn') as HTMLButtonElement;
+    const installGuide = this.shadowRoot!.querySelector('#install-guide') as HTMLDivElement;
+    this.installer = new AppInstaller(installBtn, installGuide);
+
     // Batch orchestrator owns queue state + per-item processing. Host
     // (this component) keeps the pipeline + AbortController + thumbnail
     // helper + UI swap, exposed through the BatchHost interface.
@@ -1118,11 +1126,7 @@ export class ArApp extends HTMLElement {
     if (statusLimBody) statusLimBody.innerHTML = t('features.limitations');
     const editBtn = root.querySelector('#edit-btn');
     if (editBtn) editBtn.textContent = this.preEditResult ? t('edit.discard') : t('edit.btn');
-    const installBtnEl = root.querySelector('#install-btn') as HTMLButtonElement;
-    if (installBtnEl) {
-      installBtnEl.textContent = isAppInstalled() ? t('pwa.installed') : t('pwa.install');
-      installBtnEl.setAttribute('aria-label', t('pwa.install'));
-    }
+    this.installer?.refreshText();
     const backBtnEl = root.querySelector('#back-to-grid-btn');
     if (backBtnEl) backBtnEl.textContent = t('batch.backToGrid');
     const retryBtnEl = root.querySelector('#batch-retry-btn');
@@ -1149,19 +1153,6 @@ export class ArApp extends HTMLElement {
             : 'cmdbar.failed';
       cmdStateLabel.textContent = t(key);
     }
-  }
-
-  private getInstallGuide(): string {
-    const ua = navigator.userAgent.toLowerCase();
-    let steps: string;
-    if (/firefox/i.test(ua)) {
-      steps = t('pwa.guideFirefox');
-    } else if (/iphone|ipad|ipod/i.test(ua)) {
-      steps = t('pwa.guideSafari');
-    } else {
-      steps = t('pwa.guideGeneric');
-    }
-    return `<div class="guide-motivation">${t('pwa.guideMotivation')}</div>${steps}<br><button class="install-guide-close">${t('pwa.guideDismiss')}</button>`;
   }
 
   private setupEvents(): void {
@@ -1243,68 +1234,9 @@ export class ArApp extends HTMLElement {
       }
     });
 
-    // PWA install button - mobile only
-    const installBtn = this.shadowRoot!.querySelector('#install-btn') as HTMLButtonElement;
-    const installGuide = this.shadowRoot!.querySelector('#install-guide') as HTMLDivElement;
-    let hasNativePrompt = false;
-
-    // If already installed, show the installed state
-    if (isAppInstalled()) {
-      installBtn.textContent = t('pwa.installed');
-      installBtn.classList.add('visible');
-      installBtn.disabled = true;
-    }
-
-    // Show install button when PWA native prompt is available (Chromium)
-    this.boundPwaInstallableHandler = () => {
-      hasNativePrompt = true;
-      if (!isAppInstalled()) {
-        installBtn.textContent = t('pwa.install');
-        installBtn.classList.add('visible');
-        installBtn.disabled = false;
-      }
-    };
-    document.addEventListener('nukebg:pwa-installable', this.boundPwaInstallableHandler);
-
-    // On mobile without native prompt, show install button after a delay
-    // (Firefox, Safari - they can install but need manual steps)
-    const isMobile = window.matchMedia('(hover: none), (pointer: coarse)').matches;
-    if (isMobile && !isAppInstalled()) {
-      setTimeout(() => {
-        if (!hasNativePrompt) {
-          installBtn.textContent = t('pwa.install');
-          installBtn.classList.add('visible');
-          installBtn.disabled = false;
-        }
-      }, 2000);
-    }
-
-    installBtn.addEventListener(
-      'click',
-      async () => {
-        // If native prompt available (Chromium), use it
-        if (hasNativePrompt) {
-          const accepted = await installApp();
-          if (accepted) {
-            installBtn.textContent = t('pwa.installed');
-            installBtn.disabled = true;
-            installGuide.classList.remove('visible');
-          }
-          return;
-        }
-        // Otherwise show browser-specific instructions
-        const guide = this.getInstallGuide();
-        installGuide.innerHTML = guide;
-        installGuide.classList.toggle('visible');
-        const closeBtn = installGuide.querySelector('.install-guide-close');
-        if (closeBtn) {
-          closeBtn.addEventListener('click', () => installGuide.classList.remove('visible'), {
-            signal,
-          });
-        }
-      },
-      { signal },
-    );
+    // PWA install button + guide — controller owns the wiring and uses
+    // the same AbortSignal so cleanup is automatic on disconnect.
+    this.installer.attach(signal);
 
     this.shadowRoot!.addEventListener(
       'ar:image-loaded',

--- a/src/components/ar-editor-advanced.ts
+++ b/src/components/ar-editor-advanced.ts
@@ -641,6 +641,13 @@ export class ArEditorAdvanced extends HTMLElement {
         }
         canvas.disabled { cursor: not-allowed; pointer-events: none; }
         canvas.panning { cursor: grabbing; }
+        /* Keyboard focus ring (#186). Canvas is focusable via
+           tabindex="0"; without an explicit rule, shadow-DOM scope
+           hides the document-level :focus-visible style. */
+        canvas:focus-visible {
+          outline: 2px solid var(--color-accent-primary, #00ff41);
+          outline-offset: 2px;
+        }
         .zoom-group {
           display: inline-flex;
           border: 1px solid var(--color-accent-primary, #00ff41);

--- a/src/components/ar-editor-advanced.ts
+++ b/src/components/ar-editor-advanced.ts
@@ -30,13 +30,7 @@
 
 import { createLoader, type ModelLoader } from '../refine/loaders';
 import { refineEdges } from '../pipeline/finalize';
-import {
-  loadSam,
-  encodeSam,
-  decodeSam,
-  disposeSam,
-  onSamProgress,
-} from '../refine/loaders/mobile-sam';
+import { SamRefiner } from '../controllers/sam-refiner';
 import { processRoi } from '../refine/roi-process';
 import { rasterizePolygon } from '../refine/roi-process';
 import { patchMatchInpaint } from '../workers/cv/patchmatch-inpaint';
@@ -133,7 +127,12 @@ export class ArEditorAdvanced extends HTMLElement {
   private actionAbort: AbortController | null = null;
 
   // SAM state — lazy-loaded on first Refine, encoder runs once per image.
-  private samEncoded = false;
+  /** MobileSAM lifecycle wrapper (load/encode/decode/dispose + the
+   *  encoded flag). See `src/controllers/sam-refiner.ts` (#47/Phase-3c).
+   *  Progress callback is wired in setupSamRefiner() once shadowRoot
+   *  has rendered so we can find the #hint element. */
+  private samRefiner = new SamRefiner();
+  private samProgressWired = false;
 
   private bgColor = 'transparent';
 
@@ -163,14 +162,13 @@ export class ArEditorAdvanced extends HTMLElement {
   disconnectedCallback(): void {
     this.abort?.abort();
     this.abort = null;
-    disposeSam();
-    this.samEncoded = false;
+    this.samRefiner.dispose();
   }
 
   setImage(current: ImageData, original: ImageData): void {
     this.current = current;
     this.original = original;
-    this.samEncoded = false;
+    this.samRefiner.invalidate();
     this.clearLasso();
     this.clearSelection();
     this.rebuildBackingBuffers();
@@ -1942,25 +1940,15 @@ export class ArEditorAdvanced extends HTMLElement {
     ];
   }
 
-  private async ensureSamEncoded(signal: AbortSignal): Promise<void> {
-    if (this.samEncoded) return;
-    if (!this.original) throw new Error('No image loaded');
-
-    const hint = this.shadowRoot?.getElementById('hint');
-
-    onSamProgress((pct, stage) => {
+  /** Lazy progress wiring: the #hint element doesn't exist until render
+   *  has run, so we defer the callback until the first SAM action. */
+  private wireSamProgressOnce(): void {
+    if (this.samProgressWired) return;
+    this.samRefiner.setProgressCallback((pct, stage) => {
+      const hint = this.shadowRoot?.getElementById('hint');
       if (hint) hint.textContent = t('advanced.samLoading', { pct: String(pct), stage });
     });
-
-    if (signal.aborted) throw new DOMException('Aborted', 'AbortError');
-    await loadSam();
-
-    if (signal.aborted) throw new DOMException('Aborted', 'AbortError');
-    if (hint) hint.textContent = t('advanced.samEncoding');
-    await encodeSam(this.original.data, this.original.width, this.original.height);
-
-    onSamProgress(null);
-    this.samEncoded = true;
+    this.samProgressWired = true;
   }
 
   private async refineWithSam(
@@ -1970,10 +1958,19 @@ export class ArEditorAdvanced extends HTMLElement {
     h: number,
     signal: AbortSignal,
   ): Promise<Uint8Array> {
-    await this.ensureSamEncoded(signal);
-    if (signal.aborted) throw new DOMException('Aborted', 'AbortError');
+    if (!this.original) throw new Error('No image loaded');
+    this.wireSamProgressOnce();
 
     const hint = this.shadowRoot?.getElementById('hint');
+    if (hint) hint.textContent = t('advanced.samEncoding');
+    await this.samRefiner.ensureEncoded(
+      this.original.data,
+      this.original.width,
+      this.original.height,
+      signal,
+    );
+    if (signal.aborted) throw new DOMException('Aborted', 'AbortError');
+
     if (hint) hint.textContent = t('advanced.working');
 
     let minX = w,
@@ -1991,7 +1988,7 @@ export class ArEditorAdvanced extends HTMLElement {
     maxX = Math.min(w - 1, Math.ceil(maxX));
     maxY = Math.min(h - 1, Math.ceil(maxY));
 
-    const samResult = await decodeSam(
+    const samResult = await this.samRefiner.decode(
       [
         { x: minX, y: minY },
         { x: maxX, y: maxY },

--- a/src/components/ar-editor-advanced.ts
+++ b/src/components/ar-editor-advanced.ts
@@ -42,7 +42,8 @@ import { rasterizePolygon } from '../refine/roi-process';
 import { patchMatchInpaint } from '../workers/cv/patchmatch-inpaint';
 import { PATCHMATCH_PARAMS } from '../pipeline/constants';
 import { t } from '../i18n';
-import { simplifyClosed, type Point } from './lasso-simplify';
+import { type Point } from './lasso-simplify';
+import { LassoModel } from '../lib/lasso-model';
 
 const PAD_RATIO = 0.25;
 const DEFAULT_BRUSH = 24;
@@ -121,9 +122,9 @@ export class ArEditorAdvanced extends HTMLElement {
 
   // Lasso state (all coordinates in image-space — may be outside [0..w/h]
   // because the canvas is padded and loops can cross the image edge).
-  private lassoRaw: Point[] | null = null;
-  private lassoAnchors: Point[] | null = null;
-  private dragAnchorIndex: number | null = null;
+  /** Lasso state machine (raw path → simplified polygon → anchor drags).
+   *  Pure data, no DOM. See `src/lib/lasso-model.ts` (#47/Phase-3a). */
+  private lasso = new LassoModel();
 
   // Shared RMBG-1.4 loader, warmed on first refine and reused afterwards.
   private loader: ModelLoader | null = null;
@@ -1059,7 +1060,7 @@ export class ArEditorAdvanced extends HTMLElement {
             this.cancelAction();
             return;
           }
-          if (this.lassoAnchors || this.lassoRaw) {
+          if (this.lasso.getAnchors() || this.lasso.getRawPath()) {
             this.clearLasso();
             this.redrawDisplay();
           }
@@ -1120,10 +1121,10 @@ export class ArEditorAdvanced extends HTMLElement {
     if (this.tool === 'lasso') {
       if (this.pendingPreview) this.cancelPreview();
 
-      if (this.lassoAnchors) {
+      if (this.lasso.isClosed()) {
         const idx = this.hitAnchor(ix, iy);
         if (idx !== null) {
-          this.dragAnchorIndex = idx;
+          this.lasso.beginDragAnchor(idx);
           try {
             this.canvas.setPointerCapture(e.pointerId);
           } catch {
@@ -1142,7 +1143,7 @@ export class ArEditorAdvanced extends HTMLElement {
         /* noop */
       }
       this.drawing = true;
-      this.lassoRaw = [{ x: ix, y: iy }];
+      this.lasso.startAt({ x: ix, y: iy });
       this.redrawDisplay();
       return;
     }
@@ -1179,15 +1180,16 @@ export class ArEditorAdvanced extends HTMLElement {
     const [ix, iy] = this.eventToImageCoords(e);
 
     if (this.tool === 'lasso') {
-      if (this.dragAnchorIndex !== null && this.lassoAnchors) {
-        this.lassoAnchors[this.dragAnchorIndex] = { x: ix, y: iy };
+      const dragIdx = this.lasso.getDragAnchorIndex();
+      if (dragIdx !== null) {
+        this.lasso.moveAnchor(dragIdx, { x: ix, y: iy });
         this.redrawDisplay();
         return;
       }
-      if (this.drawing && this.lassoRaw) {
-        const last = this.lassoRaw[this.lassoRaw.length - 1];
-        if (Math.hypot(ix - last.x, iy - last.y) >= MIN_LASSO_POINT_DIST) {
-          this.lassoRaw.push({ x: ix, y: iy });
+      if (this.drawing && this.lasso.getRawPath()) {
+        const before = this.lasso.getRawPath()!.length;
+        this.lasso.addRawPoint({ x: ix, y: iy }, MIN_LASSO_POINT_DIST);
+        if (this.lasso.getRawPath()!.length !== before) {
           this.redrawDisplay();
           return;
         }
@@ -1222,24 +1224,21 @@ export class ArEditorAdvanced extends HTMLElement {
     }
 
     if (this.tool === 'lasso') {
-      if (this.dragAnchorIndex !== null) {
-        this.dragAnchorIndex = null;
+      if (this.lasso.getDragAnchorIndex() !== null) {
+        this.lasso.endDragAnchor();
         return;
       }
-      if (this.drawing && this.lassoRaw) {
-        if (this.lassoRaw.length >= MIN_ANCHORS) {
-          const w = this.current?.width ?? 0;
-          const h = this.current?.height ?? 0;
-          const eps = Math.max(1.5, Math.min(w, h) * LASSO_EPS_RATIO);
-          this.lassoAnchors = simplifyClosed(this.lassoRaw, eps);
-          if (this.lassoAnchors.length < MIN_ANCHORS) this.lassoAnchors = null;
-        }
-        this.lassoRaw = null;
+      if (this.drawing && this.lasso.getRawPath()) {
+        const w = this.current?.width ?? 0;
+        const h = this.current?.height ?? 0;
+        const eps = Math.max(1.5, Math.min(w, h) * LASSO_EPS_RATIO);
+        this.lasso.setSimplifyEpsilon(eps);
+        this.lasso.close();
       }
       this.drawing = false;
       this.syncLassoActionsUI();
       this.redrawDisplay();
-      if (this.lassoAnchors) {
+      if (this.lasso.isClosed()) {
         this.rmbgDecodeFromLasso();
       }
       return;
@@ -1249,12 +1248,11 @@ export class ArEditorAdvanced extends HTMLElement {
   }
 
   private onDblClick(e: MouseEvent): void {
-    if (this.tool !== 'lasso' || !this.lassoAnchors) return;
+    if (this.tool !== 'lasso' || !this.lasso.isClosed()) return;
     const [ix, iy] = this.eventToImageCoordsFromMouse(e);
     const idx = this.hitAnchor(ix, iy);
     if (idx === null) return;
-    if (this.lassoAnchors.length <= MIN_ANCHORS) return;
-    this.lassoAnchors.splice(idx, 1);
+    if (!this.lasso.removeAnchor(idx)) return;
     this.syncLassoActionsUI();
     this.redrawDisplay();
   }
@@ -1296,16 +1294,7 @@ export class ArEditorAdvanced extends HTMLElement {
   }
 
   private hitAnchor(ix: number, iy: number): number | null {
-    if (!this.lassoAnchors) return null;
-    const tol = this.anchorRadius() + 4;
-    const tolSq = tol * tol;
-    for (let i = 0; i < this.lassoAnchors.length; i++) {
-      const a = this.lassoAnchors[i];
-      const dx = a.x - ix;
-      const dy = a.y - iy;
-      if (dx * dx + dy * dy <= tolSq) return i;
-    }
-    return null;
+    return this.lasso.hitAnchor(ix, iy, this.anchorRadius() + 4);
   }
 
   private applyStrokeSegment(fromX: number, fromY: number, toX: number, toY: number): void {
@@ -1394,7 +1383,7 @@ export class ArEditorAdvanced extends HTMLElement {
     this.lastPinchDist = this.getPinchDist(e.touches);
     // Cancel any brush stroke that might have started on the first touch.
     this.drawing = false;
-    this.dragAnchorIndex = null;
+    this.lasso.endDragAnchor();
   }
 
   private onTouchMove(e: TouchEvent): void {
@@ -1539,10 +1528,7 @@ export class ArEditorAdvanced extends HTMLElement {
     const busy = this.shadowRoot?.getElementById('busy');
     const hint = this.shadowRoot?.getElementById('hint');
     if (!row || !previewRow) return;
-    const hasAnchors =
-      this.tool === 'lasso' &&
-      this.lassoAnchors !== null &&
-      this.lassoAnchors.length >= MIN_ANCHORS;
+    const hasAnchors = this.tool === 'lasso' && this.lasso.isClosed();
     const hasSelection = this.tool === 'lasso' && this.selectionMask !== null;
     const isPreviewing = this.pendingPreview !== null;
     row.classList.toggle('visible', (hasAnchors || hasSelection) && !isPreviewing);
@@ -1561,9 +1547,7 @@ export class ArEditorAdvanced extends HTMLElement {
   }
 
   private clearLasso(): void {
-    this.lassoRaw = null;
-    this.lassoAnchors = null;
-    this.dragAnchorIndex = null;
+    this.lasso.clear();
     this.pendingPreview = null;
     this.syncLassoActionsUI();
   }
@@ -1602,7 +1586,8 @@ export class ArEditorAdvanced extends HTMLElement {
     if (!this.ctx) return;
 
     // Raw in-progress path — open polyline. Always visible, even over Quick Mask.
-    if (this.lassoRaw && this.lassoRaw.length > 1) {
+    const rawPath = this.lasso.getRawPath();
+    if (rawPath && rawPath.length > 1) {
       this.ctx.save();
       const accentRgb =
         getComputedStyle(document.documentElement).getPropertyValue('--color-accent-rgb').trim() ||
@@ -1613,10 +1598,10 @@ export class ArEditorAdvanced extends HTMLElement {
       this.ctx.shadowBlur = 3;
       this.ctx.setLineDash([]);
       this.ctx.beginPath();
-      const p0 = this.lassoRaw[0];
+      const p0 = rawPath[0];
       this.ctx.moveTo(p0.x + this.padX, p0.y + this.padY);
-      for (let i = 1; i < this.lassoRaw.length; i++) {
-        this.ctx.lineTo(this.lassoRaw[i].x + this.padX, this.lassoRaw[i].y + this.padY);
+      for (let i = 1; i < rawPath.length; i++) {
+        this.ctx.lineTo(rawPath[i].x + this.padX, rawPath[i].y + this.padY);
       }
       this.ctx.stroke();
       this.ctx.restore();
@@ -1627,8 +1612,9 @@ export class ArEditorAdvanced extends HTMLElement {
     // handles intentionally omitted: anchors are not draggable, so showing
     // them just adds visual noise. Match cursor-preview line width (2) for
     // stroke consistency across tools.
-    if (!this.selectionMask && this.lassoAnchors && this.lassoAnchors.length >= MIN_ANCHORS) {
-      const pts = this.lassoAnchors;
+    const anchors = this.lasso.getAnchors();
+    if (!this.selectionMask && anchors && anchors.length >= MIN_ANCHORS) {
+      const pts = anchors;
       this.ctx.save();
       const accentRgb2 =
         getComputedStyle(document.documentElement).getPropertyValue('--color-accent-rgb').trim() ||
@@ -1680,7 +1666,8 @@ export class ArEditorAdvanced extends HTMLElement {
     // skips the preview/confirm pattern — inpainting is non-destructive
     // and any mistake is one Ctrl+Z away.
     if (this.busy) return;
-    const hasLasso = this.lassoAnchors !== null && this.lassoAnchors.length >= MIN_ANCHORS;
+    const hasLasso = this.lasso.isClosed();
+    const lassoAnchors = this.lasso.getAnchors();
     const hasMask = this.selectionMask !== null;
     if (!hasLasso && !hasMask) return;
     if (!this.working || !this.original || !this.current) return;
@@ -1712,7 +1699,7 @@ export class ArEditorAdvanced extends HTMLElement {
       let newAlpha: Uint8Array;
 
       if (kind === 'refine') {
-        const poly = this.lassoAnchors ?? this.selectionMaskToPolygon(w, h);
+        const poly = lassoAnchors ? [...lassoAnchors] : this.selectionMaskToPolygon(w, h);
         if (!poly || poly.length < MIN_ANCHORS) throw new Error('No region for refine');
         newAlpha = await this.refineWithSam(poly, prevAlpha, w, h, ac.signal);
       } else if (hasMask) {
@@ -1730,7 +1717,7 @@ export class ArEditorAdvanced extends HTMLElement {
       } else {
         const result = await processRoi({
           original: workingData,
-          polygon: this.lassoAnchors!,
+          polygon: [...lassoAnchors!],
           previousAlpha: prevAlpha,
           mode: kind,
           segment,
@@ -1848,11 +1835,12 @@ export class ArEditorAdvanced extends HTMLElement {
   private async removeWatermarkInLasso(): Promise<void> {
     if (this.busy) return;
     if (!this.working || !this.current) return;
-    if (!this.lassoAnchors || this.lassoAnchors.length < MIN_ANCHORS) return;
+    const lassoAnchors = this.lasso.getAnchors();
+    if (!lassoAnchors || lassoAnchors.length < MIN_ANCHORS) return;
 
     const w = this.current.width;
     const h = this.current.height;
-    const mask = rasterizePolygon(this.lassoAnchors, w, h);
+    const mask = rasterizePolygon([...lassoAnchors], w, h);
 
     this.busy = true;
     this.syncBusyUI();
@@ -2030,8 +2018,9 @@ export class ArEditorAdvanced extends HTMLElement {
   // ────────────────────── RMBG lasso selection ──────────────────────────
 
   private async rmbgDecodeFromLasso(): Promise<void> {
-    if (!this.current || !this.original || !this.lassoAnchors) return;
-    if (this.lassoAnchors.length < MIN_ANCHORS) return;
+    if (!this.current || !this.original) return;
+    const lassoAnchors = this.lasso.getAnchors();
+    if (!lassoAnchors || lassoAnchors.length < MIN_ANCHORS) return;
 
     const w = this.current.width;
     const h = this.current.height;
@@ -2055,7 +2044,7 @@ export class ArEditorAdvanced extends HTMLElement {
 
       const result = await processRoi({
         original: workingData,
-        polygon: this.lassoAnchors,
+        polygon: [...lassoAnchors],
         previousAlpha: null,
         mode: 'crop',
         segment,
@@ -2074,8 +2063,7 @@ export class ArEditorAdvanced extends HTMLElement {
           if (segMask[i] === 1) this.selectionMask[i] = 1;
         }
       }
-      this.lassoAnchors = null;
-      this.lassoRaw = null;
+      this.lasso.clear();
       this.rebuildSelectionOverlay();
       this.redrawDisplay();
     } catch (err) {

--- a/src/components/ar-editor-advanced.ts
+++ b/src/components/ar-editor-advanced.ts
@@ -44,6 +44,7 @@ import { PATCHMATCH_PARAMS } from '../pipeline/constants';
 import { t } from '../i18n';
 import { type Point } from './lasso-simplify';
 import { LassoModel } from '../lib/lasso-model';
+import { HistoryManager } from '../lib/history-manager';
 
 const PAD_RATIO = 0.25;
 const DEFAULT_BRUSH = 24;
@@ -147,13 +148,11 @@ export class ArEditorAdvanced extends HTMLElement {
   private selectionOverlay: HTMLCanvasElement | null = null;
   private selectionHistory: Uint8Array[] = [];
 
-  // Undo/redo stacks of full RGBA snapshots (Uint8ClampedArray, image size).
+  // Undo/redo of full RGBA snapshots (Uint8ClampedArray, image size).
   // Full snapshots match ar-editor's pattern — simple, robust, and still
   // cheap to swap in. Depth is budget-capped per-image so we don't OOM on
   // 20-100MP payloads; see `computeMaxHistory`.
-  private undoStack: Uint8ClampedArray[] = [];
-  private redoStack: Uint8ClampedArray[] = [];
-  private maxHistory = 8;
+  private workingHistory = new HistoryManager<Uint8ClampedArray>(8);
 
   private abort: AbortController | null = null;
 
@@ -190,10 +189,11 @@ export class ArEditorAdvanced extends HTMLElement {
   }
 
   private resetHistory(): void {
-    this.undoStack = [];
-    this.redoStack = [];
+    this.workingHistory.clear();
     if (this.current) {
-      this.maxHistory = this.computeMaxHistory(this.current.width, this.current.height);
+      this.workingHistory.setMaxEntries(
+        this.computeMaxHistory(this.current.width, this.current.height),
+      );
     }
     this.syncHistoryUI();
   }
@@ -217,19 +217,16 @@ export class ArEditorAdvanced extends HTMLElement {
   private pushUndo(): void {
     const snap = this.snapshotWorking();
     if (!snap) return;
-    this.undoStack.push(snap);
-    if (this.undoStack.length > this.maxHistory) this.undoStack.shift();
-    // Any new action invalidates the redo branch.
-    this.redoStack = [];
+    this.workingHistory.push(snap);
     this.syncHistoryUI();
   }
 
   private undo(): void {
     if (this.tool === 'lasso' && this.undoSelection()) return;
-    if (this.undoStack.length === 0) return;
-    const before = this.undoStack.pop()!;
-    const after = this.snapshotWorking();
-    if (after) this.redoStack.push(after);
+    const current = this.snapshotWorking();
+    if (!current) return;
+    const before = this.workingHistory.undo(current);
+    if (!before) return;
     this.restoreWorking(before);
     this.clearLasso();
     this.redrawDisplay();
@@ -237,10 +234,10 @@ export class ArEditorAdvanced extends HTMLElement {
   }
 
   private redo(): void {
-    if (this.redoStack.length === 0) return;
-    const next = this.redoStack.pop()!;
     const current = this.snapshotWorking();
-    if (current) this.undoStack.push(current);
+    if (!current) return;
+    const next = this.workingHistory.redo(current);
+    if (!next) return;
     this.restoreWorking(next);
     this.clearLasso();
     this.redrawDisplay();
@@ -250,8 +247,8 @@ export class ArEditorAdvanced extends HTMLElement {
   private syncHistoryUI(): void {
     const undoBtn = this.shadowRoot?.getElementById('undo') as HTMLButtonElement | null;
     const redoBtn = this.shadowRoot?.getElementById('redo') as HTMLButtonElement | null;
-    if (undoBtn) undoBtn.disabled = this.busy || this.undoStack.length === 0;
-    if (redoBtn) redoBtn.disabled = this.busy || this.redoStack.length === 0;
+    if (undoBtn) undoBtn.disabled = this.busy || !this.workingHistory.canUndo();
+    if (redoBtn) redoBtn.disabled = this.busy || !this.workingHistory.canRedo();
   }
 
   private syncBusyUI(): void {

--- a/src/components/ar-editor.ts
+++ b/src/components/ar-editor.ts
@@ -5,22 +5,15 @@
  */
 
 import { t } from '../i18n';
-
-type BrushShape = 'circle' | 'square';
-
-interface HistoryEntry {
-  // Full RGBA snapshot. Needed because the Restore tool writes RGB (not just
-  // alpha); alpha-only snapshots cannot undo color changes. Bounded by
-  // maxHistory to keep memory predictable on large images.
-  rgba: Uint8ClampedArray;
-}
+import { BrushStroke, type BrushShape, type BrushTool } from '../lib/brush-stroke';
+import { HistoryManager } from '../lib/history-manager';
 
 /** Generate a CSS cursor data URL that matches the brush shape, size and tool */
 function makeBrushCursor(
   size: number,
   shape: BrushShape,
   zoom: number,
-  tool: 'erase' | 'restore' = 'erase',
+  tool: BrushTool = 'erase',
 ): string {
   const raw = size * zoom;
   // Defensive: Number.isFinite guards against NaN from upstream state bugs.
@@ -82,7 +75,7 @@ export class ArEditor extends HTMLElement {
   // Brush state
   private brushSize = 20;
   private brushShape: BrushShape = 'circle';
-  private tool: 'erase' | 'restore' = 'erase';
+  private tool: BrushTool = 'erase';
   private isErasing = false;
 
   // Background preview
@@ -93,12 +86,10 @@ export class ArEditor extends HTMLElement {
   private lastPinchDist = 0;
   private isTouchErasing = false;
 
-  // History
-  private undoStack: HistoryEntry[] = [];
-  private redoStack: HistoryEntry[] = [];
-  // Full-RGBA snapshots × maxHistory — budget this conservatively so large
-  // images (up to 4096² ≈ 67 MB per entry) don't blow RAM.
-  private maxHistory = 12;
+  // History — full-RGBA snapshots, FIFO cap. Restore tool writes RGB (not
+  // just alpha); alpha-only snapshots can't undo color changes. Cap = 12
+  // so large images (up to 4096² ≈ 67 MB per entry) don't blow RAM.
+  private history = new HistoryManager<Uint8ClampedArray>(12);
   private boundLocaleHandler: (() => void) | null = null;
   private abortController: AbortController | null = null;
 
@@ -997,8 +988,7 @@ export class ArEditor extends HTMLElement {
       this.height,
     );
 
-    this.undoStack = [];
-    this.redoStack = [];
+    this.history.clear();
     this.updateUndoRedoButtons();
 
     this.fitToView();
@@ -1251,30 +1241,14 @@ export class ArEditor extends HTMLElement {
    */
   private stamp(cx: number, cy: number): void {
     if (!this.imageData || !this.originalImage) return;
-    const data = this.imageData.data;
-    const src = this.originalImage.data;
-    const restore = this.tool === 'restore';
-    const r = Math.floor(this.brushSize / 2);
-    const circle = this.brushShape === 'circle';
-    const r2 = r * r;
-
-    for (let dy = -r; dy <= r; dy++) {
-      for (let dx = -r; dx <= r; dx++) {
-        const px = cx + dx;
-        const py = cy + dy;
-        if (px < 0 || px >= this.width || py < 0 || py >= this.height) continue;
-        if (circle && dx * dx + dy * dy > r2) continue;
-        const i = (py * this.width + px) * 4;
-        if (restore) {
-          data[i] = src[i];
-          data[i + 1] = src[i + 1];
-          data[i + 2] = src[i + 2];
-          data[i + 3] = src[i + 3];
-        } else {
-          data[i + 3] = 0;
-        }
-      }
-    }
+    const stroke = new BrushStroke({
+      cx,
+      cy,
+      tool: this.tool,
+      size: this.brushSize,
+      shape: this.brushShape,
+    });
+    stroke.apply(this.imageData, this.originalImage, this.width, this.height);
     this.redraw();
   }
 
@@ -1284,26 +1258,24 @@ export class ArEditor extends HTMLElement {
 
   private pushUndo(): void {
     if (!this.imageData) return;
-    this.undoStack.push({ rgba: this.snapshot() });
-    if (this.undoStack.length > this.maxHistory) this.undoStack.shift();
-    this.redoStack = [];
+    this.history.push(this.snapshot());
     this.updateUndoRedoButtons();
   }
 
   private undo(): void {
-    if (!this.undoStack.length || !this.imageData) return;
-    this.redoStack.push({ rgba: this.snapshot() });
-    const prev = this.undoStack.pop()!;
-    this.imageData.data.set(prev.rgba);
+    if (!this.imageData) return;
+    const prev = this.history.undo(this.snapshot());
+    if (!prev) return;
+    this.imageData.data.set(prev);
     this.updateUndoRedoButtons();
     this.redraw();
   }
 
   private redo(): void {
-    if (!this.redoStack.length || !this.imageData) return;
-    this.undoStack.push({ rgba: this.snapshot() });
-    const next = this.redoStack.pop()!;
-    this.imageData.data.set(next.rgba);
+    if (!this.imageData) return;
+    const next = this.history.redo(this.snapshot());
+    if (!next) return;
+    this.imageData.data.set(next);
     this.updateUndoRedoButtons();
     this.redraw();
   }
@@ -1311,8 +1283,8 @@ export class ArEditor extends HTMLElement {
   private updateUndoRedoButtons(): void {
     const undoBtn = this.shadowRoot!.querySelector('#undo-btn') as HTMLButtonElement;
     const redoBtn = this.shadowRoot!.querySelector('#redo-btn') as HTMLButtonElement;
-    if (undoBtn) undoBtn.disabled = this.undoStack.length === 0;
-    if (redoBtn) redoBtn.disabled = this.redoStack.length === 0;
+    if (undoBtn) undoBtn.disabled = !this.history.canUndo();
+    if (redoBtn) redoBtn.disabled = !this.history.canRedo();
   }
 
   /** Get the edited ImageData */
@@ -1323,8 +1295,7 @@ export class ArEditor extends HTMLElement {
   reset(): void {
     this.imageData = null;
     this.originalImage = null;
-    this.undoStack = [];
-    this.redoStack = [];
+    this.history.clear();
   }
 }
 

--- a/src/components/ar-editor.ts
+++ b/src/components/ar-editor.ts
@@ -488,6 +488,13 @@ export class ArEditor extends HTMLElement {
         canvas {
           image-rendering: pixelated;
         }
+        /* Keyboard focus ring (#186). Canvas is focusable via
+           tabindex="0"; without an explicit rule, shadow-DOM scope
+           hides the document-level :focus-visible style. */
+        canvas:focus-visible {
+          outline: 2px solid var(--color-accent-primary, #00ff41);
+          outline-offset: 2px;
+        }
         .editor-footer {
           display: flex;
           justify-content: flex-end;

--- a/src/components/ar-reactor.ts
+++ b/src/components/ar-reactor.ts
@@ -17,6 +17,7 @@ import {
   computeRuntime,
   formatRuntime,
   donationToRuntimeDelta,
+  isDonorsFile,
   type DonorsFile,
 } from '../utils/reactor-economics';
 
@@ -47,7 +48,15 @@ class ArReactor extends HTMLElement {
     try {
       const res = await fetch(DONORS_URL, { cache: 'no-cache' });
       if (!res.ok) return;
-      this.donors = (await res.json()) as DonorsFile;
+      const payload: unknown = await res.json();
+      if (!isDonorsFile(payload)) {
+        // Malformed donors file — keep EMPTY_DONORS so renderSupporters()
+        // and totalDonationsEur() don't NaN out on missing fields. Logging
+        // helps the maintainer notice if a deploy ever ships a bad file.
+        console.warn('[ar-reactor] donors.json failed shape validation; using empty fallback');
+        return;
+      }
+      this.donors = payload;
     } catch {
       // Stay with EMPTY_DONORS — same shape, the page still renders
       // honestly with "0 months" + empty supporters table.

--- a/src/components/ar-reactor.ts
+++ b/src/components/ar-reactor.ts
@@ -134,7 +134,6 @@ class ArReactor extends HTMLElement {
         <section class="block prose methodology" id="methodology">
           <h2 class="block-title">── ${t('reactor.methodology')} ──</h2>
           <p>${t('reactor.methodologyBody')}</p>
-          <p class="muted">${t('reactor.removalNotice')}</p>
         </section>
       </article>
     `;

--- a/src/components/ar-viewer.ts
+++ b/src/components/ar-viewer.ts
@@ -119,6 +119,14 @@ export class ArViewer extends HTMLElement {
           color: var(--color-bg-primary, #000);
           box-shadow: 0 0 10px rgba(var(--color-accent-rgb, 0, 255, 65), 0.4);
         }
+        /* Keyboard focus ring (#186). Slider handle is the before/after
+           split control — focusable for accessibility. Without an
+           explicit rule, shadow-DOM scope hides the document-level
+           :focus-visible style. */
+        .slider-handle:focus-visible {
+          outline: 2px solid var(--color-accent-primary, #00ff41);
+          outline-offset: 2px;
+        }
         /* Viewer chips per design #71 — solid black fill + status dot
            + accent border on the active (result) side.
            Pre-existing UX had rgba(0,0,0,0.85) which washed out over the

--- a/src/controllers/app-install.ts
+++ b/src/controllers/app-install.ts
@@ -1,0 +1,103 @@
+/**
+ * Controller for the PWA install affordance:
+ *   - Toggles the install button between "install" / "installed".
+ *   - Listens for `nukebg:pwa-installable` (dispatched by sw-register on
+ *     `beforeinstallprompt`) to surface the native prompt path.
+ *   - Falls back to a 2s mobile-only delayed appearance for browsers
+ *     without `beforeinstallprompt` (Firefox / iOS Safari).
+ *   - On click: triggers native prompt OR shows browser-specific guide.
+ *
+ * Extracted from ar-app.ts in #47/Phase-1b. Native-prompt and installed
+ * detection live in `src/sw-register.ts`; this controller wires the UI
+ * to those primitives. AbortSignal-based cleanup, no manual disconnect.
+ */
+import { installApp, isAppInstalled } from '../sw-register';
+import { t } from '../i18n';
+
+export class AppInstaller {
+  private hasNativePrompt = false;
+
+  constructor(
+    private installBtn: HTMLButtonElement,
+    private installGuide: HTMLDivElement,
+  ) {}
+
+  /** Wire up listeners + initial state. AbortSignal lifetime ties
+   *  cleanup to the host component. */
+  attach(signal: AbortSignal): void {
+    if (isAppInstalled()) {
+      this.installBtn.textContent = t('pwa.installed');
+      this.installBtn.classList.add('visible');
+      this.installBtn.disabled = true;
+    }
+
+    const onInstallable = () => {
+      this.hasNativePrompt = true;
+      if (!isAppInstalled()) {
+        this.installBtn.textContent = t('pwa.install');
+        this.installBtn.classList.add('visible');
+        this.installBtn.disabled = false;
+      }
+    };
+    document.addEventListener('nukebg:pwa-installable', onInstallable, { signal });
+
+    // Firefox + iOS Safari can install via manual steps but never fire
+    // `beforeinstallprompt`. Surface the button after a short delay if
+    // the native prompt hasn't fired by then.
+    const isMobile = window.matchMedia('(hover: none), (pointer: coarse)').matches;
+    if (isMobile && !isAppInstalled()) {
+      setTimeout(() => {
+        if (!this.hasNativePrompt && !signal.aborted) {
+          this.installBtn.textContent = t('pwa.install');
+          this.installBtn.classList.add('visible');
+          this.installBtn.disabled = false;
+        }
+      }, 2000);
+    }
+
+    this.installBtn.addEventListener(
+      'click',
+      async () => {
+        if (this.hasNativePrompt) {
+          const accepted = await installApp();
+          if (accepted) {
+            this.installBtn.textContent = t('pwa.installed');
+            this.installBtn.disabled = true;
+            this.installGuide.classList.remove('visible');
+          }
+          return;
+        }
+        // Browser-specific instructions for non-Chromium installs.
+        this.installGuide.innerHTML = this.buildGuide();
+        this.installGuide.classList.toggle('visible');
+        const closeBtn = this.installGuide.querySelector('.install-guide-close');
+        if (closeBtn) {
+          closeBtn.addEventListener('click', () => this.installGuide.classList.remove('visible'), {
+            signal,
+          });
+        }
+      },
+      { signal },
+    );
+  }
+
+  /** Re-applies button text after a locale change. Host's updateTexts()
+   *  calls this so the button stays in sync with the active locale. */
+  refreshText(): void {
+    this.installBtn.textContent = isAppInstalled() ? t('pwa.installed') : t('pwa.install');
+    this.installBtn.setAttribute('aria-label', t('pwa.install'));
+  }
+
+  private buildGuide(): string {
+    const ua = navigator.userAgent.toLowerCase();
+    let steps: string;
+    if (/firefox/i.test(ua)) {
+      steps = t('pwa.guideFirefox');
+    } else if (/iphone|ipad|ipod/i.test(ua)) {
+      steps = t('pwa.guideSafari');
+    } else {
+      steps = t('pwa.guideGeneric');
+    }
+    return `<div class="guide-motivation">${t('pwa.guideMotivation')}</div>${steps}<br><button class="install-guide-close">${t('pwa.guideDismiss')}</button>`;
+  }
+}

--- a/src/controllers/batch-orchestrator.ts
+++ b/src/controllers/batch-orchestrator.ts
@@ -1,0 +1,293 @@
+/**
+ * Batch queue controller. Owns the multi-image processing state machine
+ * (items, mode, detail-id, abort flag, currently-processing item) and the
+ * per-item pipeline execution loop. Extracted from ar-app.ts in #47/Phase-1
+ * so the host component shrinks toward pure orchestration + render.
+ *
+ * The host (ar-app) keeps:
+ *   - The PipelineOrchestrator instance (single-image flow shares it)
+ *   - The in-flight AbortController (cancel-processing handler must reach it
+ *     on either path)
+ *   - The detail-view rendering (it touches single-image fields + DOM
+ *     templates that live in the host)
+ *
+ * The orchestrator never reaches into the host directly — it talks through
+ * the BatchHost interface. The host passes itself in at construction.
+ */
+import { PipelineAbortError, type PipelineOrchestrator } from '../pipeline/orchestrator';
+import type { PipelineStage, StageStatus } from '../types/pipeline';
+import type { ModelId } from '../types/worker-messages';
+import type { ArViewer } from '../components/ar-viewer';
+import type { ArProgress } from '../components/ar-progress';
+import type { ArDownload } from '../components/ar-download';
+import type { ArBatchGrid } from '../components/ar-batch-grid';
+import type { BatchItem, StageSnapshot } from '../types/batch';
+import { createZip, safeZipEntryName, downloadBlob } from '../utils/zip';
+import { dropOrphanBlobs, fillSubjectHoles, promoteSpeckleAlpha } from '../pipeline/finalize';
+import { composeAtOriginal } from '../utils/final-composite';
+import { exportPng } from '../utils/image-io';
+
+export type BatchMode = 'off' | 'grid' | 'detail';
+
+export type BatchStageCallback = (
+  stage: PipelineStage,
+  status: StageStatus,
+  message?: string,
+) => void;
+
+/** UI components the orchestrator drives. Owned by host; orchestrator
+ *  borrows references. */
+export interface BatchUi {
+  viewer: ArViewer;
+  progress: ArProgress;
+  download: ArDownload;
+  batchGrid: ArBatchGrid | null;
+}
+
+/** Host-private capabilities the orchestrator needs to call into. */
+export interface BatchHost {
+  /** Install the per-batch stage callback onto the (lazy) pipeline and
+   *  return the armed pipeline for `process()` calls. The host owns the
+   *  lazy-creation logic so single-image flow can share the same instance. */
+  installBatchStageCallback(cb: BatchStageCallback): PipelineOrchestrator;
+
+  /** Set the AbortController for the in-flight item. Host stores it so the
+   *  global `ar:cancel-processing` handler can abort either single-image
+   *  or batch flows uniformly. */
+  setProcessingAbortController(c: AbortController | null): void;
+
+  /** Build a thumbnail data-URL. Host owns this because it uses a DOM
+   *  canvas (orchestrator stays DOM-free except for borrowed components). */
+  makeThumbnail(img: ImageData, maxSide?: number): string;
+
+  /** Called once when `start()` flips the UI to grid mode — host swaps
+   *  the hero/workspace DOM. Pure UI, no return value. */
+  enterGridMode(): void;
+}
+
+export class BatchOrchestrator {
+  private static readonly MODEL_ID: ModelId = 'briaai/RMBG-1.4';
+
+  private items: BatchItem[] = [];
+  private mode: BatchMode = 'off';
+  private detailId: string | null = null;
+  private aborted = false;
+  private currentProcessingItem: BatchItem | null = null;
+
+  /** Optional callback invoked when an item finishes processing AND
+   *  it's the one currently shown in detail view. Host wires this so the
+   *  detail UI auto-refreshes from "live" to "done"/"failed". */
+  private onItemRefreshed?: (id: string) => Promise<void> | void;
+
+  constructor(
+    private ui: BatchUi,
+    private host: BatchHost,
+  ) {}
+
+  // ── Accessors ──────────────────────────────────────────────────────
+
+  getMode(): BatchMode {
+    return this.mode;
+  }
+
+  isInBatchMode(): boolean {
+    return this.mode !== 'off';
+  }
+
+  getDetailId(): string | null {
+    return this.detailId;
+  }
+
+  findItem(id: string): BatchItem | undefined {
+    return this.items.find((i) => i.id === id);
+  }
+
+  // ── Mutators wired from host UI handlers ──────────────────────────
+
+  setMode(mode: BatchMode): void {
+    this.mode = mode;
+  }
+
+  setDetailId(id: string | null): void {
+    this.detailId = id;
+  }
+
+  abort(): void {
+    this.aborted = true;
+  }
+
+  setOnItemRefreshed(cb: (id: string) => Promise<void> | void): void {
+    this.onItemRefreshed = cb;
+  }
+
+  // ── Public lifecycle ───────────────────────────────────────────────
+
+  /** Initialize a new batch from dropped images and run the queue. */
+  async start(
+    images: Array<{
+      file: File;
+      imageData: ImageData;
+      originalImageData: ImageData;
+      originalWidth: number;
+      originalHeight: number;
+      wasDownsampled: boolean;
+    }>,
+  ): Promise<void> {
+    this.aborted = false;
+    this.items = images.map((img, i) => ({
+      id: `batch-${Date.now()}-${i}`,
+      originalName: img.file.name || `image-${i + 1}.png`,
+      file: img.file,
+      imageData: img.imageData,
+      originalImageData: img.originalImageData ?? img.imageData,
+      state: 'pending',
+      result: null,
+      finalImageData: null,
+      thumbnailUrl: this.host.makeThumbnail(img.originalImageData ?? img.imageData),
+      stageHistory: [],
+    }));
+
+    this.mode = 'grid';
+    this.host.enterGridMode();
+
+    if (this.ui.batchGrid) {
+      this.ui.batchGrid.setItems(this.items);
+      this.ui.batchGrid.setCurrentIndex(0);
+    }
+
+    await this.runQueue();
+  }
+
+  /** Run the queue until all items are done/failed/discarded. Re-entrant
+   *  from retry flows — re-installs the stage callback each time so the
+   *  pipeline records into the current batch's items. */
+  async runQueue(): Promise<void> {
+    const stageCallback: BatchStageCallback = (stage, status, message) => {
+      this.ui.progress.setStage(stage, status, message);
+      const current = this.currentProcessingItem;
+      if (current) current.stageHistory.push({ stage, status, message });
+    };
+    const pipeline = this.host.installBatchStageCallback(stageCallback);
+
+    for (let i = 0; i < this.items.length; i++) {
+      if (this.aborted) return;
+      const item = this.items[i];
+      if (item.state === 'done' || item.state === 'discarded') continue;
+      if (this.ui.batchGrid) this.ui.batchGrid.setCurrentIndex(i);
+      item.state = 'processing';
+      // Fresh slate for this item: empty history, empty live console.
+      item.stageHistory = [];
+      this.ui.progress.reset();
+      this.ui.progress.setRunning(true);
+      this.currentProcessingItem = item;
+      if (this.ui.batchGrid) this.ui.batchGrid.updateItem(item.id, 'processing');
+      // One signal per batch item so cancelling the batch aborts the
+      // in-flight one promptly without waiting for the current stage.
+      const ac = new AbortController();
+      this.host.setProcessingAbortController(ac);
+      try {
+        const result = await pipeline.process(
+          item.imageData,
+          BatchOrchestrator.MODEL_ID,
+          'high-power',
+          ac.signal,
+        );
+        if (this.aborted) return;
+        const composed = composeAtOriginal({
+          originalRgba: item.originalImageData.data,
+          originalWidth: item.originalImageData.width,
+          originalHeight: item.originalImageData.height,
+          workingRgba: result.workingPixels,
+          workingWidth: result.workingWidth,
+          workingHeight: result.workingHeight,
+          workingAlpha: result.workingAlpha,
+          inpaintMask: result.watermarkMask,
+        });
+        const finalImageData =
+          result.contentType === 'PHOTO' || result.contentType === 'ILLUSTRATION'
+            ? promoteSpeckleAlpha(fillSubjectHoles(dropOrphanBlobs(composed)))
+            : composed;
+        item.result = result;
+        item.finalImageData = finalImageData;
+        item.thumbnailUrl = this.host.makeThumbnail(finalImageData);
+        item.state = 'done';
+        if (this.ui.batchGrid) this.ui.batchGrid.updateItem(item.id, 'done', item.thumbnailUrl);
+        // Auto-refresh detail view if the user is currently watching this item.
+        if (this.detailId === item.id && this.onItemRefreshed) {
+          await this.onItemRefreshed(item.id);
+        }
+      } catch (err) {
+        // Abort during batch = user cancelled. Don't mark the item as
+        // failed; the outer abort check returns on next tick.
+        if (err instanceof PipelineAbortError || this.aborted) {
+          this.ui.progress.setRunning(false);
+          return;
+        }
+        item.errorMessage = err instanceof Error ? err.message : String(err);
+        item.state = 'failed';
+        if (this.ui.batchGrid) this.ui.batchGrid.updateItem(item.id, 'failed');
+        if (this.detailId === item.id && this.onItemRefreshed) {
+          await this.onItemRefreshed(item.id);
+        }
+      }
+    }
+    this.ui.progress.setRunning(false);
+    this.currentProcessingItem = null;
+  }
+
+  /** Mark a failed item as pending and re-run the queue. Host wires this
+   *  to the retry button. Caller is expected to close detail view first. */
+  async retry(id: string): Promise<void> {
+    const item = this.items.find((i) => i.id === id);
+    if (!item) return;
+    item.state = 'pending';
+    item.errorMessage = undefined;
+    item.stageHistory = [];
+    if (this.ui.batchGrid) this.ui.batchGrid.updateItem(item.id, 'pending');
+    await this.runQueue();
+  }
+
+  /** Mark an item as discarded so it's excluded from the ZIP and the
+   *  queue skips it on a re-run. */
+  markDiscarded(id: string): void {
+    const item = this.items.find((i) => i.id === id);
+    if (!item) return;
+    item.state = 'discarded';
+    if (this.ui.batchGrid) this.ui.batchGrid.updateItem(item.id, 'discarded');
+  }
+
+  /** Replay a finished item's captured stage events into the shared
+   *  progress console. Resets first so no stale state from the previous
+   *  item leaks through, then reapplies each snapshot in order. */
+  replayStageHistory(history: StageSnapshot[]): void {
+    this.ui.progress.reset();
+    for (const snap of history) {
+      this.ui.progress.setStage(snap.stage, snap.status, snap.message);
+    }
+  }
+
+  /** ZIP the finished items and trigger a browser download. */
+  async downloadZip(): Promise<void> {
+    const done = this.items.filter((i) => i.state === 'done' && i.result);
+    if (done.length === 0) return;
+    const files = await Promise.all(
+      done.map(async (item, idx) => ({
+        name: safeZipEntryName(idx + 1, done.length, item.originalName),
+        blob: await exportPng(item.finalImageData ?? item.result!.imageData),
+      })),
+    );
+    const zip = await createZip(files);
+    downloadBlob(zip, `nukebg-batch-${Date.now()}.zip`);
+  }
+
+  /** Wipe queue state. Called from host's resetToIdle when the user
+   *  hits "back" on a running/finished batch. */
+  reset(): void {
+    this.items = [];
+    this.detailId = null;
+    this.mode = 'off';
+    this.currentProcessingItem = null;
+    // Keep `aborted = true` so any in-flight runQueue tick returns on
+    // its next iteration; runQueue resets it at the next start().
+  }
+}

--- a/src/controllers/sam-refiner.ts
+++ b/src/controllers/sam-refiner.ts
@@ -1,0 +1,110 @@
+/**
+ * MobileSAM lifecycle wrapper for the advanced editor:
+ *   - Lazy-loads the model on first encode (~45MB download, one-time).
+ *   - Caches the encoded image embedding in the worker; re-decodes are
+ *     fast (no re-encode).
+ *   - Tracks whether the current image is already encoded so callers
+ *     don't need to manage the flag themselves.
+ *   - Forwards the SAM worker's progress events to an optional callback.
+ *
+ * Extracted from `ar-editor-advanced.ts` in #47/Phase-3c. The component
+ * used to carry a `samEncoded` boolean and inline `ensureSamEncoded()` /
+ * `refineWithSam()` orchestration that mixed model loading, hint-DOM
+ * updates, and lasso-mask blending. Pulling the model lifecycle into a
+ * controller leaves the host with the UI + pixel composition only.
+ *
+ * The host instantiates one SamRefiner per component, wires a progress
+ * callback that updates whatever UI element it cares about, and calls
+ * `invalidate()` whenever the underlying image changes so the next
+ * action triggers a fresh encode.
+ */
+import {
+  loadSam,
+  encodeSam,
+  decodeSam,
+  disposeSam,
+  onSamProgress,
+  type SamMaskResult,
+} from '../refine/loaders/mobile-sam';
+
+export type SamProgressCallback = (pct: number, stage: 'encoder' | 'decoder') => void;
+
+export class SamRefiner {
+  private encoded = false;
+
+  constructor(private progressCb?: SamProgressCallback) {}
+
+  /** Lazy-load the model and encode the given image. Idempotent — if
+   *  the image is already encoded (no `invalidate()` since the last
+   *  call), this returns immediately.
+   *
+   *  Throws `DOMException('Aborted', 'AbortError')` if `signal` fires
+   *  before either of the two awaited stages completes. */
+  async ensureEncoded(
+    pixels: Uint8ClampedArray,
+    width: number,
+    height: number,
+    signal: AbortSignal,
+  ): Promise<void> {
+    if (this.encoded) return;
+
+    if (this.progressCb) onSamProgress(this.progressCb);
+
+    try {
+      if (signal.aborted) throw new DOMException('Aborted', 'AbortError');
+      await loadSam();
+
+      if (signal.aborted) throw new DOMException('Aborted', 'AbortError');
+      await encodeSam(pixels, width, height);
+
+      this.encoded = true;
+    } finally {
+      // Always clear the progress wiring — leaking it across actions
+      // would cause stale callbacks to fire on later encodes.
+      if (this.progressCb) onSamProgress(null);
+    }
+  }
+
+  /** Run the decoder on the cached embedding. Caller is responsible for
+   *  having called `ensureEncoded()` first; calling `decode()` before
+   *  the model is loaded throws. */
+  async decode(
+    points: Array<{ x: number; y: number }>,
+    labels: number[],
+    width: number,
+    height: number,
+  ): Promise<SamMaskResult> {
+    if (!this.encoded) {
+      throw new Error('SamRefiner: decode() called before ensureEncoded()');
+    }
+    return decodeSam(points, labels, width, height);
+  }
+
+  /** Whether the current image's embedding is cached. Resets to false
+   *  on `invalidate()` and `dispose()`. */
+  isEncoded(): boolean {
+    return this.encoded;
+  }
+
+  /** Tell the controller the host loaded a new image. The next
+   *  `ensureEncoded()` call will run a fresh load + encode. Cheaper
+   *  than `dispose()` because the worker stays alive. */
+  invalidate(): void {
+    this.encoded = false;
+  }
+
+  /** Update the progress callback. Pass `null` to detach. The change
+   *  takes effect on the next `ensureEncoded()` call (any in-flight
+   *  encode keeps using the previous callback). */
+  setProgressCallback(cb: SamProgressCallback | null): void {
+    this.progressCb = cb ?? undefined;
+  }
+
+  /** Tear down the SAM worker and free its ONNX sessions. Call from
+   *  the host's disconnectedCallback so the model doesn't leak across
+   *  component instances. */
+  dispose(): void {
+    disposeSam();
+    this.encoded = false;
+  }
+}

--- a/src/i18n/index.ts
+++ b/src/i18n/index.ts
@@ -230,7 +230,6 @@ const translations: Translations = {
     'reactor.tipCta': 'Tip the reactor →',
     'reactor.methodology': 'How is this calculated?',
     'reactor.methodologyBody': 'Hours estimated from git commit count weighted by typical time-per-commit per category, with adjustments for research, debugging, and discarded explorations not visible in the commit log. Estimate accuracy: ±15h. Fair-rate set deliberately below mid-market freelance rate in Spain (€22-25/h for mid devs) to avoid inflation.',
-    'reactor.removalNotice': 'If you appear on this page and want to be removed, email yocreoquesi at gmail dot com — done within 7 days, no questions.',
     'reactor.noSupportersYet': 'No supporters yet — code shipping is currently funded by the maintainer pocket. Tip below to extend the runway.',
     'reactor.anonymousLine': '+ {count} anonymous supporters ({total} combined)',
 
@@ -494,7 +493,6 @@ const translations: Translations = {
     'reactor.tipCta': 'Alimentar el reactor →',
     'reactor.methodology': '¿Cómo se calcula?',
     'reactor.methodologyBody': 'Horas estimadas desde el commit count de git ponderado por tiempo típico por commit por categoría, con ajustes por investigación, debugging y exploraciones descartadas no visibles en los commits. Precisión estimada: ±15h. La tarifa se fija deliberadamente por debajo del rate mid-market freelance en España (€22-25/h para devs mid) para evitar inflación.',
-    'reactor.removalNotice': 'Si apareces en esta página y quieres que te quitemos, manda un correo a yocreoquesi arroba gmail punto com — resuelto en 7 días, sin preguntas.',
     'reactor.noSupportersYet': 'Sin supporters todavía — el shipeo de código está financiado actualmente por el bolsillo del maintainer. Alimenta abajo para extender el runway.',
     'reactor.anonymousLine': '+ {count} supporters anónimos ({total} combinados)',
 
@@ -758,7 +756,6 @@ const translations: Translations = {
     'reactor.tipCta': 'Alimenter le réacteur →',
     'reactor.methodology': 'Comment c\'est calculé ?',
     'reactor.methodologyBody': 'Heures estimées depuis le commit count git pondéré par temps typique par commit par catégorie, avec ajustements pour la recherche, le debugging et les explorations abandonnées non visibles dans les commits. Précision : ±15h. Tarif fixé délibérément en dessous du mid-market freelance en Espagne (€22-25/h pour devs mid) pour éviter l\'inflation.',
-    'reactor.removalNotice': 'Si tu apparais sur cette page et veux être retiré, envoie un email à yocreoquesi arobase gmail point com — fait sous 7 jours, sans questions.',
     'reactor.noSupportersYet': 'Pas encore de supporters — le shipping de code est actuellement financé par les fonds personnels du maintainer. Alimente en dessous pour étendre le runway.',
     'reactor.anonymousLine': '+ {count} supporters anonymes ({total} cumulé)',
 
@@ -1022,7 +1019,6 @@ const translations: Translations = {
     'reactor.tipCta': 'Reaktor speisen →',
     'reactor.methodology': 'Wie wird das berechnet?',
     'reactor.methodologyBody': 'Stunden geschätzt aus Git-Commit-Anzahl, gewichtet nach typischer Zeit-pro-Commit pro Kategorie, mit Anpassungen für Forschung, Debugging und verworfene Explorationen, die nicht in Commits sichtbar sind. Genauigkeit: ±15h. Stundensatz bewusst unter dem Mid-Market-Freelance-Satz in Spanien (€22-25/h für Mid-Devs) gesetzt, um Inflation zu vermeiden.',
-    'reactor.removalNotice': 'Wenn Sie auf dieser Seite erscheinen und entfernt werden möchten, mailen Sie an yocreoquesi at gmail dot com — innerhalb 7 Tagen erledigt, keine Fragen.',
     'reactor.noSupportersYet': 'Noch keine Supporter — Code-Shipping wird aktuell aus eigener Tasche des Maintainers finanziert. Speisen Sie unten, um das Runway zu verlängern.',
     'reactor.anonymousLine': '+ {count} anonyme Supporter ({total} kombiniert)',
 
@@ -1286,7 +1282,6 @@ const translations: Translations = {
     'reactor.tipCta': 'Alimentar o reator →',
     'reactor.methodology': 'Como é calculado?',
     'reactor.methodologyBody': 'Horas estimadas pelo commit count git ponderado por tempo típico por commit por categoria, com ajustes para pesquisa, debugging e explorações descartadas não visíveis nos commits. Precisão: ±15h. Taxa fixada deliberadamente abaixo do mid-market freelance na Espanha (€22-25/h para devs mid) para evitar inflação.',
-    'reactor.removalNotice': 'Se você aparece nesta página e quer ser removido, envie email para yocreoquesi arroba gmail ponto com — feito em 7 dias, sem perguntas.',
     'reactor.noSupportersYet': 'Sem supporters ainda — o shipping de código está financiado pelo bolso do maintainer. Alimente abaixo para estender o runway.',
     'reactor.anonymousLine': '+ {count} supporters anônimos ({total} combinado)',
 
@@ -1550,7 +1545,6 @@ const translations: Translations = {
     'reactor.tipCta': '\u8D44\u52A9\u53CD\u5E94\u5806 \u2192',
     'reactor.methodology': '\u5982\u4F55\u8BA1\u7B97?',
     'reactor.methodologyBody': '\u6839\u636E git \u63D0\u4EA4\u6570\u91CF\u6309\u7C7B\u522B\u4F30\u7B97\u5178\u578B\u6BCF\u63D0\u4EA4\u65F6\u95F4, \u5E76\u8C03\u6574\u63D0\u4EA4\u65E5\u5FD7\u4E2D\u4E0D\u53EF\u89C1\u7684\u7814\u7A76\u3001\u8C03\u8BD5\u548C\u5E9F\u5F03\u63A2\u7D22\u3002\u7CBE\u5EA6: \u00B115h\u3002\u65F6\u85AA\u6545\u610F\u4F4E\u4E8E\u897F\u73ED\u7259\u4E2D\u7AEF\u81EA\u7531\u804C\u4E1A\u5E02\u573A (\u20AC22-25/h) \u4EE5\u907F\u514D\u81A8\u80C0\u3002',
-    'reactor.removalNotice': '\u5982\u679C\u60A8\u51FA\u73B0\u5728\u6B64\u9875\u9762\u5E76\u5E0C\u671B\u88AB\u79FB\u9664, \u8BF7\u53D1\u9001\u90AE\u4EF6\u81F3 yocreoquesi at gmail dot com \u2014 7 \u5929\u5185\u5904\u7406, \u4E0D\u95EE\u95EE\u9898\u3002',
     'reactor.noSupportersYet': '\u8FD8\u6CA1\u6709\u652F\u6301\u8005 \u2014 \u4EE3\u7801\u53D1\u5E03\u76EE\u524D\u7531\u7EF4\u62A4\u8005\u81EA\u638F\u8170\u5305\u8D44\u52A9\u3002\u5728\u4E0B\u9762\u8D44\u52A9\u4EE5\u5EF6\u957F\u8FD0\u884C\u65F6\u95F4\u3002',
     'reactor.anonymousLine': '+ {count} \u4F4D\u533F\u540D\u652F\u6301\u8005 (\u5408\u8BA1 {total})',
 

--- a/src/i18n/index.ts
+++ b/src/i18n/index.ts
@@ -18,10 +18,8 @@ const translations: Translations = {
 
     // Dropzone
     'dropzone.title': 'Drop your image here',
-    'dropzone.subtitle': "or click to browse. We'll nuke the background",
     'dropzone.hint': '# or click to browse · paste with Ctrl+V',
     'dropzone.formats': 'PNG, JPG, WebP up to 32 MP / 80 MB',
-    'dropzone.clipboard': 'Ctrl+V to paste from clipboard',
     'dropzone.dragover': 'Drop to process',
     'dropzone.ariaLabel': 'Upload image for background removal',
     'dropzone.errorFormat': 'Unsupported format. Use PNG, JPG, or WebP.',
@@ -30,19 +28,11 @@ const translations: Translations = {
     'progress.detectBg': 'Scanning image...',
     'progress.watermarkScan': 'Checking for watermarks',
     'progress.inpaint': 'Removing watermark',
-    'progress.bgRemoval': 'Removing background',
-    'progress.bgRemovalCV': 'Removing background [CV]',
     'progress.bgRemovalML': 'Removing background [ML]',
     'progress.initAI': 'Initializing AI engine...',
-    'progress.cancel': 'Cancel',
-    'progress.total': 'Total:',
     'progress.downscaled': 'Large image: processing at {w}\u00D7{h} to fit memory (output at original {ow}\u00D7{oh}).',
 
     // Download
-    'download.btn': '\u2193 Download Clean PNG',
-    'download.btnWebp': '\u2193 Download Clean WebP',
-    'download.formatPng': 'PNG',
-    'download.formatWebp': 'WebP',
     'download.copy': '\uD83D\uDCCB Copy',
     'download.copied': '\u2713 Copied!',
     'download.copyFailed': 'Copy not supported',
@@ -162,13 +152,6 @@ const translations: Translations = {
     'privacy.tooltip.line3': 'Verify: check Network tab in DevTools.',
 
     // Features
-    'features.srTitle': 'Background Removal That Never Uploads Your Images',
-    'features.bgRemoval.title': 'Your Images Never Leave.',
-    'features.bgRemoval.desc': 'Zero uploads. Zero tracking. The ML model runs in your browser via WebAssembly. Don\'t trust us. Open DevTools and check the Network tab.',
-    'features.aiArtifacts.title': 'It Knows What You Dropped.',
-    'features.aiArtifacts.desc': 'Photo, illustration, signature, icon. We classify it and pick the right algorithm. Not one model blindly applied to everything.',
-    'features.private.title': 'No Account. No Paywall. No Catch.',
-    'features.private.desc': 'Unlimited uses, no watermarks on output, no credit system. GPL-3.0. Go read the code.',
     'features.disclaimer': 'We\'re <s>perfect</s> honest. Sometimes we miss. Fix it with the editor or <a href="https://github.com/yocreoquesi/nukebg/issues" target="_blank" rel="noopener">yell at the repo</a>.',
     'support.kofi': 'The reactor stays online while caffeine flows. <a href="https://ko-fi.com/yocreoquesi" target="_blank" rel="noopener">Fuel it on Ko-fi</a>.',
     'features.limitations': '\u2192 <strong>Works best with:</strong> clear subjects on contrasting backgrounds, photos, logos, signatures.<br>\u2192 <strong>May struggle with:</strong> hair on busy backgrounds, semi-transparent objects, very complex poses.<br>\u2192 <strong>Tip:</strong> use the manual editor to fix any rough spots. The eraser gives you pixel-level control.',
@@ -263,12 +246,10 @@ const translations: Translations = {
     'batch.done': 'Done',
     'batch.discarded': 'Discarded',
     'batch.completed': '{done}/{total} ready, {failed} failed',
-    'batch.emptyZip': 'No completed images to download',
     'batch.cancel': 'Cancel batch',
     'dropzone.multi': 'Drop up to 12 images for batch mode',
 
     // Language selector
-    'lang.label': 'Language',
   },
   es: {
     // Hero
@@ -281,10 +262,8 @@ const translations: Translations = {
 
     // Dropzone
     'dropzone.title': 'Arrastra tu imagen aqu\u00ED',
-    'dropzone.subtitle': 'o haz clic para buscar. Nukearemos el fondo',
     'dropzone.hint': '# o clic para buscar · pega con Ctrl+V',
     'dropzone.formats': 'PNG, JPG, WebP hasta 32 MP / 80 MB',
-    'dropzone.clipboard': 'Ctrl+V para pegar del portapapeles',
     'dropzone.dragover': 'Suelta para procesar',
     'dropzone.ariaLabel': 'Subir imagen para eliminar fondo',
     'dropzone.errorFormat': 'Formato no soportado. Usa PNG, JPG o WebP.',
@@ -293,19 +272,11 @@ const translations: Translations = {
     'progress.detectBg': 'Analizando imagen...',
     'progress.watermarkScan': 'Buscando marcas de agua',
     'progress.inpaint': 'Eliminando marca de agua',
-    'progress.bgRemoval': 'Eliminando fondo',
-    'progress.bgRemovalCV': 'Eliminando fondo [CV]',
     'progress.bgRemovalML': 'Eliminando fondo [ML]',
     'progress.initAI': 'Inicializando motor IA...',
-    'progress.cancel': 'Cancelar',
-    'progress.total': 'Total:',
     'progress.downscaled': 'Imagen grande: procesando en {w}\u00D7{h} para ahorrar memoria (salida a {ow}\u00D7{oh} original).',
 
     // Download
-    'download.btn': '\u2193 Descargar PNG limpio',
-    'download.btnWebp': '\u2193 Descargar WebP limpio',
-    'download.formatPng': 'PNG',
-    'download.formatWebp': 'WebP',
     'download.copy': '\uD83D\uDCCB Copiar',
     'download.copied': '\u2713 \u00A1Copiado!',
     'download.copyFailed': 'Copia no soportada',
@@ -425,13 +396,6 @@ const translations: Translations = {
     'privacy.tooltip.line3': 'Verifica: revisa la pesta\u00F1a Red en DevTools.',
 
     // Features
-    'features.srTitle': 'Eliminador de fondos que nunca sube tus im\u00E1genes',
-    'features.bgRemoval.title': 'Tus im\u00E1genes no salen.',
-    'features.bgRemoval.desc': 'Cero subidas. Cero rastreo. El modelo de IA corre en tu navegador via WebAssembly. No conf\u00EDes en nosotros. Abre DevTools y revisa la pesta\u00F1a Red.',
-    'features.aiArtifacts.title': 'Sabe qu\u00E9 le tiraste.',
-    'features.aiArtifacts.desc': 'Foto, ilustraci\u00F3n, firma, icono. Lo clasificamos y elegimos el algoritmo correcto. No un modelo aplicado a ciegas a todo.',
-    'features.private.title': 'Sin cuenta. Sin muro de pago. Sin trampa.',
-    'features.private.desc': 'Usos ilimitados, sin marca de agua en el resultado, sin sistema de cr\u00E9ditos. Es GPL-3.0. Lee el c\u00F3digo.',
     'features.disclaimer': 'Somos <s>perfectos</s> honestos. A veces fallamos. Arr\u00E9glalo con el editor o <a href="https://github.com/yocreoquesi/nukebg/issues" target="_blank" rel="noopener">grita en el repo</a>.',
     'support.kofi': 'El reactor sigue prendido mientras haya caf\u00E9. <a href="https://ko-fi.com/yocreoquesi" target="_blank" rel="noopener">Dale combustible en Ko-fi</a>.',
     'features.limitations': '\u2192 <strong>Funciona mejor con:</strong> sujetos claros sobre fondos contrastados, fotos, logos, firmas.<br>\u2192 <strong>Puede fallar con:</strong> pelo sobre fondos complejos, objetos semitransparentes, poses muy complejas.<br>\u2192 <strong>Consejo:</strong> usa el editor manual para corregir las zonas que no queden bien. El borrador te da control pixel a pixel.',
@@ -526,12 +490,10 @@ const translations: Translations = {
     'batch.done': 'Listo',
     'batch.discarded': 'Descartada',
     'batch.completed': '{done}/{total} listas, {failed} fallidas',
-    'batch.emptyZip': 'No hay im\u00E1genes procesadas para descargar',
     'batch.cancel': 'Cancelar lote',
     'dropzone.multi': 'Suelta hasta 12 im\u00E1genes para procesarlas juntas',
 
     // Language selector
-    'lang.label': 'Idioma',
   },
   fr: {
     // Hero
@@ -544,10 +506,8 @@ const translations: Translations = {
 
     // Dropzone
     'dropzone.title': 'D\u00E9pose ton image ici',
-    'dropzone.subtitle': 'ou clique pour parcourir. On atomise le fond',
     'dropzone.hint': '# ou cliquez pour parcourir · collez avec Ctrl+V',
     'dropzone.formats': 'PNG, JPG, WebP jusqu\u2019\u00E0 32 MP / 80 Mo',
-    'dropzone.clipboard': 'Ctrl+V pour coller depuis le presse-papiers',
     'dropzone.dragover': 'L\u00E2che pour traiter',
     'dropzone.ariaLabel': "Charger une image pour supprimer l'arri\u00E8re-plan",
     'dropzone.errorFormat': 'Format non support\u00E9. Utilise PNG, JPG ou WebP.',
@@ -556,19 +516,11 @@ const translations: Translations = {
     'progress.detectBg': 'Analyse en cours...',
     'progress.watermarkScan': 'V\u00E9rification des filigranes',
     'progress.inpaint': 'Suppression du filigrane',
-    'progress.bgRemoval': "Suppression de l'arri\u00E8re-plan",
-    'progress.bgRemovalCV': "Suppression de l'arri\u00E8re-plan [CV]",
     'progress.bgRemovalML': "Suppression de l'arri\u00E8re-plan [ML]",
     'progress.initAI': "Initialisation du moteur IA...",
-    'progress.cancel': 'Annuler',
-    'progress.total': 'Total :',
     'progress.downscaled': 'Grande image : traitement en {w}\u00D7{h} pour la m\u00E9moire (sortie en {ow}\u00D7{oh} d\u2019origine).',
 
     // Download
-    'download.btn': '\u2193 T\u00E9l\u00E9charger PNG propre',
-    'download.btnWebp': '\u2193 T\u00E9l\u00E9charger WebP propre',
-    'download.formatPng': 'PNG',
-    'download.formatWebp': 'WebP',
     'download.copy': '\uD83D\uDCCB Copier',
     'download.copied': '\u2713 Copi\u00E9 !',
     'download.copyFailed': 'Copie non support\u00E9e',
@@ -688,13 +640,6 @@ const translations: Translations = {
     'privacy.tooltip.line3': "V\u00E9rifie : ouvre l'onglet R\u00E9seau dans DevTools.",
 
     // Features
-    'features.srTitle': "D\u00E9tourage qui n'uploade jamais tes images",
-    'features.bgRemoval.title': 'Tes images ne sortent pas.',
-    'features.bgRemoval.desc': "Z\u00E9ro upload. Z\u00E9ro tracking. Le mod\u00E8le IA tourne dans ton navigateur via WebAssembly. Ne nous fais pas confiance. Ouvre DevTools et v\u00E9rifie l'onglet R\u00E9seau.",
-    'features.aiArtifacts.title': 'Il sait ce que tu lui as fil\u00E9.',
-    'features.aiArtifacts.desc': "Photo, illustration, signature, ic\u00F4ne. On classifie et on choisit le bon algorithme. Pas un mod\u00E8le appliqu\u00E9 \u00E0 l'aveugle sur tout.",
-    'features.private.title': 'Ni compte. Ni paywall. Ni entourloupe.',
-    'features.private.desc': "Utilisations illimit\u00E9es, pas de filigrane sur le r\u00E9sultat, pas de syst\u00E8me de cr\u00E9dits. GPL-3.0. Va lire le code.",
     'features.disclaimer': "On est <s>parfaits</s> honn\u00EAtes. Parfois on rate. Corrige avec l'\u00E9diteur ou <a href=\"https://github.com/yocreoquesi/nukebg/issues\" target=\"_blank\" rel=\"noopener\">gueule sur le repo</a>.",
     'features.limitations': "\u2192 <strong>Marche mieux avec :</strong> sujets nets sur fond contrast\u00E9, photos, logos, signatures.<br>\u2192 <strong>Peut galérer avec :</strong> cheveux sur fonds charg\u00E9s, objets semi-transparents, poses tr\u00E8s complexes.<br>\u2192 <strong>Astuce :</strong> utilise l'\u00E9diteur manuel pour corriger les zones approximatives. La gomme te donne le contr\u00F4le au pixel.",
     'status.reactor.offline': 'r\u00E9acteur inactif',
@@ -789,12 +734,10 @@ const translations: Translations = {
     'batch.done': 'Termin\u00E9',
     'batch.discarded': 'Supprim\u00E9e',
     'batch.completed': '{done}/{total} pr\u00EAtes, {failed} \u00E9chou\u00E9es',
-    'batch.emptyZip': 'Aucune image pr\u00EAte \u00E0 t\u00E9l\u00E9charger',
     'batch.cancel': 'Annuler le lot',
     'dropzone.multi': 'D\u00E9pose jusqu\u2019\u00E0 12 images pour le mode lot',
 
     // Language selector
-    'lang.label': 'Langue',
   },
   de: {
     // Hero
@@ -807,10 +750,8 @@ const translations: Translations = {
 
     // Dropzone
     'dropzone.title': 'Bild hier ablegen',
-    'dropzone.subtitle': 'oder klicken zum Ausw\u00E4hlen. Wir nuken den Hintergrund',
     'dropzone.hint': '# oder klicken · Strg+V zum Einf\u00FCgen',
     'dropzone.formats': 'PNG, JPG, WebP bis 32 MP / 80 MB',
-    'dropzone.clipboard': 'Strg+V zum Einf\u00FCgen aus Zwischenablage',
     'dropzone.dragover': 'Loslassen zum Verarbeiten',
     'dropzone.ariaLabel': 'Bild hochladen zur Hintergrundentfernung',
     'dropzone.errorFormat': 'Format nicht unterst\u00FCtzt. Nutze PNG, JPG oder WebP.',
@@ -819,19 +760,11 @@ const translations: Translations = {
     'progress.detectBg': 'Bild wird gescannt...',
     'progress.watermarkScan': 'Wasserzeichen-Check',
     'progress.inpaint': 'Wasserzeichen entfernen',
-    'progress.bgRemoval': 'Hintergrund entfernen',
-    'progress.bgRemovalCV': 'Hintergrund entfernen [CV]',
     'progress.bgRemovalML': 'Hintergrund entfernen [ML]',
     'progress.initAI': 'KI-Engine wird initialisiert...',
-    'progress.cancel': 'Abbrechen',
-    'progress.total': 'Gesamt:',
     'progress.downscaled': 'Gro\u00DFes Bild: Verarbeitung bei {w}\u00D7{h} zur Speicherschonung (Ausgabe in Original {ow}\u00D7{oh}).',
 
     // Download
-    'download.btn': '\u2193 Sauberes PNG laden',
-    'download.btnWebp': '\u2193 Sauberes WebP laden',
-    'download.formatPng': 'PNG',
-    'download.formatWebp': 'WebP',
     'download.copy': '\uD83D\uDCCB Kopieren',
     'download.copied': '\u2713 Kopiert!',
     'download.copyFailed': 'Kopieren nicht m\u00F6glich',
@@ -951,13 +884,6 @@ const translations: Translations = {
     'privacy.tooltip.line3': 'Pr\u00FCfe selbst: Netzwerk-Tab in DevTools \u00F6ffnen.',
 
     // Features
-    'features.srTitle': 'Hintergrundentfernung, die deine Bilder nie hochl\u00E4dt',
-    'features.bgRemoval.title': 'Deine Bilder bleiben bei dir.',
-    'features.bgRemoval.desc': 'Null Uploads. Null Tracking. Das KI-Modell l\u00E4uft im Browser via WebAssembly. Vertrau uns nicht. \u00D6ffne DevTools und check den Netzwerk-Tab.',
-    'features.aiArtifacts.title': 'Erkennt, was du reingeworfen hast.',
-    'features.aiArtifacts.desc': 'Foto, Illustration, Unterschrift, Icon. Wir klassifizieren und w\u00E4hlen den richtigen Algorithmus. Kein Modell, das blind auf alles losgelassen wird.',
-    'features.private.title': 'Kein Konto. Keine Paywall. Kein Haken.',
-    'features.private.desc': 'Unbegrenzt nutzbar, kein Wasserzeichen, kein Credit-System. GPL-3.0. Lies den Code.',
     'features.disclaimer': 'Wir sind <s>perfekt</s> ehrlich. Manchmal daneben. Nachbessern im Editor oder <a href="https://github.com/yocreoquesi/nukebg/issues" target="_blank" rel="noopener">im Repo meckern</a>.',
     'support.kofi': 'Der Reaktor l\u00E4uft, solange der Kaffee flie\u00DFt. <a href="https://ko-fi.com/yocreoquesi" target="_blank" rel="noopener">F\u00FCttere ihn auf Ko-fi</a>.',
     'features.limitations': '\u2192 <strong>Funktioniert am besten mit:</strong> klare Motive vor kontrastreichem Hintergrund, Fotos, Logos, Unterschriften.<br>\u2192 <strong>Kann Probleme haben mit:</strong> Haare vor unruhigem Hintergrund, halbtransparente Objekte, sehr komplexe Posen.<br>\u2192 <strong>Tipp:</strong> nutze den manuellen Editor f\u00FCr unsaubere Stellen. Der Radierer gibt dir Kontrolle auf Pixelebene.',
@@ -1052,12 +978,10 @@ const translations: Translations = {
     'batch.done': 'Fertig',
     'batch.discarded': 'Verworfen',
     'batch.completed': '{done}/{total} fertig, {failed} fehlgeschlagen',
-    'batch.emptyZip': 'Keine fertigen Bilder zum Herunterladen',
     'batch.cancel': 'Stapel abbrechen',
     'dropzone.multi': 'Bis zu 12 Bilder f\u00FCr den Stapelmodus ablegen',
 
     // Language selector
-    'lang.label': 'Sprache',
   },
   pt: {
     // Hero
@@ -1070,10 +994,8 @@ const translations: Translations = {
 
     // Dropzone
     'dropzone.title': 'Solta a imagem aqui',
-    'dropzone.subtitle': 'ou clica pra escolher. A gente nukeia o fundo',
     'dropzone.hint': '# ou clique pra escolher · cole com Ctrl+V',
     'dropzone.formats': 'PNG, JPG, WebP at\u00E9 32 MP / 80 MB',
-    'dropzone.clipboard': 'Ctrl+V pra colar da \u00E1rea de transfer\u00EAncia',
     'dropzone.dragover': 'Solta pra processar',
     'dropzone.ariaLabel': 'Enviar imagem para remover fundo',
     'dropzone.errorFormat': 'Formato n\u00E3o suportado. Usa PNG, JPG ou WebP.',
@@ -1082,19 +1004,11 @@ const translations: Translations = {
     'progress.detectBg': 'Escaneando imagem...',
     'progress.watermarkScan': 'Procurando marcas d\u2019\u00E1gua',
     'progress.inpaint': 'Removendo marca d\u2019\u00E1gua',
-    'progress.bgRemoval': 'Removendo fundo',
-    'progress.bgRemovalCV': 'Removendo fundo [CV]',
     'progress.bgRemovalML': 'Removendo fundo [ML]',
     'progress.initAI': 'Inicializando motor de IA...',
-    'progress.cancel': 'Cancelar',
-    'progress.total': 'Total:',
     'progress.downscaled': 'Imagem grande: processando em {w}\u00D7{h} para economizar mem\u00F3ria (sa\u00EDda em {ow}\u00D7{oh} original).',
 
     // Download
-    'download.btn': '\u2193 Baixar PNG limpo',
-    'download.btnWebp': '\u2193 Baixar WebP limpo',
-    'download.formatPng': 'PNG',
-    'download.formatWebp': 'WebP',
     'download.copy': '\uD83D\uDCCB Copiar',
     'download.copied': '\u2713 Copiado!',
     'download.copyFailed': 'C\u00F3pia n\u00E3o suportada',
@@ -1214,13 +1128,6 @@ const translations: Translations = {
     'privacy.tooltip.line3': 'Confere: abre a aba Rede no DevTools.',
 
     // Features
-    'features.srTitle': 'Removedor de fundo que nunca sobe suas imagens',
-    'features.bgRemoval.title': 'Suas imagens n\u00E3o saem daqui.',
-    'features.bgRemoval.desc': 'Zero uploads. Zero rastreamento. O modelo de IA roda no seu navegador via WebAssembly. N\u00E3o confia na gente? Abre o DevTools e confere a aba Rede.',
-    'features.aiArtifacts.title': 'Ele sabe o que voc\u00EA jogou.',
-    'features.aiArtifacts.desc': 'Foto, ilustra\u00E7\u00E3o, assinatura, \u00EDcone. A gente classifica e escolhe o algoritmo certo. Nada de um modelo cego aplicado em tudo.',
-    'features.private.title': 'Sem conta. Sem paywall. Sem pegadinha.',
-    'features.private.desc': 'Uso ilimitado, sem marca d\u2019\u00E1gua no resultado, sem sistema de cr\u00E9ditos. GPL-3.0. Vai ler o c\u00F3digo.',
     'features.disclaimer': 'Somos <s>perfeitos</s> honestos. \u00C0s vezes erramos. Arruma no editor ou <a href="https://github.com/yocreoquesi/nukebg/issues" target="_blank" rel="noopener">xinga no repo</a>.',
     'support.kofi': 'O reator s\u00F3 fica ligado enquanto tiver caf\u00E9. <a href="https://ko-fi.com/yocreoquesi" target="_blank" rel="noopener">Abastece no Ko-fi</a>.',
     'features.limitations': '\u2192 <strong>Funciona melhor com:</strong> sujeitos n\u00EDtidos em fundos contrastados, fotos, logos, assinaturas.<br>\u2192 <strong>Pode penar com:</strong> cabelo em fundos complexos, objetos semitransparentes, poses muito complicadas.<br>\u2192 <strong>Dica:</strong> usa o editor manual pra corrigir as partes que ficaram estranhas. A borracha d\u00E1 controle pixel a pixel.',
@@ -1315,12 +1222,10 @@ const translations: Translations = {
     'batch.done': 'Pronto',
     'batch.discarded': 'Descartada',
     'batch.completed': '{done}/{total} prontas, {failed} falharam',
-    'batch.emptyZip': 'Sem imagens prontas para baixar',
     'batch.cancel': 'Cancelar lote',
     'dropzone.multi': 'Solta at\u00E9 12 imagens pra modo em lote',
 
     // Language selector
-    'lang.label': 'Idioma',
   },
   zh: {
     // Hero
@@ -1333,10 +1238,8 @@ const translations: Translations = {
 
     // Dropzone
     'dropzone.title': '\u628A\u56FE\u7247\u4E22\u8FD9\u91CC',
-    'dropzone.subtitle': '\u6216\u8005\u70B9\u51FB\u9009\u62E9\uFF0C\u6211\u4EEC\u6765\u6838\u7206\u80CC\u666F',
     'dropzone.hint': '# \u70B9\u51FB\u9009\u62E9 · Ctrl+V \u7C98\u8D34',
     'dropzone.formats': 'PNG, JPG, WebP \u6700\u5927 32 MP / 80 MB',
-    'dropzone.clipboard': 'Ctrl+V \u4ECE\u526A\u8D34\u677F\u7C98\u8D34',
     'dropzone.dragover': '\u677E\u624B\u5F00\u59CB\u5904\u7406',
     'dropzone.ariaLabel': '\u4E0A\u4F20\u56FE\u7247\u4EE5\u53BB\u9664\u80CC\u666F',
     'dropzone.errorFormat': '\u4E0D\u652F\u6301\u7684\u683C\u5F0F\u3002\u8BF7\u7528 PNG\u3001JPG \u6216 WebP\u3002',
@@ -1345,19 +1248,11 @@ const translations: Translations = {
     'progress.detectBg': '\u626B\u63CF\u56FE\u7247\u4E2D...',
     'progress.watermarkScan': '\u68C0\u67E5\u6C34\u5370',
     'progress.inpaint': '\u6E05\u9664\u6C34\u5370',
-    'progress.bgRemoval': '\u53BB\u9664\u80CC\u666F',
-    'progress.bgRemovalCV': '\u53BB\u9664\u80CC\u666F [CV]',
     'progress.bgRemovalML': '\u53BB\u9664\u80CC\u666F [ML]',
     'progress.initAI': 'AI \u5F15\u64CE\u521D\u59CB\u5316\u4E2D...',
-    'progress.cancel': '\u53D6\u6D88',
-    'progress.total': '\u603B\u8BA1:',
     'progress.downscaled': '\u5927\u56FE\u50CF\uFF1A\u4EE5 {w}\u00D7{h} \u5904\u7406\u4EE5\u8282\u7701\u5185\u5B58\uFF08\u8F93\u51FA\u4F4D\u539F\u59CB {ow}\u00D7{oh}\uFF09\u3002',
 
     // Download
-    'download.btn': '\u2193 \u4E0B\u8F7D\u5E72\u51C0 PNG',
-    'download.btnWebp': '\u2193 \u4E0B\u8F7D\u5E72\u51C0 WebP',
-    'download.formatPng': 'PNG',
-    'download.formatWebp': 'WebP',
     'download.copy': '\uD83D\uDCCB \u590D\u5236',
     'download.copied': '\u2713 \u5DF2\u590D\u5236\uFF01',
     'download.copyFailed': '\u4E0D\u652F\u6301\u590D\u5236',
@@ -1477,13 +1372,6 @@ const translations: Translations = {
     'privacy.tooltip.line3': '\u9A8C\u8BC1\uFF1A\u6253\u5F00 DevTools \u67E5\u770B\u7F51\u7EDC\u9762\u677F\u3002',
 
     // Features
-    'features.srTitle': '\u6C38\u8FDC\u4E0D\u4F1A\u4E0A\u4F20\u4F60\u56FE\u7247\u7684\u80CC\u666F\u53BB\u9664\u5DE5\u5177',
-    'features.bgRemoval.title': '\u4F60\u7684\u56FE\u7247\u54EA\u513F\u4E5F\u4E0D\u53BB\u3002',
-    'features.bgRemoval.desc': '\u96F6\u4E0A\u4F20\u3002\u96F6\u8FFD\u8E2A\u3002AI\u6A21\u578B\u901A\u8FC7 WebAssembly \u5728\u4F60\u7684\u6D4F\u89C8\u5668\u91CC\u8FD0\u884C\u3002\u522B\u4FE1\u6211\u4EEC\u7684\u8BDD\u3002\u6253\u5F00 DevTools \u81EA\u5DF1\u770B\u7F51\u7EDC\u9762\u677F\u3002',
-    'features.aiArtifacts.title': '\u5B83\u77E5\u9053\u4F60\u4E22\u4E86\u4EC0\u4E48\u3002',
-    'features.aiArtifacts.desc': '\u7167\u7247\u3001\u63D2\u753B\u3001\u7B7E\u540D\u3001\u56FE\u6807\u3002\u6211\u4EEC\u5148\u5206\u7C7B\uFF0C\u518D\u9009\u7B97\u6CD5\u3002\u4E0D\u662F\u4E00\u4E2A\u6A21\u578B\u65E0\u8111\u5957\u5728\u6240\u6709\u4E1C\u897F\u4E0A\u3002',
-    'features.private.title': '\u4E0D\u7528\u6CE8\u518C\u3002\u4E0D\u7528\u4ED8\u8D39\u3002\u6CA1\u6709\u5957\u8DEF\u3002',
-    'features.private.desc': '\u65E0\u9650\u4F7F\u7528\uFF0C\u8F93\u51FA\u65E0\u6C34\u5370\uFF0C\u6CA1\u6709\u79EF\u5206\u5236\u3002GPL-3.0\u3002\u53BB\u770B\u6E90\u7801\u3002',
     'features.disclaimer': '\u6211\u4EEC<s>\u5B8C\u7F8E</s>\u8BDA\u5B9E\u3002\u6709\u65F6\u7FFB\u8F66\u3002\u7528\u7F16\u8F91\u5668\u4FEE\uFF0C\u6216<a href="https://github.com/yocreoquesi/nukebg/issues" target="_blank" rel="noopener">\u53BB repo \u5410\u69FD</a>\u3002',
     'support.kofi': '\u53CD\u5E94\u5806\u9760\u5496\u5561\u8FD0\u8F6C\u3002<a href="https://ko-fi.com/yocreoquesi" target="_blank" rel="noopener">\u5728 Ko-fi \u4E0A\u52A0\u6CB9</a>\u3002',
     'features.limitations': '\u2192 <strong>\u6700\u9002\u5408\uFF1A</strong>\u6E05\u6670\u4E3B\u4F53\u914D\u5BF9\u6BD4\u660E\u663E\u7684\u80CC\u666F\u3001\u7167\u7247\u3001logo\u3001\u7B7E\u540D\u3002<br>\u2192 <strong>\u53EF\u80FD\u7FFB\u8F66\uFF1A</strong>\u590D\u6742\u80CC\u666F\u4E0A\u7684\u5934\u53D1\u3001\u534A\u900F\u660E\u7269\u4F53\u3001\u975E\u5E38\u590D\u6742\u7684\u59FF\u52BF\u3002<br>\u2192 <strong>\u5C0F\u8D34\u58EB\uFF1A</strong>\u7528\u624B\u52A8\u7F16\u8F91\u5668\u4FEE\u590D\u4E0D\u5B8C\u7F8E\u7684\u5730\u65B9\u3002\u6A61\u76AE\u64E6\u7ED9\u4F60\u50CF\u7D20\u7EA7\u7684\u63A7\u5236\u3002',
@@ -1578,12 +1466,10 @@ const translations: Translations = {
     'batch.done': '\u5B8C\u6210',
     'batch.discarded': '\u5DF2\u4E22\u5F03',
     'batch.completed': '{done}/{total} \u5B8C\u6210\uFF0C{failed} \u5931\u8D25',
-    'batch.emptyZip': '\u6CA1\u6709\u5DF2\u5904\u7406\u7684\u56FE\u7247\u53EF\u4E0B\u8F7D',
     'batch.cancel': '\u53D6\u6D88\u6279\u91CF',
     'dropzone.multi': '\u62D6\u5165\u6700\u591A 12 \u5F20\u56FE\u7247\u8FDB\u5165\u6279\u91CF\u6A21\u5F0F',
 
     // Language selector
-    'lang.label': '\u8BED\u8A00',
   },
 };
 

--- a/src/lib/brush-stroke.ts
+++ b/src/lib/brush-stroke.ts
@@ -1,0 +1,84 @@
+/**
+ * Immutable record of a single brush operation in the basic editor:
+ * a circular or square stamp at one image-pixel coordinate, in either
+ * 'erase' (zero alpha) or 'restore' (copy RGBA from the pre-segmentation
+ * source) mode.
+ *
+ * Extracted from `ar-editor.ts` in #47/Phase-2. The component used to
+ * inline this logic in a private `stamp()` method that mutated
+ * `this.imageData` directly. Pulling it out as a value type lets tests
+ * exercise the pixel arithmetic without spinning up a custom element,
+ * and keeps the component focused on input + canvas wiring.
+ *
+ * The class intentionally has no DOM / canvas dependencies — only
+ * ImageData buffers in and out. That makes it safe to call from a
+ * worker if we ever need to replay strokes off the main thread.
+ */
+export type BrushTool = 'erase' | 'restore';
+
+export type BrushShape = 'circle' | 'square';
+
+export interface BrushStrokeConfig {
+  /** Center X in image pixels. */
+  cx: number;
+  /** Center Y in image pixels. */
+  cy: number;
+  /** Erase = drop alpha to 0; restore = copy RGBA from `originalImage`. */
+  tool: BrushTool;
+  /** Diameter in image pixels. Radius is derived as `Math.floor(size / 2)`. */
+  size: number;
+  /** Footprint shape. Square is bbox; circle clips to (dx² + dy² ≤ r²). */
+  shape: BrushShape;
+}
+
+export class BrushStroke {
+  readonly cx: number;
+  readonly cy: number;
+  readonly tool: BrushTool;
+  readonly size: number;
+  readonly shape: BrushShape;
+
+  constructor(config: BrushStrokeConfig) {
+    this.cx = config.cx;
+    this.cy = config.cy;
+    this.tool = config.tool;
+    this.size = config.size;
+    this.shape = config.shape;
+  }
+
+  /**
+   * Apply this stroke onto `imageData` (mutating its pixel buffer).
+   * The `originalImage` source is only read when the tool is 'restore';
+   * 'erase' just zeros out alpha. Both buffers must share `width × height`
+   * dimensions; mismatches are caller error.
+   *
+   * Pixels outside the image bounds are skipped silently — the editor
+   * lets the user paint past the canvas edge without errors.
+   */
+  apply(imageData: ImageData, originalImage: ImageData, width: number, height: number): void {
+    const data = imageData.data;
+    const src = originalImage.data;
+    const restore = this.tool === 'restore';
+    const r = Math.floor(this.size / 2);
+    const circle = this.shape === 'circle';
+    const r2 = r * r;
+
+    for (let dy = -r; dy <= r; dy++) {
+      for (let dx = -r; dx <= r; dx++) {
+        const px = this.cx + dx;
+        const py = this.cy + dy;
+        if (px < 0 || px >= width || py < 0 || py >= height) continue;
+        if (circle && dx * dx + dy * dy > r2) continue;
+        const i = (py * width + px) * 4;
+        if (restore) {
+          data[i] = src[i];
+          data[i + 1] = src[i + 1];
+          data[i + 2] = src[i + 2];
+          data[i + 3] = src[i + 3];
+        } else {
+          data[i + 3] = 0;
+        }
+      }
+    }
+  }
+}

--- a/src/lib/history-manager.ts
+++ b/src/lib/history-manager.ts
@@ -18,8 +18,21 @@
 export class HistoryManager<T> {
   private undoStack: T[] = [];
   private redoStack: T[] = [];
+  private maxEntries: number;
 
-  constructor(private readonly maxEntries: number = 12) {}
+  constructor(maxEntries: number = 12) {
+    this.maxEntries = maxEntries;
+  }
+
+  /** Adjust the cap. Useful when the underlying state changes size and
+   *  the memory budget needs re-tuning (e.g. ar-editor-advanced computes
+   *  cap from image dimensions). Trims existing stacks to fit so we
+   *  don't carry stale entries beyond the new budget. */
+  setMaxEntries(n: number): void {
+    this.maxEntries = n;
+    while (this.undoStack.length > this.maxEntries) this.undoStack.shift();
+    while (this.redoStack.length > this.maxEntries) this.redoStack.shift();
+  }
 
   /** Push a new state. Drops the oldest entry once we exceed the cap.
    *  Pushing always wipes the redo stack — once the user starts a fresh

--- a/src/lib/history-manager.ts
+++ b/src/lib/history-manager.ts
@@ -1,0 +1,70 @@
+/**
+ * Bounded undo/redo stack, generic over the state shape it holds. The
+ * caller decides what a "state" is — for the basic editor it's a
+ * Uint8ClampedArray RGBA snapshot; for advanced editors it could be a
+ * stroke record or a typed delta.
+ *
+ * Extracted from `ar-editor.ts` in #47/Phase-2. The component used to
+ * carry two raw arrays (`undoStack` / `redoStack`) plus a hand-rolled
+ * `pushUndo / undo / redo` triplet. Pulling it out lets the advanced
+ * editor (Phase 3b) reuse the same primitive instead of growing yet
+ * another copy.
+ *
+ * Cap policy: FIFO eviction at `maxEntries`. The default of 12 matches
+ * the basic editor's existing budget — enough room for typical
+ * touch-up sessions without letting full-RGBA snapshots blow the heap
+ * on multi-megapixel images.
+ */
+export class HistoryManager<T> {
+  private undoStack: T[] = [];
+  private redoStack: T[] = [];
+
+  constructor(private readonly maxEntries: number = 12) {}
+
+  /** Push a new state. Drops the oldest entry once we exceed the cap.
+   *  Pushing always wipes the redo stack — once the user starts a fresh
+   *  branch of edits, the previously redoable entries are unreachable. */
+  push(state: T): void {
+    this.undoStack.push(state);
+    if (this.undoStack.length > this.maxEntries) {
+      this.undoStack.shift();
+    }
+    this.redoStack = [];
+  }
+
+  /** Pop the most recent undo entry and return it. The caller passes
+   *  the current state, which gets moved onto the redo stack so a
+   *  subsequent `redo()` can return to it. Returns null if the undo
+   *  stack is empty. */
+  undo(currentState: T): T | null {
+    const prev = this.undoStack.pop();
+    if (prev === undefined) return null;
+    this.redoStack.push(currentState);
+    return prev;
+  }
+
+  /** Pop the most recent redo entry and return it. Mirrors `undo()`:
+   *  current state moves to the undo stack. Returns null if the redo
+   *  stack is empty. */
+  redo(currentState: T): T | null {
+    const next = this.redoStack.pop();
+    if (next === undefined) return null;
+    this.undoStack.push(currentState);
+    return next;
+  }
+
+  canUndo(): boolean {
+    return this.undoStack.length > 0;
+  }
+
+  canRedo(): boolean {
+    return this.redoStack.length > 0;
+  }
+
+  /** Wipe both stacks. Call when the underlying state is replaced
+   *  wholesale (new image loaded, editor reset, etc.). */
+  clear(): void {
+    this.undoStack = [];
+    this.redoStack = [];
+  }
+}

--- a/src/lib/lasso-model.ts
+++ b/src/lib/lasso-model.ts
@@ -1,0 +1,203 @@
+/**
+ * Lasso state machine for the advanced editor: tracks the raw freehand
+ * path the user is drawing, the simplified anchor polygon once they
+ * close it, and any in-flight anchor drag. Pure data + geometry — no
+ * DOM, canvas, or pipeline knowledge.
+ *
+ * Extracted from `ar-editor-advanced.ts` in #47/Phase-3a. The component
+ * used to carry four instance fields (`lassoRaw`, `lassoAnchors`,
+ * `dragAnchorIndex`, plus the simplification math inline) and call into
+ * `simplifyClosed()` directly. Pulling the state into its own class
+ * lets the host stay focused on input + render + pipeline wiring, and
+ * gives us a place to unit-test the geometry without spinning up a
+ * shadow DOM.
+ *
+ * Reuses `simplifyClosed()` from `../components/lasso-simplify.ts`
+ * (pure function, no DOM deps) for Douglas-Peucker reduction.
+ */
+import { simplifyClosed, type Point } from '../components/lasso-simplify';
+
+export type { Point };
+
+export class LassoModel {
+  /** Polygon must have at least this many anchors to be considered
+   *  closed. Below this, `close()` discards the path and stays empty. */
+  static readonly MIN_ANCHORS = 3;
+
+  /** Default min-distance gate for `addRawPoint()`. Avoids burying the
+   *  Douglas-Peucker step in noise from a single user gesture. */
+  static readonly DEFAULT_MIN_POINT_DIST = 2;
+
+  private rawPath: Point[] | null = null;
+  private anchors: Point[] | null = null;
+  private dragIndex: number | null = null;
+
+  constructor(private simplifyEpsilon: number = 1.5) {}
+
+  // ── Read accessors ─────────────────────────────────────────────────
+
+  /** In-progress freehand points, dense and unsimplified. Null while
+   *  the lasso is closed or empty. Returned as a defensive shallow copy
+   *  is unnecessary — callers should treat it as read-only. */
+  getRawPath(): readonly Point[] | null {
+    return this.rawPath;
+  }
+
+  /** Closed simplified polygon. Null until `close()` succeeds. */
+  getAnchors(): readonly Point[] | null {
+    return this.anchors;
+  }
+
+  /** Index of the anchor currently being dragged, or null. */
+  getDragAnchorIndex(): number | null {
+    return this.dragIndex;
+  }
+
+  isClosed(): boolean {
+    return this.anchors !== null && this.anchors.length >= LassoModel.MIN_ANCHORS;
+  }
+
+  isEmpty(): boolean {
+    return this.rawPath === null && this.anchors === null;
+  }
+
+  // ── Mutators ───────────────────────────────────────────────────────
+
+  /** Update the simplification epsilon. Call when the image dimensions
+   *  change so the tolerance scales with the canvas. */
+  setSimplifyEpsilon(eps: number): void {
+    this.simplifyEpsilon = eps;
+  }
+
+  /** Begin a fresh raw path. Wipes any prior state including a closed
+   *  polygon and any in-progress anchor drag. */
+  startAt(point: Point): void {
+    this.rawPath = [{ x: point.x, y: point.y }];
+    this.anchors = null;
+    this.dragIndex = null;
+  }
+
+  /** Append a point to the raw path if it sits at least `minDist` away
+   *  from the last raw point. Noop when no raw path is active. */
+  addRawPoint(point: Point, minDist: number = LassoModel.DEFAULT_MIN_POINT_DIST): void {
+    if (!this.rawPath) return;
+    const last = this.rawPath[this.rawPath.length - 1];
+    const dx = point.x - last.x;
+    const dy = point.y - last.y;
+    if (dx * dx + dy * dy < minDist * minDist) return;
+    this.rawPath.push({ x: point.x, y: point.y });
+  }
+
+  /** Close the lasso: run Douglas-Peucker on the raw path. If the
+   *  resulting polygon has fewer than MIN_ANCHORS vertices, both raw
+   *  path and anchors are cleared and 0 is returned. Otherwise the
+   *  raw path is dropped and the simplified polygon becomes the
+   *  active anchor set; returns the anchor count. */
+  close(): number {
+    if (!this.rawPath) return 0;
+    const simplified = simplifyClosed(this.rawPath, this.simplifyEpsilon);
+    this.rawPath = null;
+    if (simplified.length < LassoModel.MIN_ANCHORS) {
+      this.anchors = null;
+      return 0;
+    }
+    this.anchors = simplified;
+    return simplified.length;
+  }
+
+  /** Move the anchor at index `idx` to a new position. Noop if the
+   *  lasso isn't closed or `idx` is out of bounds. */
+  moveAnchor(idx: number, point: Point): void {
+    if (!this.anchors) return;
+    if (idx < 0 || idx >= this.anchors.length) return;
+    this.anchors[idx] = { x: point.x, y: point.y };
+  }
+
+  /** Mark `idx` as the anchor being dragged. Caller should subsequently
+   *  call `moveAnchor()` on each pointer-move and `endDragAnchor()` on
+   *  pointer-up. */
+  beginDragAnchor(idx: number): void {
+    if (!this.anchors) return;
+    if (idx < 0 || idx >= this.anchors.length) return;
+    this.dragIndex = idx;
+  }
+
+  /** Clear any drag state. Idempotent. */
+  endDragAnchor(): void {
+    this.dragIndex = null;
+  }
+
+  /** Remove the anchor at `idx`. Refuses to delete if it would leave
+   *  fewer than MIN_ANCHORS — caller should check `isClosed()` after
+   *  to know whether the polygon survived. Returns true if removed. */
+  removeAnchor(idx: number): boolean {
+    if (!this.anchors) return false;
+    if (idx < 0 || idx >= this.anchors.length) return false;
+    if (this.anchors.length <= LassoModel.MIN_ANCHORS) return false;
+    this.anchors.splice(idx, 1);
+    return true;
+  }
+
+  /** Wipe all lasso state. Equivalent to "user pressed Esc" or
+   *  "controller decided the selection is no longer relevant". */
+  clear(): void {
+    this.rawPath = null;
+    this.anchors = null;
+    this.dragIndex = null;
+  }
+
+  // ── Geometry queries ───────────────────────────────────────────────
+
+  /** Find the anchor closest to (ix, iy), within `tolerance` pixels.
+   *  Returns the index, or null if no anchor is in range. */
+  hitAnchor(ix: number, iy: number, tolerance: number): number | null {
+    if (!this.anchors) return null;
+    const tolSq = tolerance * tolerance;
+    let closest = -1;
+    let closestDistSq = Infinity;
+    for (let i = 0; i < this.anchors.length; i++) {
+      const dx = this.anchors[i].x - ix;
+      const dy = this.anchors[i].y - iy;
+      const distSq = dx * dx + dy * dy;
+      if (distSq <= tolSq && distSq < closestDistSq) {
+        closest = i;
+        closestDistSq = distSq;
+      }
+    }
+    return closest >= 0 ? closest : null;
+  }
+
+  /** Axis-aligned bounding box of the closed polygon, in image pixels.
+   *  Null if the lasso isn't closed. */
+  getBoundingBox(): { x: number; y: number; w: number; h: number } | null {
+    if (!this.anchors || this.anchors.length === 0) return null;
+    let minX = Infinity;
+    let minY = Infinity;
+    let maxX = -Infinity;
+    let maxY = -Infinity;
+    for (const p of this.anchors) {
+      if (p.x < minX) minX = p.x;
+      if (p.y < minY) minY = p.y;
+      if (p.x > maxX) maxX = p.x;
+      if (p.y > maxY) maxY = p.y;
+    }
+    return { x: minX, y: minY, w: maxX - minX, h: maxY - minY };
+  }
+
+  /** Even-odd ray-casting point-in-polygon test. Returns false if the
+   *  lasso isn't closed. */
+  containsPoint(p: Point): boolean {
+    const poly = this.anchors;
+    if (!poly || poly.length < LassoModel.MIN_ANCHORS) return false;
+    let inside = false;
+    for (let i = 0, j = poly.length - 1; i < poly.length; j = i++) {
+      const xi = poly[i].x;
+      const yi = poly[i].y;
+      const xj = poly[j].x;
+      const yj = poly[j].y;
+      const intersect = yi > p.y !== yj > p.y && p.x < ((xj - xi) * (p.y - yi)) / (yj - yi) + xi;
+      if (intersect) inside = !inside;
+    }
+    return inside;
+  }
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -161,7 +161,7 @@ function createShortcutOverlay(): HTMLDivElement {
 function showConsoleLogo(): void {
   const logo = `
 %c    ☢ NUKEBG ☢
-    v2.9.5 | Terminal Edition
+    v2.10.0 | Terminal Edition
 
     Your images never leave this machine.
     Don't believe us? Read the source:

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -153,7 +153,10 @@
 :root[data-theme='amber'] {
   --color-text-primary: #ff8c00;
   --color-text-secondary: #cc7000;
-  --color-text-tertiary: #995300;
+  /* Tertiary was #995300 (3.59:1 on black, fails WCAG AA). Bumped to
+     #b06400 (~4.67:1, AA pass) while keeping it dimmer than secondary
+     to preserve the primary > secondary > tertiary luminance ramp. */
+  --color-text-tertiary: #b06400;
   --color-accent-rgb: 255, 140, 0;
   --color-accent-primary: #ff8c00;
   --color-accent-hover: #ffaa33;

--- a/src/utils/capability-detector.ts
+++ b/src/utils/capability-detector.ts
@@ -1,17 +1,22 @@
 /**
  * Device capability detector for adaptive image processing.
  *
- * Combines multiple signals to decide the safe working resolution
- * for the pipeline on the current device:
- *   - navigator.deviceMemory (Chromium only, quantized to 0.25/0.5/1/2/4/8 GB)
- *   - performance.memory.jsHeapSizeLimit (Chromium only, tab-level cap)
- *   - navigator.hardwareConcurrency (all browsers, proxy for device tier)
- *   - userAgent (mobile detection)
- *   - Active probe: allocate OffscreenCanvas + ImageData at target size
+ * Policy: every device starts at the highest tier the available memory
+ * signals can justify, and the active probe downgrades when allocation
+ * fails. No User-Agent-based downgrades — mobile/desktop are NOT
+ * pre-classified — so output stays consistent across devices that share
+ * the same memory budget.
  *
- * The probe is the authoritative signal: if the browser can't allocate
- * the target buffer, we step down. Safari/Firefox have no deviceMemory
- * so the probe is their only defense.
+ * Signals consulted, in priority order:
+ *   - performance.memory.jsHeapSizeLimit (Chromium only, tab-level cap)
+ *   - navigator.deviceMemory (Chromium only, quantized to 0.25/0.5/1/2/4/8 GB)
+ *   - navigator.hardwareConcurrency (proxy for device class when memory APIs absent)
+ *   - Active probe: allocate an RGBA buffer at tier size; on failure, step down.
+ *
+ * When no memory API is exposed (notably iOS Safari and some Firefox builds)
+ * we start at `high` and let the probe decide. The probe is intentionally
+ * the only safety net for these cases — UA sniffing produced inconsistent
+ * results across devices that could otherwise handle the same workload.
  */
 
 export type CapabilityTier = 'low' | 'mid' | 'high' | 'ultra';
@@ -60,27 +65,11 @@ type PerformanceWithMemory = Performance & {
   };
 };
 
-function isMobileUA(): boolean {
-  if (typeof navigator === 'undefined') return false;
-  return /Mobi|Android|iPhone|iPad/i.test(navigator.userAgent);
-}
-
 /**
- * Safari/WebKit detection. iOS devices (iPhone, iPad) always run WebKit
- * regardless of which browser label is shown. Desktop Safari on macOS
- * also routes through this path. Chromium on iOS reports as CriOS,
- * which we want to EXCLUDE — it behaves like Chromium, not Safari.
- */
-function isSafari(): boolean {
-  if (typeof navigator === 'undefined') return false;
-  const ua = navigator.userAgent;
-  if (/CriOS|FxiOS|EdgiOS/i.test(ua)) return false;
-  return /Safari/i.test(ua) && /AppleWebKit/i.test(ua) && !/Chrome|Chromium/i.test(ua);
-}
-
-/**
- * Pick an initial tier from passive signals, before any probe.
- * This is a best-guess starting point; the probe can downgrade it.
+ * Pick an initial tier from memory signals, before any probe.
+ * Memory APIs are authoritative when present; otherwise default to `high`
+ * and rely on the probe to downgrade. No UA sniffing — output consistency
+ * across devices is the explicit goal.
  */
 function guessTier(): { tier: CapabilityTier; reason: string } {
   const nav = (typeof navigator !== 'undefined' ? navigator : undefined) as
@@ -90,30 +79,13 @@ function guessTier(): { tier: CapabilityTier; reason: string } {
     | PerformanceWithMemory
     | undefined;
 
-  const mobile = isMobileUA();
-  const safari = isSafari();
   const memory = nav?.deviceMemory; // 0.25 | 0.5 | 1 | 2 | 4 | 8 | undefined
   const cores = nav?.hardwareConcurrency ?? 0;
   const heapLimit = perf?.memory?.jsHeapSizeLimit;
 
-  // iOS Safari: force low tier. iOS tabs have ~1 GB heap ceiling (lower
-  // on older devices) and Safari doesn't expose deviceMemory/heapLimit,
-  // so without this check we fall through to `mid` (16 MP, 64 MB per
-  // buffer) and hit OOM / canvas allocation failures mid-pipeline. Low
-  // (8 MP, 32 MB per buffer) is the only reliably-safe budget on iOS.
-  if (mobile && safari) {
-    return { tier: 'low', reason: 'iOS Safari (no memory API, ~1GB tab cap)' };
-  }
-
-  // Low tier: explicit low memory or clearly constrained mobile
-  if (memory !== undefined && memory <= 2) {
-    return { tier: 'low', reason: `deviceMemory=${memory}GB` };
-  }
-  if (mobile && cores > 0 && cores <= 4) {
-    return { tier: 'low', reason: `mobile, cores=${cores}` };
-  }
-
-  // Chromium-only: heap cap gives us an actual budget
+  // Chromium: heap cap is authoritative. Allocating beyond it throws
+  // synchronously and the probe cannot rescue us — start at the tier the
+  // budget actually fits.
   if (heapLimit !== undefined) {
     const heapGB = heapLimit / (1024 * 1024 * 1024);
     if (heapGB < 1) return { tier: 'low', reason: `heapLimit=${heapGB.toFixed(2)}GB` };
@@ -122,29 +94,22 @@ function guessTier(): { tier: CapabilityTier; reason: string } {
     return { tier: 'ultra', reason: `heapLimit=${heapGB.toFixed(2)}GB` };
   }
 
-  // No heap info (Safari / Firefox). Use deviceMemory + cores.
-  if (memory !== undefined && memory >= 8) {
-    return {
-      tier: cores >= 8 ? 'ultra' : 'high',
-      reason: `deviceMemory=${memory}GB, cores=${cores}`,
-    };
-  }
-  if (memory !== undefined && memory >= 4) {
+  // No heap (Safari / Firefox). Use deviceMemory if exposed; treat it as
+  // a memory budget hint, not a device-class label.
+  if (memory !== undefined) {
+    if (memory <= 2) return { tier: 'low', reason: `deviceMemory=${memory}GB` };
+    if (memory <= 4) return { tier: 'mid', reason: `deviceMemory=${memory}GB` };
+    if (memory >= 8 && cores >= 8) {
+      return { tier: 'ultra', reason: `deviceMemory=${memory}GB, cores=${cores}` };
+    }
     return { tier: 'high', reason: `deviceMemory=${memory}GB` };
   }
-  if (mobile) {
-    return { tier: 'mid', reason: `mobile (no memory API)` };
-  }
 
-  // Desktop Safari — no memory API, but typically runs on 8+ GB
-  // machines. Default to `mid` instead of the `high` a Chromium heap
-  // hint would produce. Probe may promote if the machine is capable.
-  if (safari) {
-    return { tier: 'mid', reason: 'desktop Safari (no memory API)' };
-  }
-
-  // Desktop, unknown memory. Assume mid — probe will confirm.
-  return { tier: 'mid', reason: 'desktop (no memory API)' };
+  // No memory API at all (notably iOS Safari, some Firefox builds). Start
+  // at `high` and let the probe step down if allocation fails. This is the
+  // deliberate trade for output consistency: a device that genuinely cannot
+  // hold the high-tier budget will downgrade through `mid` → `low` cleanly.
+  return { tier: 'high', reason: 'no memory API — probe-driven' };
 }
 
 /**

--- a/src/utils/image-io.ts
+++ b/src/utils/image-io.ts
@@ -175,7 +175,7 @@ export async function exportPng(imageData: ImageData): Promise<Blob> {
     });
   }
   return injectPngMetadata(rawBlob, {
-    Software: 'NukeBG v2.9.5',
+    Software: 'NukeBG v2.10.0',
     Source: 'https://nukebg.app',
   });
 }

--- a/src/utils/image-io.ts
+++ b/src/utils/image-io.ts
@@ -39,7 +39,12 @@ async function sniffImageFormat(file: File): Promise<SupportedFormat | null> {
   if (head[0] === 0xff && head[1] === 0xd8 && head[2] === 0xff) {
     return 'image/jpeg';
   }
-  // WebP: "RIFF" <size> "WEBP"
+  // WebP: "RIFF" <size: LE uint32> "WEBP"
+  // The size field at bytes 4-7 (little-endian uint32) declares the byte
+  // count of everything after the size itself, so it must equal
+  // file.size - 8. Validating this guards against polyglot files that
+  // pass the magic-byte check but carry trailing/truncated content
+  // (#189).
   if (
     head[0] === 0x52 &&
     head[1] === 0x49 &&
@@ -50,6 +55,8 @@ async function sniffImageFormat(file: File): Promise<SupportedFormat | null> {
     head[10] === 0x42 &&
     head[11] === 0x50
   ) {
+    const declaredSize = (head[4] | (head[5] << 8) | (head[6] << 16) | (head[7] << 24)) >>> 0;
+    if (declaredSize + 8 !== file.size) return null;
     return 'image/webp';
   }
   return null;

--- a/src/utils/reactor-economics.ts
+++ b/src/utils/reactor-economics.ts
@@ -77,6 +77,35 @@ export interface DonorsFile {
 }
 
 /**
+ * Runtime shape guard for `/donors.json` payloads (#188). Cheap manual
+ * check — no Zod dependency for one schema. Validates the version
+ * sentinel, the four expected fields and (shallowly) the supporters
+ * array entries so consumers can trust `donors.supporters[i].amount_eur`
+ * without runtime surprises.
+ *
+ * Returns false (rather than throwing) so callers can fall back to an
+ * empty donors object and keep the page rendering honestly.
+ */
+export function isDonorsFile(x: unknown): x is DonorsFile {
+  if (typeof x !== 'object' || x === null) return false;
+  const o = x as Record<string, unknown>;
+  if (o.version !== 1) return false;
+  if (typeof o.updated_at !== 'string') return false;
+  if (typeof o.anonymous_count !== 'number') return false;
+  if (typeof o.anonymous_total_eur !== 'number') return false;
+  if (!Array.isArray(o.supporters)) return false;
+  for (const s of o.supporters) {
+    if (typeof s !== 'object' || s === null) return false;
+    const e = s as Record<string, unknown>;
+    if (typeof e.name !== 'string') return false;
+    if (typeof e.amount_eur !== 'number') return false;
+    if (typeof e.date !== 'string') return false;
+    if (e.consent !== 'explicit') return false;
+  }
+  return true;
+}
+
+/**
  * Total sunk investment in EUR (time at fair-rate + cash spent).
  */
 export function totalSunkEur(): number {

--- a/src/utils/reactor-status-injector.ts
+++ b/src/utils/reactor-status-injector.ts
@@ -17,6 +17,7 @@ import {
   formatRuntime,
   totalDonationsEur,
   MONTHLY_BURN_EUR,
+  isDonorsFile,
   type DonorsFile,
 } from './reactor-economics';
 
@@ -45,7 +46,9 @@ async function fetchAndComputeRuntime(): Promise<string> {
   try {
     const res = await fetch(DONORS_URL, { cache: 'no-cache' });
     if (!res.ok) return formatRuntime(0);
-    const donors = (await res.json()) as DonorsFile;
+    const payload: unknown = await res.json();
+    if (!isDonorsFile(payload)) return formatRuntime(0);
+    const donors: DonorsFile = payload;
     const totalEur = totalDonationsEur(donors);
     const { months, days } = computeRuntime(totalEur);
     const monthsFloat = months + days / 30;

--- a/src/workers/cv.worker.ts
+++ b/src/workers/cv.worker.ts
@@ -9,6 +9,10 @@ import { estimateForeground } from './cv/foreground-estimation';
 import type { CvWorkerRequest } from '../types/worker-messages';
 
 self.onmessage = (e: MessageEvent<CvWorkerRequest>) => {
+  // Reject cross-origin postMessage (CodeQL js/missing-origin-check, #187).
+  // Empty-origin events are allowed: dedicated Workers receive '' in some
+  // browsers; same-origin spawning is enforced by the page's CSP.
+  if (e.origin && e.origin !== self.location.origin) return;
   const { id, type, payload } = e.data;
 
   try {

--- a/src/workers/cv/clamp.ts
+++ b/src/workers/cv/clamp.ts
@@ -1,0 +1,18 @@
+/**
+ * Clamp a number into the byte range [0, 255] and round to integer.
+ *
+ * Float→Uint8ClampedArray writes auto-clamp + round under the hood, so
+ * skipping this helper does NOT corrupt output today. We use it where
+ * the pixel arithmetic produces floats (bilinear interpolation, alpha
+ * blending with noise) so the intent is explicit at the call site and
+ * a NaN doesn't silently become 0 if upstream math ever drifts.
+ *
+ * Extracted from `foreground-estimation.ts` and applied in
+ * `inpaint-blend.ts` + `lama-crop.ts` per #194.
+ */
+export function clamp255(v: number): number {
+  if (Number.isNaN(v)) return 0;
+  if (v <= 0) return 0;
+  if (v >= 255) return 255;
+  return Math.round(v);
+}

--- a/src/workers/cv/inpaint-blend.ts
+++ b/src/workers/cv/inpaint-blend.ts
@@ -18,6 +18,7 @@
  * Kept as a pure, standalone function so the inpaint worker stays
  * testable and the orchestrator can wire it independently.
  */
+import { clamp255 } from './clamp';
 
 export interface FeatherOptions {
   /** Pixels of soft transition from inpainted to original. */
@@ -143,9 +144,13 @@ export function compositeWithFeather(
     }
 
     const inv = 255 - a;
-    out[p] = (ir * a + original[p] * inv) / 255;
-    out[p + 1] = (ig * a + original[p + 1] * inv) / 255;
-    out[p + 2] = (ib * a + original[p + 2] * inv) / 255;
+    // Explicit clamp + round (#194). Uint8ClampedArray would clamp anyway,
+    // but writing it out documents intent and traps a NaN before it
+    // becomes a silent 0 (would happen only if upstream math drifts —
+    // gauss() is currently NaN-safe via Math.max(u1, 1e-12)).
+    out[p] = clamp255((ir * a + original[p] * inv) / 255);
+    out[p + 1] = clamp255((ig * a + original[p + 1] * inv) / 255);
+    out[p + 2] = clamp255((ib * a + original[p + 2] * inv) / 255);
     // Alpha channel: always 255 (opaque). Inpaint output may have garbage
     // here; the original is guaranteed opaque for loaded images.
     out[p + 3] = 255;

--- a/src/workers/cv/lama-crop.ts
+++ b/src/workers/cv/lama-crop.ts
@@ -1,4 +1,5 @@
 import { LAMA_PARAMS } from '../../pipeline/constants';
+import { clamp255 } from './clamp';
 
 export interface LamaCropRect {
   x: number;
@@ -174,7 +175,10 @@ export function spliceLamaOutput(
       for (let c = 0; c < 3; c++) {
         const top = lamaOutput[i00 + c] * (1 - fx) + lamaOutput[i01 + c] * fx;
         const bot = lamaOutput[i10 + c] * (1 - fx) + lamaOutput[i11 + c] * fx;
-        out[di + c] = top * (1 - fy) + bot * fy;
+        // Explicit clamp + round (#194). Uint8ClampedArray clamps and
+        // rounds on assign, but stating it makes the intent visible and
+        // traps NaN before it becomes a silent 0.
+        out[di + c] = clamp255(top * (1 - fy) + bot * fy);
       }
       // out[di + 3] left untouched — preserves the original alpha.
     }

--- a/src/workers/inpaint.worker.ts
+++ b/src/workers/inpaint.worker.ts
@@ -35,6 +35,10 @@ async function inpaint(
 }
 
 self.onmessage = async (e: MessageEvent<InpaintWorkerRequest>) => {
+  // Reject cross-origin postMessage (CodeQL js/missing-origin-check, #187).
+  // Empty-origin events are allowed: dedicated Workers receive '' in some
+  // browsers; same-origin spawning is enforced by the page's CSP.
+  if (e.origin && e.origin !== self.location.origin) return;
   const msg = e.data;
   try {
     switch (msg.type) {

--- a/src/workers/lama.worker.ts
+++ b/src/workers/lama.worker.ts
@@ -234,6 +234,10 @@ async function runInpaint(
 }
 
 self.onmessage = async (e: MessageEvent<LamaWorkerRequest>) => {
+  // Reject cross-origin postMessage (CodeQL js/missing-origin-check, #187).
+  // Empty-origin events are allowed: dedicated Workers receive '' in some
+  // browsers; same-origin spawning is enforced by the page's CSP.
+  if (e.origin && e.origin !== self.location.origin) return;
   const msg = e.data;
   try {
     switch (msg.type) {

--- a/src/workers/ml.worker.ts
+++ b/src/workers/ml.worker.ts
@@ -546,6 +546,10 @@ async function segment(
 }
 
 self.onmessage = async (e: MessageEvent<MlWorkerRequest>) => {
+  // Reject cross-origin postMessage (CodeQL js/missing-origin-check, #187).
+  // Empty-origin events are allowed: dedicated Workers receive '' in some
+  // browsers; same-origin spawning is enforced by the page's CSP.
+  if (e.origin && e.origin !== self.location.origin) return;
   const msg = e.data;
   try {
     switch (msg.type) {

--- a/src/workers/sam.worker.ts
+++ b/src/workers/sam.worker.ts
@@ -316,6 +316,10 @@ function dispose(): void {
 // ────────────────────────────── Message router ─────────────────────────────
 
 self.addEventListener('message', async (e: MessageEvent<SamWorkerRequest>) => {
+  // Reject cross-origin postMessage (CodeQL js/missing-origin-check, #187).
+  // Empty-origin events are allowed: dedicated Workers receive '' in some
+  // browsers; same-origin spawning is enforced by the page's CSP.
+  if (e.origin && e.origin !== self.location.origin) return;
   const msg = e.data;
   try {
     switch (msg.type) {

--- a/tests/color-consistency.test.ts
+++ b/tests/color-consistency.test.ts
@@ -46,6 +46,7 @@ const FORBIDDEN_HEX = [
   '#008830', // previous tertiary — keep blocked so it can't regress
   '#1a3a1a', // --color-surface-border
   '#ffd700', // old --color-accent (no longer exists)
+  '#995300', // amber tertiary previous (3.59:1 fail) — keep blocked
 ];
 
 // Allowed contexts where these hex values appear as CSS variable FALLBACKS

--- a/tests/controllers/sam-refiner.test.ts
+++ b/tests/controllers/sam-refiner.test.ts
@@ -1,0 +1,169 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+// ─── Mocks for ../../src/refine/loaders/mobile-sam ──────────────────────
+// Hoisted so vi.mock can hoist them above the SamRefiner import below.
+const { loadSamMock, encodeSamMock, decodeSamMock, disposeSamMock, onSamProgressMock } = vi.hoisted(
+  () => ({
+    loadSamMock: vi.fn(() => Promise.resolve()),
+    encodeSamMock: vi.fn(() => Promise.resolve()),
+    decodeSamMock: vi.fn(() => Promise.resolve({ mask: new Uint8Array(16), width: 4, height: 4 })),
+    disposeSamMock: vi.fn(),
+    onSamProgressMock: vi.fn(),
+  }),
+);
+
+vi.mock('../../src/refine/loaders/mobile-sam', () => ({
+  loadSam: loadSamMock,
+  encodeSam: encodeSamMock,
+  decodeSam: decodeSamMock,
+  disposeSam: disposeSamMock,
+  onSamProgress: onSamProgressMock,
+}));
+
+import { SamRefiner } from '../../src/controllers/sam-refiner';
+
+beforeEach(() => {
+  loadSamMock.mockClear();
+  encodeSamMock.mockClear();
+  decodeSamMock.mockClear();
+  disposeSamMock.mockClear();
+  onSamProgressMock.mockClear();
+});
+
+const ac = (): AbortController => new AbortController();
+
+describe('SamRefiner', () => {
+  describe('ensureEncoded', () => {
+    it('runs load + encode then flips isEncoded() to true', async () => {
+      const r = new SamRefiner();
+      expect(r.isEncoded()).toBe(false);
+
+      await r.ensureEncoded(new Uint8ClampedArray(64), 4, 4, ac().signal);
+
+      expect(loadSamMock).toHaveBeenCalledTimes(1);
+      expect(encodeSamMock).toHaveBeenCalledTimes(1);
+      expect(encodeSamMock).toHaveBeenCalledWith(expect.any(Uint8ClampedArray), 4, 4);
+      expect(r.isEncoded()).toBe(true);
+    });
+
+    it('is idempotent — second call skips load + encode', async () => {
+      const r = new SamRefiner();
+      const signal = ac().signal;
+      await r.ensureEncoded(new Uint8ClampedArray(64), 4, 4, signal);
+      await r.ensureEncoded(new Uint8ClampedArray(64), 4, 4, signal);
+
+      expect(loadSamMock).toHaveBeenCalledTimes(1);
+      expect(encodeSamMock).toHaveBeenCalledTimes(1);
+    });
+
+    it('wires the progress callback before load and clears it after', async () => {
+      const cb = vi.fn();
+      const r = new SamRefiner(cb);
+      await r.ensureEncoded(new Uint8ClampedArray(64), 4, 4, ac().signal);
+
+      expect(onSamProgressMock).toHaveBeenCalledTimes(2);
+      expect(onSamProgressMock.mock.calls[0][0]).toBe(cb);
+      expect(onSamProgressMock.mock.calls[1][0]).toBeNull();
+    });
+
+    it('does not touch onSamProgress if no callback was supplied', async () => {
+      const r = new SamRefiner();
+      await r.ensureEncoded(new Uint8ClampedArray(64), 4, 4, ac().signal);
+      expect(onSamProgressMock).not.toHaveBeenCalled();
+    });
+
+    it('throws AbortError when signal is already aborted before load', async () => {
+      const r = new SamRefiner();
+      const c = ac();
+      c.abort();
+
+      await expect(r.ensureEncoded(new Uint8ClampedArray(64), 4, 4, c.signal)).rejects.toThrowError(
+        /Aborted/,
+      );
+      expect(loadSamMock).not.toHaveBeenCalled();
+      expect(r.isEncoded()).toBe(false);
+    });
+
+    it('clears the progress callback even when aborted mid-flight', async () => {
+      const cb = vi.fn();
+      const r = new SamRefiner(cb);
+      const c = ac();
+      // Abort right after load resolves but before encode would run.
+      loadSamMock.mockImplementationOnce(() => {
+        c.abort();
+        return Promise.resolve();
+      });
+
+      await expect(r.ensureEncoded(new Uint8ClampedArray(64), 4, 4, c.signal)).rejects.toThrowError(
+        /Aborted/,
+      );
+      // First call wires cb, finally clears it.
+      expect(onSamProgressMock).toHaveBeenCalledTimes(2);
+      expect(onSamProgressMock.mock.calls[1][0]).toBeNull();
+    });
+  });
+
+  describe('decode', () => {
+    it('throws if called before ensureEncoded', async () => {
+      const r = new SamRefiner();
+      await expect(r.decode([{ x: 0, y: 0 }], [1], 4, 4)).rejects.toThrow(/before ensureEncoded/);
+      expect(decodeSamMock).not.toHaveBeenCalled();
+    });
+
+    it('passes args through to decodeSam after encode', async () => {
+      const r = new SamRefiner();
+      await r.ensureEncoded(new Uint8ClampedArray(64), 4, 4, ac().signal);
+
+      const result = await r.decode([{ x: 1, y: 1 }], [2], 4, 4);
+      expect(decodeSamMock).toHaveBeenCalledWith([{ x: 1, y: 1 }], [2], 4, 4);
+      expect(result.mask).toBeInstanceOf(Uint8Array);
+    });
+  });
+
+  describe('invalidate', () => {
+    it('flips isEncoded() back to false so the next ensureEncoded re-runs', async () => {
+      const r = new SamRefiner();
+      await r.ensureEncoded(new Uint8ClampedArray(64), 4, 4, ac().signal);
+      expect(r.isEncoded()).toBe(true);
+
+      r.invalidate();
+      expect(r.isEncoded()).toBe(false);
+
+      await r.ensureEncoded(new Uint8ClampedArray(64), 4, 4, ac().signal);
+      expect(loadSamMock).toHaveBeenCalledTimes(2);
+      expect(encodeSamMock).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe('dispose', () => {
+    it('calls disposeSam and resets isEncoded()', async () => {
+      const r = new SamRefiner();
+      await r.ensureEncoded(new Uint8ClampedArray(64), 4, 4, ac().signal);
+
+      r.dispose();
+      expect(disposeSamMock).toHaveBeenCalledTimes(1);
+      expect(r.isEncoded()).toBe(false);
+    });
+  });
+
+  describe('setProgressCallback', () => {
+    it('replaces the callback used by the next ensureEncoded', async () => {
+      const r = new SamRefiner();
+      const cb = vi.fn();
+      r.setProgressCallback(cb);
+      await r.ensureEncoded(new Uint8ClampedArray(64), 4, 4, ac().signal);
+
+      expect(onSamProgressMock.mock.calls[0][0]).toBe(cb);
+    });
+
+    it('detaches when passed null', async () => {
+      const cb = vi.fn();
+      const r = new SamRefiner(cb);
+      r.setProgressCallback(null);
+      await r.ensureEncoded(new Uint8ClampedArray(64), 4, 4, ac().signal);
+
+      // No progress wiring at all (null detaches before ensureEncoded gates).
+      expect(onSamProgressMock).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/tests/lib/brush-stroke.test.ts
+++ b/tests/lib/brush-stroke.test.ts
@@ -1,0 +1,126 @@
+import { describe, it, expect } from 'vitest';
+import { BrushStroke } from '../../src/lib/brush-stroke';
+
+/**
+ * Behavioural tests for BrushStroke.apply() — the pixel arithmetic
+ * pulled out of ar-editor.ts in #47/Phase-2.
+ *
+ * Strategy: build tiny ImageData buffers with a known initial pattern,
+ * apply a stroke, and assert exact pixel mutations. No DOM, no canvas.
+ */
+
+function makeImage(w: number, h: number, fill: [number, number, number, number]): ImageData {
+  const data = new Uint8ClampedArray(w * h * 4);
+  for (let i = 0; i < w * h; i++) {
+    data[i * 4] = fill[0];
+    data[i * 4 + 1] = fill[1];
+    data[i * 4 + 2] = fill[2];
+    data[i * 4 + 3] = fill[3];
+  }
+  // happy-dom doesn't ship a real ImageData ctor in every version — stub
+  // the minimum surface our code reads.
+  return { data, width: w, height: h, colorSpace: 'srgb' } as ImageData;
+}
+
+function alphaAt(img: ImageData, x: number, y: number): number {
+  return img.data[(y * img.width + x) * 4 + 3];
+}
+
+function rgbaAt(img: ImageData, x: number, y: number): [number, number, number, number] {
+  const i = (y * img.width + x) * 4;
+  return [img.data[i], img.data[i + 1], img.data[i + 2], img.data[i + 3]];
+}
+
+describe('BrushStroke', () => {
+  describe('erase tool', () => {
+    it('zeros alpha inside a square footprint', () => {
+      const img = makeImage(5, 5, [200, 100, 50, 255]);
+      const orig = makeImage(5, 5, [10, 20, 30, 255]); // unused for erase
+      const stroke = new BrushStroke({ cx: 2, cy: 2, tool: 'erase', size: 3, shape: 'square' });
+
+      stroke.apply(img, orig, 5, 5);
+
+      // Center 3x3 cleared (radius=1 → covers cx±1, cy±1)
+      for (let y = 1; y <= 3; y++) {
+        for (let x = 1; x <= 3; x++) {
+          expect(alphaAt(img, x, y)).toBe(0);
+        }
+      }
+      // Corners untouched
+      expect(alphaAt(img, 0, 0)).toBe(255);
+      expect(alphaAt(img, 4, 4)).toBe(255);
+      // RGB preserved (erase only touches alpha)
+      expect(rgbaAt(img, 2, 2)).toEqual([200, 100, 50, 0]);
+    });
+
+    it('clips to circular footprint when shape=circle', () => {
+      // size=3 → r=1 → r²=1. Diagonals (dx²+dy²=2) get skipped.
+      const img = makeImage(5, 5, [255, 255, 255, 255]);
+      const orig = makeImage(5, 5, [0, 0, 0, 0]);
+      const stroke = new BrushStroke({ cx: 2, cy: 2, tool: 'erase', size: 3, shape: 'circle' });
+
+      stroke.apply(img, orig, 5, 5);
+
+      // Cardinal neighbours cleared
+      expect(alphaAt(img, 2, 2)).toBe(0); // center
+      expect(alphaAt(img, 1, 2)).toBe(0);
+      expect(alphaAt(img, 3, 2)).toBe(0);
+      expect(alphaAt(img, 2, 1)).toBe(0);
+      expect(alphaAt(img, 2, 3)).toBe(0);
+      // Diagonal corners preserved
+      expect(alphaAt(img, 1, 1)).toBe(255);
+      expect(alphaAt(img, 3, 3)).toBe(255);
+    });
+
+    it('skips pixels outside image bounds without throwing', () => {
+      const img = makeImage(3, 3, [100, 100, 100, 255]);
+      const orig = makeImage(3, 3, [0, 0, 0, 0]);
+      // Centered at (0,0) with size=5 — half the footprint is OOB.
+      const stroke = new BrushStroke({ cx: 0, cy: 0, tool: 'erase', size: 5, shape: 'square' });
+
+      expect(() => stroke.apply(img, orig, 3, 3)).not.toThrow();
+      // In-bounds pixels in the top-left quadrant were touched.
+      expect(alphaAt(img, 0, 0)).toBe(0);
+      expect(alphaAt(img, 1, 1)).toBe(0);
+      expect(alphaAt(img, 2, 2)).toBe(0);
+    });
+  });
+
+  describe('restore tool', () => {
+    it('copies RGBA from originalImage at every painted pixel', () => {
+      const img = makeImage(5, 5, [0, 0, 0, 0]); // fully erased state
+      const orig = makeImage(5, 5, [220, 110, 55, 200]);
+      const stroke = new BrushStroke({ cx: 2, cy: 2, tool: 'restore', size: 3, shape: 'square' });
+
+      stroke.apply(img, orig, 5, 5);
+
+      expect(rgbaAt(img, 2, 2)).toEqual([220, 110, 55, 200]);
+      expect(rgbaAt(img, 1, 1)).toEqual([220, 110, 55, 200]);
+      expect(rgbaAt(img, 3, 3)).toEqual([220, 110, 55, 200]);
+      // Outside footprint untouched (still erased)
+      expect(rgbaAt(img, 0, 0)).toEqual([0, 0, 0, 0]);
+    });
+
+    it('respects circle shape clipping in restore mode too', () => {
+      const img = makeImage(5, 5, [0, 0, 0, 0]);
+      const orig = makeImage(5, 5, [255, 0, 0, 255]);
+      const stroke = new BrushStroke({ cx: 2, cy: 2, tool: 'restore', size: 3, shape: 'circle' });
+
+      stroke.apply(img, orig, 5, 5);
+
+      expect(rgbaAt(img, 2, 2)).toEqual([255, 0, 0, 255]);
+      expect(rgbaAt(img, 1, 1)).toEqual([0, 0, 0, 0]); // diagonal skipped
+    });
+  });
+
+  describe('immutability', () => {
+    it('exposes config as readonly fields', () => {
+      const stroke = new BrushStroke({ cx: 5, cy: 7, tool: 'erase', size: 10, shape: 'circle' });
+      expect(stroke.cx).toBe(5);
+      expect(stroke.cy).toBe(7);
+      expect(stroke.tool).toBe('erase');
+      expect(stroke.size).toBe(10);
+      expect(stroke.shape).toBe('circle');
+    });
+  });
+});

--- a/tests/lib/history-manager.test.ts
+++ b/tests/lib/history-manager.test.ts
@@ -121,6 +121,44 @@ describe('HistoryManager', () => {
     });
   });
 
+  describe('setMaxEntries', () => {
+    it('trims existing entries when shrinking the cap', () => {
+      const h = new HistoryManager<number>(10);
+      for (let i = 0; i < 8; i++) h.push(i);
+      h.setMaxEntries(3);
+
+      // 8 pushed, cap shrunk to 3 → only [5, 6, 7] should remain
+      const seen: number[] = [];
+      let cur = 99;
+      while (h.canUndo()) {
+        const v = h.undo(cur)!;
+        seen.push(v);
+        cur = v;
+      }
+      expect(seen).toEqual([7, 6, 5]);
+    });
+
+    it('lets future pushes grow up to the new cap', () => {
+      const h = new HistoryManager<number>(2);
+      h.push(1);
+      h.push(2);
+      h.setMaxEntries(5);
+      h.push(3);
+      h.push(4);
+      h.push(5);
+
+      // 5 entries, cap 5 → all preserved
+      const seen: number[] = [];
+      let cur = 99;
+      while (h.canUndo()) {
+        const v = h.undo(cur)!;
+        seen.push(v);
+        cur = v;
+      }
+      expect(seen).toEqual([5, 4, 3, 2, 1]);
+    });
+  });
+
   describe('works with non-trivial state types', () => {
     it('handles Uint8ClampedArray snapshots without issue', () => {
       const h = new HistoryManager<Uint8ClampedArray>();

--- a/tests/lib/history-manager.test.ts
+++ b/tests/lib/history-manager.test.ts
@@ -1,0 +1,137 @@
+import { describe, it, expect } from 'vitest';
+import { HistoryManager } from '../../src/lib/history-manager';
+
+/**
+ * Behavioural tests for the generic undo/redo manager extracted from
+ * ar-editor.ts in #47/Phase-2.
+ */
+describe('HistoryManager', () => {
+  describe('push + undo/redo round-trip', () => {
+    it('returns the most recent push on undo', () => {
+      const h = new HistoryManager<string>();
+      h.push('a');
+      h.push('b');
+      h.push('c');
+
+      expect(h.undo('current')).toBe('c');
+      expect(h.undo('c-was-current')).toBe('b');
+      expect(h.undo('b-was-current')).toBe('a');
+    });
+
+    it('moves current state onto redo stack during undo', () => {
+      const h = new HistoryManager<string>();
+      h.push('a');
+      h.undo('current'); // current goes to redo stack
+      expect(h.canRedo()).toBe(true);
+      expect(h.redo('a')).toBe('current');
+    });
+
+    it('round-trips undo → redo with state preserved', () => {
+      const h = new HistoryManager<number>();
+      h.push(1);
+      h.push(2);
+      const undone = h.undo(3);
+      expect(undone).toBe(2);
+      const redone = h.redo(undone!);
+      expect(redone).toBe(3);
+    });
+
+    it('returns null when stacks are empty', () => {
+      const h = new HistoryManager<string>();
+      expect(h.undo('x')).toBeNull();
+      expect(h.redo('x')).toBeNull();
+    });
+  });
+
+  describe('redo invalidation', () => {
+    it('clears the redo stack when push is called after undo', () => {
+      const h = new HistoryManager<string>();
+      h.push('a');
+      h.push('b');
+      h.undo('current');
+      expect(h.canRedo()).toBe(true);
+
+      h.push('new-branch');
+      expect(h.canRedo()).toBe(false);
+    });
+  });
+
+  describe('cap policy', () => {
+    it('drops the oldest entry when maxEntries is exceeded', () => {
+      const h = new HistoryManager<string>(3);
+      h.push('a');
+      h.push('b');
+      h.push('c');
+      h.push('d'); // evicts 'a'
+
+      // Walk back as far as we can
+      expect(h.undo('current')).toBe('d');
+      expect(h.undo('d')).toBe('c');
+      expect(h.undo('c')).toBe('b');
+      // 'a' was evicted, no more entries
+      expect(h.undo('b')).toBeNull();
+    });
+
+    it('uses default cap of 12 when not specified', () => {
+      const h = new HistoryManager<number>();
+      for (let i = 0; i < 15; i++) h.push(i);
+
+      // 15 pushed, cap 12 → entries [3..14] should remain
+      const seen: number[] = [];
+      let cur = 99;
+      while (h.canUndo()) {
+        const v = h.undo(cur);
+        if (v !== null) {
+          seen.push(v);
+          cur = v;
+        }
+      }
+      expect(seen).toEqual([14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3]);
+    });
+  });
+
+  describe('canUndo / canRedo', () => {
+    it('reports false on a fresh manager', () => {
+      const h = new HistoryManager();
+      expect(h.canUndo()).toBe(false);
+      expect(h.canRedo()).toBe(false);
+    });
+
+    it('flips true after push', () => {
+      const h = new HistoryManager<number>();
+      h.push(1);
+      expect(h.canUndo()).toBe(true);
+      expect(h.canRedo()).toBe(false);
+    });
+  });
+
+  describe('clear', () => {
+    it('wipes both stacks', () => {
+      const h = new HistoryManager<string>();
+      h.push('a');
+      h.push('b');
+      h.undo('current');
+
+      h.clear();
+
+      expect(h.canUndo()).toBe(false);
+      expect(h.canRedo()).toBe(false);
+      expect(h.undo('x')).toBeNull();
+      expect(h.redo('x')).toBeNull();
+    });
+  });
+
+  describe('works with non-trivial state types', () => {
+    it('handles Uint8ClampedArray snapshots without issue', () => {
+      const h = new HistoryManager<Uint8ClampedArray>();
+      const a = new Uint8ClampedArray([1, 2, 3, 4]);
+      const b = new Uint8ClampedArray([5, 6, 7, 8]);
+      h.push(a);
+      h.push(b);
+
+      const cur = new Uint8ClampedArray([9, 9, 9, 9]);
+      const undone = h.undo(cur);
+      expect(undone).toBe(b); // identity preserved (no clone)
+    });
+  });
+});

--- a/tests/lib/lasso-model.test.ts
+++ b/tests/lib/lasso-model.test.ts
@@ -1,0 +1,266 @@
+import { describe, it, expect } from 'vitest';
+import { LassoModel } from '../../src/lib/lasso-model';
+
+/**
+ * Behavioural tests for the LassoModel state machine extracted from
+ * ar-editor-advanced.ts in #47/Phase-3a.
+ */
+describe('LassoModel', () => {
+  describe('lifecycle: empty → drawing → closed → empty', () => {
+    it('starts empty', () => {
+      const m = new LassoModel();
+      expect(m.isEmpty()).toBe(true);
+      expect(m.isClosed()).toBe(false);
+      expect(m.getRawPath()).toBeNull();
+      expect(m.getAnchors()).toBeNull();
+    });
+
+    it('startAt seeds a single-point raw path', () => {
+      const m = new LassoModel();
+      m.startAt({ x: 10, y: 20 });
+      expect(m.isEmpty()).toBe(false);
+      expect(m.isClosed()).toBe(false);
+      expect(m.getRawPath()).toEqual([{ x: 10, y: 20 }]);
+    });
+
+    it('startAt wipes any prior closed lasso', () => {
+      const m = new LassoModel(0.5);
+      // Build a triangle (>= MIN_ANCHORS) and close.
+      m.startAt({ x: 0, y: 0 });
+      m.addRawPoint({ x: 100, y: 0 });
+      m.addRawPoint({ x: 50, y: 100 });
+      m.close();
+      expect(m.isClosed()).toBe(true);
+
+      m.startAt({ x: 5, y: 5 });
+      expect(m.isClosed()).toBe(false);
+      expect(m.getRawPath()).toEqual([{ x: 5, y: 5 }]);
+    });
+
+    it('addRawPoint respects min-distance gate', () => {
+      const m = new LassoModel();
+      m.startAt({ x: 0, y: 0 });
+      m.addRawPoint({ x: 1, y: 0 }); // distSq=1 < 4 → skipped
+      m.addRawPoint({ x: 5, y: 0 }); // distSq=25 ≥ 4 → kept
+      expect(m.getRawPath()).toEqual([
+        { x: 0, y: 0 },
+        { x: 5, y: 0 },
+      ]);
+    });
+
+    it('addRawPoint is a noop when no raw path is active', () => {
+      const m = new LassoModel();
+      m.addRawPoint({ x: 1, y: 1 });
+      expect(m.getRawPath()).toBeNull();
+    });
+  });
+
+  describe('close(): simplification', () => {
+    it('returns 0 and clears state if too few unique points', () => {
+      const m = new LassoModel(0.5);
+      m.startAt({ x: 0, y: 0 });
+      m.addRawPoint({ x: 10, y: 0 });
+      // Only 2 anchors → below MIN_ANCHORS=3 even before simplification.
+      const count = m.close();
+      expect(count).toBe(0);
+      expect(m.isClosed()).toBe(false);
+      expect(m.getRawPath()).toBeNull();
+    });
+
+    it('reduces a near-collinear path to a low-vertex polygon', () => {
+      const m = new LassoModel(2.0);
+      // Walk a noisy "square" — 16 points, but the simplifier should
+      // reduce to roughly the 4 corners.
+      m.startAt({ x: 0, y: 0 });
+      for (let i = 1; i <= 4; i++) m.addRawPoint({ x: i * 25, y: 0 });
+      for (let i = 1; i <= 4; i++) m.addRawPoint({ x: 100, y: i * 25 });
+      for (let i = 1; i <= 4; i++) m.addRawPoint({ x: 100 - i * 25, y: 100 });
+      for (let i = 1; i <= 3; i++) m.addRawPoint({ x: 0, y: 100 - i * 25 });
+
+      const count = m.close();
+      expect(count).toBeGreaterThanOrEqual(3);
+      expect(count).toBeLessThan(16);
+      expect(m.isClosed()).toBe(true);
+      expect(m.getAnchors()).toHaveLength(count);
+    });
+  });
+
+  describe('drag flow', () => {
+    function buildSquare(): LassoModel {
+      const m = new LassoModel(0.5);
+      m.startAt({ x: 0, y: 0 });
+      m.addRawPoint({ x: 100, y: 0 });
+      m.addRawPoint({ x: 100, y: 100 });
+      m.addRawPoint({ x: 0, y: 100 });
+      m.close();
+      return m;
+    }
+
+    it('beginDragAnchor sets the index and ignores out-of-range', () => {
+      const m = buildSquare();
+      m.beginDragAnchor(2);
+      expect(m.getDragAnchorIndex()).toBe(2);
+
+      // Out-of-range is ignored, leaves prior index intact.
+      m.beginDragAnchor(99);
+      expect(m.getDragAnchorIndex()).toBe(2);
+    });
+
+    it('endDragAnchor clears the index', () => {
+      const m = buildSquare();
+      m.beginDragAnchor(0);
+      m.endDragAnchor();
+      expect(m.getDragAnchorIndex()).toBeNull();
+    });
+
+    it('moveAnchor updates anchor coords', () => {
+      const m = buildSquare();
+      m.moveAnchor(0, { x: -5, y: -5 });
+      expect(m.getAnchors()![0]).toEqual({ x: -5, y: -5 });
+    });
+
+    it('moveAnchor is a noop on closed=false or out-of-range', () => {
+      const open = new LassoModel();
+      open.moveAnchor(0, { x: 1, y: 1 }); // no anchors → noop
+      expect(open.getAnchors()).toBeNull();
+
+      const m = buildSquare();
+      const before = JSON.stringify(m.getAnchors());
+      m.moveAnchor(99, { x: 1, y: 1 });
+      expect(JSON.stringify(m.getAnchors())).toBe(before);
+    });
+  });
+
+  describe('removeAnchor', () => {
+    it('removes when above the minimum count', () => {
+      const m = new LassoModel(0.5);
+      m.startAt({ x: 0, y: 0 });
+      m.addRawPoint({ x: 100, y: 0 });
+      m.addRawPoint({ x: 100, y: 100 });
+      m.addRawPoint({ x: 50, y: 50 });
+      m.addRawPoint({ x: 0, y: 100 });
+      m.close();
+      const before = m.getAnchors()!.length;
+      const ok = m.removeAnchor(2);
+      expect(ok).toBe(true);
+      expect(m.getAnchors()!.length).toBe(before - 1);
+    });
+
+    it('refuses when at MIN_ANCHORS exactly', () => {
+      const m = new LassoModel(0.5);
+      m.startAt({ x: 0, y: 0 });
+      m.addRawPoint({ x: 100, y: 0 });
+      m.addRawPoint({ x: 50, y: 100 });
+      m.close();
+      expect(m.getAnchors()!.length).toBe(3);
+      expect(m.removeAnchor(1)).toBe(false);
+      expect(m.getAnchors()!.length).toBe(3);
+    });
+  });
+
+  describe('hitAnchor', () => {
+    function square(): LassoModel {
+      const m = new LassoModel(0.5);
+      m.startAt({ x: 0, y: 0 });
+      m.addRawPoint({ x: 100, y: 0 });
+      m.addRawPoint({ x: 100, y: 100 });
+      m.addRawPoint({ x: 0, y: 100 });
+      m.close();
+      return m;
+    }
+
+    it('returns null when no anchor is within tolerance', () => {
+      const m = square();
+      expect(m.hitAnchor(50, 50, 5)).toBeNull();
+    });
+
+    it('returns the closest anchor index within tolerance', () => {
+      const m = square();
+      // (102, 1) is 2.236 from (100,0) and 99 from the next corner — pick 1.
+      expect(m.hitAnchor(102, 1, 5)).toBe(1);
+    });
+
+    it('returns null on an empty lasso', () => {
+      const m = new LassoModel();
+      expect(m.hitAnchor(0, 0, 100)).toBeNull();
+    });
+  });
+
+  describe('getBoundingBox', () => {
+    it('returns null when not closed', () => {
+      const m = new LassoModel();
+      expect(m.getBoundingBox()).toBeNull();
+    });
+
+    it('returns the AABB of the closed polygon', () => {
+      const m = new LassoModel(0.5);
+      m.startAt({ x: 10, y: 20 });
+      m.addRawPoint({ x: 110, y: 20 });
+      m.addRawPoint({ x: 110, y: 80 });
+      m.addRawPoint({ x: 10, y: 80 });
+      m.close();
+      expect(m.getBoundingBox()).toEqual({ x: 10, y: 20, w: 100, h: 60 });
+    });
+  });
+
+  describe('containsPoint', () => {
+    function square(): LassoModel {
+      const m = new LassoModel(0.5);
+      m.startAt({ x: 0, y: 0 });
+      m.addRawPoint({ x: 100, y: 0 });
+      m.addRawPoint({ x: 100, y: 100 });
+      m.addRawPoint({ x: 0, y: 100 });
+      m.close();
+      return m;
+    }
+
+    it('returns true for an interior point', () => {
+      expect(square().containsPoint({ x: 50, y: 50 })).toBe(true);
+    });
+
+    it('returns false for an exterior point', () => {
+      expect(square().containsPoint({ x: 200, y: 50 })).toBe(false);
+    });
+
+    it('returns false on an empty lasso', () => {
+      expect(new LassoModel().containsPoint({ x: 0, y: 0 })).toBe(false);
+    });
+  });
+
+  describe('clear', () => {
+    it('wipes all state', () => {
+      const m = new LassoModel(0.5);
+      m.startAt({ x: 0, y: 0 });
+      m.addRawPoint({ x: 100, y: 0 });
+      m.addRawPoint({ x: 50, y: 100 });
+      m.close();
+      m.beginDragAnchor(0);
+
+      m.clear();
+      expect(m.isEmpty()).toBe(true);
+      expect(m.isClosed()).toBe(false);
+      expect(m.getDragAnchorIndex()).toBeNull();
+    });
+  });
+
+  describe('setSimplifyEpsilon', () => {
+    it('influences a subsequent close()', () => {
+      // Same path simplified at two different tolerances should yield
+      // different anchor counts.
+      function pathInto(m: LassoModel) {
+        m.startAt({ x: 0, y: 0 });
+        for (let i = 1; i <= 9; i++) m.addRawPoint({ x: i * 10, y: i * 0.4 });
+        m.addRawPoint({ x: 100, y: 100 });
+        m.addRawPoint({ x: 0, y: 100 });
+      }
+      const tight = new LassoModel(0.5);
+      pathInto(tight);
+      tight.close();
+      const loose = new LassoModel(0.5);
+      pathInto(loose);
+      loose.setSimplifyEpsilon(20);
+      loose.close();
+      expect(loose.getAnchors()?.length ?? 0).toBeLessThanOrEqual(tight.getAnchors()?.length ?? 0);
+    });
+  });
+});

--- a/tests/utils/image-io.test.ts
+++ b/tests/utils/image-io.test.ts
@@ -9,8 +9,10 @@ const PNG_MAGIC = new Uint8Array([
 const JPEG_MAGIC = new Uint8Array([
   0xff, 0xd8, 0xff, 0xe0, 0x00, 0x10, 0x4a, 0x46, 0x49, 0x46, 0x00, 0x01,
 ]);
+// Size field (bytes 4-7, LE uint32) must equal file.size - 8 — for the
+// 12-byte stub below that's 4 (#189).
 const WEBP_MAGIC = new Uint8Array([
-  0x52, 0x49, 0x46, 0x46, 0x00, 0x00, 0x00, 0x00, 0x57, 0x45, 0x42, 0x50,
+  0x52, 0x49, 0x46, 0x46, 0x04, 0x00, 0x00, 0x00, 0x57, 0x45, 0x42, 0x50,
 ]);
 
 function fileFrom(bytes: Uint8Array, name: string, type: string): File {
@@ -52,5 +54,36 @@ describe('loadImage magic-byte sniffing', () => {
   it('passes the magic-byte gate for a valid WebP header', async () => {
     const webpStub = fileFrom(WEBP_MAGIC, 'img.webp', 'image/webp');
     await expect(loadImage(webpStub)).rejects.not.toThrow(/does not match|not a valid/i);
+  });
+
+  describe('WebP RIFF size validation (#189)', () => {
+    it('rejects a WebP whose declared RIFF size does not match file length', async () => {
+      // Magic bytes valid, but declaredSize=999 + 8 ≠ 12. Sniff should fail.
+      const bogus = new Uint8Array([
+        0x52,
+        0x49,
+        0x46,
+        0x46,
+        0xe7,
+        0x03,
+        0x00,
+        0x00, // 999 little-endian
+        0x57,
+        0x45,
+        0x42,
+        0x50,
+      ]);
+      const file = fileFrom(bogus, 'polyglot.webp', 'image/webp');
+      await expect(loadImage(file)).rejects.toThrow(/not a valid PNG, JPG, or WebP/i);
+    });
+
+    it('rejects a WebP whose declared RIFF size is zero', async () => {
+      // Common malformed pattern: encoder writes 0 instead of file.size - 8.
+      const bogus = new Uint8Array([
+        0x52, 0x49, 0x46, 0x46, 0x00, 0x00, 0x00, 0x00, 0x57, 0x45, 0x42, 0x50,
+      ]);
+      const file = fileFrom(bogus, 'zerosize.webp', 'image/webp');
+      await expect(loadImage(file)).rejects.toThrow(/not a valid PNG, JPG, or WebP/i);
+    });
   });
 });

--- a/tests/utils/reactor-economics.test.ts
+++ b/tests/utils/reactor-economics.test.ts
@@ -8,8 +8,53 @@ import {
   computeRuntime,
   formatRuntime,
   donationToRuntimeDelta,
+  isDonorsFile,
   type DonorsFile,
 } from '../../src/utils/reactor-economics';
+
+describe('reactor-economics — isDonorsFile (#188)', () => {
+  const valid: DonorsFile = {
+    version: 1,
+    updated_at: '2026-04-28',
+    supporters: [{ name: 'Alice', amount_eur: 25, date: '2026-04-01', consent: 'explicit' }],
+    anonymous_count: 3,
+    anonymous_total_eur: 9,
+  };
+
+  it('accepts a fully-formed file', () => {
+    expect(isDonorsFile(valid)).toBe(true);
+  });
+
+  it('accepts an empty supporters array', () => {
+    expect(isDonorsFile({ ...valid, supporters: [] })).toBe(true);
+  });
+
+  it.each([null, undefined, 42, 'string', []])('rejects non-object payload (%p)', (v) => {
+    expect(isDonorsFile(v)).toBe(false);
+  });
+
+  it.each([
+    ['missing version', { ...valid, version: undefined }],
+    ['wrong version sentinel', { ...valid, version: 2 }],
+    ['missing updated_at', { ...valid, updated_at: undefined }],
+    ['updated_at not a string', { ...valid, updated_at: 12345 }],
+    ['anonymous_count not a number', { ...valid, anonymous_count: '3' }],
+    ['anonymous_total_eur not a number', { ...valid, anonymous_total_eur: null }],
+    ['supporters not an array', { ...valid, supporters: 'oops' }],
+  ])('rejects payload with %s', (_label, payload) => {
+    expect(isDonorsFile(payload)).toBe(false);
+  });
+
+  it.each([
+    ['missing name', [{ amount_eur: 1, date: 'x', consent: 'explicit' }]],
+    ['amount_eur not a number', [{ name: 'A', amount_eur: '1', date: 'x', consent: 'explicit' }]],
+    ['date not a string', [{ name: 'A', amount_eur: 1, date: 0, consent: 'explicit' }]],
+    ['consent not "explicit"', [{ name: 'A', amount_eur: 1, date: 'x', consent: 'maybe' }]],
+    ['supporter is not an object', [42]],
+  ])('rejects malformed supporter entry (%s)', (_label, supporters) => {
+    expect(isDonorsFile({ ...valid, supporters })).toBe(false);
+  });
+});
 
 describe('reactor-economics — constants', () => {
   it('TIME_BREAKDOWN percents sum to 100', () => {

--- a/tests/workers/cv/clamp.test.ts
+++ b/tests/workers/cv/clamp.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect } from 'vitest';
+import { clamp255 } from '../../../src/workers/cv/clamp';
+
+describe('clamp255 (#194)', () => {
+  it('passes integers in range through unchanged', () => {
+    expect(clamp255(0)).toBe(0);
+    expect(clamp255(128)).toBe(128);
+    expect(clamp255(255)).toBe(255);
+  });
+
+  it('rounds floats to nearest integer', () => {
+    expect(clamp255(127.4)).toBe(127);
+    expect(clamp255(127.6)).toBe(128);
+    expect(clamp255(0.4)).toBe(0);
+    expect(clamp255(0.6)).toBe(1);
+  });
+
+  it('clamps below 0 to 0', () => {
+    expect(clamp255(-1)).toBe(0);
+    expect(clamp255(-1000)).toBe(0);
+    expect(clamp255(-Infinity)).toBe(0);
+  });
+
+  it('clamps above 255 to 255', () => {
+    expect(clamp255(256)).toBe(255);
+    expect(clamp255(1000)).toBe(255);
+    expect(clamp255(Infinity)).toBe(255);
+  });
+
+  it('returns 0 for NaN (defensive — upstream math should not produce NaN)', () => {
+    expect(clamp255(NaN)).toBe(0);
+  });
+});


### PR DESCRIPTION
Ships v2.10.0 to production. 17 commits (15 from this work session + 2 pre-session: capability-detector consistency fix + reactor removal-notice drop).

## Highlights

- **Bundle shrinks despite the refactor.** \`index.js\` 466.91 kB → **465.19 kB** raw (−1.72 kB / −0.37%); gzip 125.66 → 125.60 kB (essentially flat). Net of split + cleanups was bundle-positive thanks to the i18n key prune.
- **Audit cleanup complete.** All 4 medium-priority issues from the 2026-04-28 audit are closed: amber AA contrast (#185), focus-visible shadow DOM (#186), worker e.origin guards (#187), donors.json schema validation (#188). Plus #189 (WebP sniff) and #194 (clamp helper). #190 was already implemented as a vitest test.
- **Internal architecture: monolith split.** \`ar-app.ts\` 2178 → 1969 LOC across two phases. \`ar-editor.ts\` and \`ar-editor-advanced.ts\` got their lasso, history, brush stroke, SAM lifecycle pulled into pure modules under \`src/lib/\` and \`src/controllers/\`. 6 new modules, 80 new tests. Tracked in #47.
- **CI hardening.** Dependabot patch+minor PRs auto-merge once CI is green (#191). OSV-Scanner runs alongside \`npm audit\` and CodeQL (#192).

## Validation gates

| Gate | Result |
|------|--------|
| \`npm run typecheck\` | ✅ green |
| \`npm test\` | ✅ **914/914** |
| \`npm run build\` | ✅ green |

## Risk

Internal-only refactor. Public event surface (\`ar:*\`, \`batch:*\` custom events) is unchanged. Manual smoke recommended before merge:

- [ ] Drop a single image — basic flow runs end-to-end.
- [ ] Drop multiple images — batch grid + detail view + ZIP download.
- [ ] Advanced editor — lasso draw + drag anchors + SAM refine + undo/redo.
- [ ] Editor canvases show focus ring on Tab.
- [ ] Switch to amber theme — tertiary text legible.

## Roll-back

\`git revert\` this merge commit, OR \`git reset --hard\` to the v2.9.5 commit on main. The refactor is internal, so a rollback is symmetric.

## CHANGELOG

See full entry on dev: https://github.com/yocreoquesi/nukebg/blob/dev/CHANGELOG.md#2100--2026-04-28