### PR TITLE
test(cv): unit coverage for watermark-dalle + inpaint-telea (#195)

### DIFF
--- a/tests/workers/cv/inpaint-telea.test.ts
+++ b/tests/workers/cv/inpaint-telea.test.ts
@@ -1,0 +1,195 @@
+import { describe, it, expect } from 'vitest';
+import { inpaintTelea } from '../../../src/workers/cv/inpaint-telea';
+
+/**
+ * Behavioural tests for inpaintTelea (#195).
+ *
+ * Telea's Fast Marching Method is propagation-order dependent, so we
+ * assert structural invariants (output bounds, mask-only mutation,
+ * within-source value range) rather than trying to hand-compute the
+ * exact reconstructed RGBA.
+ */
+
+function solidImage(w: number, h: number, rgb: [number, number, number]): Uint8ClampedArray {
+  const out = new Uint8ClampedArray(w * h * 4);
+  for (let i = 0; i < w * h; i++) {
+    out[i * 4] = rgb[0];
+    out[i * 4 + 1] = rgb[1];
+    out[i * 4 + 2] = rgb[2];
+    out[i * 4 + 3] = 255;
+  }
+  return out;
+}
+
+function rgbAt(
+  px: Uint8ClampedArray,
+  x: number,
+  y: number,
+  w: number,
+): [number, number, number, number] {
+  const i = (y * w + x) * 4;
+  return [px[i], px[i + 1], px[i + 2], px[i + 3]];
+}
+
+describe('inpaintTelea', () => {
+  describe('basic invariants', () => {
+    it('returns a buffer of the same length as input', () => {
+      const w = 16;
+      const h = 16;
+      const px = solidImage(w, h, [100, 50, 200]);
+      const mask = new Uint8Array(w * h);
+      mask[8 * w + 8] = 1;
+
+      const out = inpaintTelea(px, w, h, mask);
+      expect(out.length).toBe(px.length);
+    });
+
+    it('returns input unchanged when mask is all zeros', () => {
+      const w = 16;
+      const h = 16;
+      const px = solidImage(w, h, [42, 99, 200]);
+      const mask = new Uint8Array(w * h);
+      const out = inpaintTelea(px, w, h, mask);
+      // Pixel-for-pixel equality (no mask = no work)
+      for (let i = 0; i < px.length; i++) {
+        expect(out[i]).toBe(px[i]);
+      }
+    });
+
+    it('does not mutate pixels outside the mask', () => {
+      const w = 20;
+      const h = 20;
+      const px = solidImage(w, h, [200, 100, 50]);
+      const mask = new Uint8Array(w * h);
+      // 3x3 mask in the middle
+      for (let dy = -1; dy <= 1; dy++) {
+        for (let dx = -1; dx <= 1; dx++) {
+          mask[(10 + dy) * w + (10 + dx)] = 1;
+        }
+      }
+      const out = inpaintTelea(px, w, h, mask);
+      // Far corner unchanged
+      expect(rgbAt(out, 0, 0, w)).toEqual([200, 100, 50, 255]);
+      expect(rgbAt(out, w - 1, h - 1, w)).toEqual([200, 100, 50, 255]);
+      // Pixel adjacent to but outside mask unchanged
+      expect(rgbAt(out, 10, 7, w)).toEqual([200, 100, 50, 255]);
+    });
+
+    it('writes alpha=255 inside the mask region', () => {
+      const w = 16;
+      const h = 16;
+      const px = solidImage(w, h, [128, 128, 128]);
+      // Drop alpha to 100 outside (Telea promises opaque output INSIDE
+      // the mask only — outside is preserved verbatim).
+      for (let i = 0; i < w * h; i++) px[i * 4 + 3] = 100;
+      const mask = new Uint8Array(w * h);
+      mask[8 * w + 8] = 1;
+
+      const out = inpaintTelea(px, w, h, mask);
+      // Inside mask: alpha forced to 255
+      expect(out[(8 * w + 8) * 4 + 3]).toBe(255);
+      // Outside mask: alpha preserved (100, not 255)
+      expect(out[(0 * w + 0) * 4 + 3]).toBe(100);
+    });
+  });
+
+  describe('reconstruction bounds', () => {
+    it('reconstructs masked pixels within the [min, max] of source RGB', () => {
+      // Solid 100/50/200 background with a 3x3 hole. Reconstruction
+      // should produce values in [100, 100] / [50, 50] / [200, 200] —
+      // i.e., reproduce the surrounding solid color (or stay within it).
+      const w = 16;
+      const h = 16;
+      const px = solidImage(w, h, [100, 50, 200]);
+      const mask = new Uint8Array(w * h);
+      for (let dy = -1; dy <= 1; dy++) {
+        for (let dx = -1; dx <= 1; dx++) {
+          mask[(8 + dy) * w + (8 + dx)] = 1;
+        }
+      }
+      const out = inpaintTelea(px, w, h, mask);
+      // Every masked pixel should land at exactly (100, 50, 200) since
+      // every neighbor is the same color. Tight invariant.
+      for (let dy = -1; dy <= 1; dy++) {
+        for (let dx = -1; dx <= 1; dx++) {
+          const [r, g, b, a] = rgbAt(out, 8 + dx, 8 + dy, w);
+          expect(r).toBe(100);
+          expect(g).toBe(50);
+          expect(b).toBe(200);
+          expect(a).toBe(255);
+        }
+      }
+    });
+
+    it('keeps reconstructed RGB inside source RGB envelope on a 2-color split', () => {
+      // Left half red, right half blue, with a vertical-line hole down
+      // the middle. Reconstruction must yield colors in [red, blue]
+      // envelope per channel — never extrapolate outside.
+      const w = 20;
+      const h = 16;
+      const px = new Uint8ClampedArray(w * h * 4);
+      for (let y = 0; y < h; y++) {
+        for (let x = 0; x < w; x++) {
+          const i = (y * w + x) * 4;
+          const isLeft = x < w / 2;
+          px[i] = isLeft ? 200 : 0;
+          px[i + 1] = 0;
+          px[i + 2] = isLeft ? 0 : 200;
+          px[i + 3] = 255;
+        }
+      }
+      const mask = new Uint8Array(w * h);
+      const xMid = Math.floor(w / 2);
+      for (let y = 4; y < h - 4; y++) mask[y * w + xMid] = 1;
+
+      const out = inpaintTelea(px, w, h, mask);
+      for (let y = 4; y < h - 4; y++) {
+        const [r, g, b] = rgbAt(out, xMid, y, w);
+        expect(r).toBeGreaterThanOrEqual(0);
+        expect(r).toBeLessThanOrEqual(200);
+        expect(g).toBe(0); // both sides have G=0; reconstruction must not invent
+        expect(b).toBeGreaterThanOrEqual(0);
+        expect(b).toBeLessThanOrEqual(200);
+      }
+    });
+  });
+
+  describe('robustness', () => {
+    it('honors a custom radius without throwing', () => {
+      const w = 16;
+      const h = 16;
+      const px = solidImage(w, h, [50, 50, 50]);
+      const mask = new Uint8Array(w * h);
+      mask[8 * w + 8] = 1;
+      expect(() => inpaintTelea(px, w, h, mask, 3)).not.toThrow();
+      expect(() => inpaintTelea(px, w, h, mask, 9)).not.toThrow();
+    });
+
+    it('survives a mask covering > 50% of the canvas (slow but should not infinite-loop)', () => {
+      const w = 16;
+      const h = 16;
+      const px = solidImage(w, h, [128, 64, 192]);
+      const mask = new Uint8Array(w * h);
+      // Mask everything except the outer 2-pixel ring
+      for (let y = 2; y < h - 2; y++) {
+        for (let x = 2; x < w - 2; x++) {
+          mask[y * w + x] = 1;
+        }
+      }
+      const before = Date.now();
+      const out = inpaintTelea(px, w, h, mask);
+      const elapsed = Date.now() - before;
+      expect(elapsed).toBeLessThan(5000);
+      // The masked center is in a ring of solid 128/64/192 — should
+      // reconstruct very close to that color.
+      const [r, g, b, a] = rgbAt(out, 8, 8, w);
+      expect(r).toBeGreaterThanOrEqual(120);
+      expect(r).toBeLessThanOrEqual(136);
+      expect(g).toBeGreaterThanOrEqual(56);
+      expect(g).toBeLessThanOrEqual(72);
+      expect(b).toBeGreaterThanOrEqual(184);
+      expect(b).toBeLessThanOrEqual(200);
+      expect(a).toBe(255);
+    });
+  });
+});

--- a/tests/workers/cv/watermark-dalle.test.ts
+++ b/tests/workers/cv/watermark-dalle.test.ts
@@ -1,0 +1,138 @@
+import { describe, it, expect } from 'vitest';
+import { watermarkDetectDalle } from '../../../src/workers/cv/watermark-dalle';
+import { DALLE_WATERMARK_PARAMS } from '../../../src/pipeline/constants';
+
+/**
+ * Behavioural tests for watermarkDetectDalle (#195).
+ *
+ * The detector scans the bottom-right corner for a horizontal stripe with
+ * high color variance — the multicolor DALL-E 3 signature bar. Tests
+ * cover the four gates the algorithm uses:
+ *   1. minUniqueColors  — at least N quantized colors per scan row
+ *   2. contrastThreshold — bar row has > 2× more colors than reference row
+ *   3. minChannelSpread — bar row has > 200 R+G+B range
+ *   4. mask geometry — covers detected band + MASK_MARGIN pixels
+ */
+
+const W = 300;
+const H = 40;
+
+function blankImage(rgb: [number, number, number] = [255, 255, 255]): Uint8ClampedArray {
+  const out = new Uint8ClampedArray(W * H * 4);
+  for (let i = 0; i < W * H; i++) {
+    out[i * 4] = rgb[0];
+    out[i * 4 + 1] = rgb[1];
+    out[i * 4 + 2] = rgb[2];
+    out[i * 4 + 3] = 255;
+  }
+  return out;
+}
+
+/** Paint a horizontal multicolor stripe across rows [yStart, yEnd] in the
+ *  rightmost 100 px (>= scanW for W=300). Uses 16 distinct hues so the
+ *  quantized-color count clears MIN_UNIQUE_COLORS=15 with margin, and
+ *  spans full RGB range so MIN_CHANNEL_SPREAD=200 is satisfied. */
+function paintWatermarkStripe(pixels: Uint8ClampedArray, yStart: number, yEnd: number): void {
+  const xStart = W - 100;
+  for (let y = yStart; y <= yEnd; y++) {
+    for (let x = xStart; x < W; x++) {
+      const i = (y * W + x) * 4;
+      // Cycle through 16 distinct hues by stepping x in groups.
+      const hueIdx = ((x - xStart) >> 2) & 0x0f;
+      pixels[i] = (hueIdx * 17) & 0xff; // 0, 17, 34, ..., 255
+      pixels[i + 1] = (hueIdx * 23 + 50) & 0xff;
+      pixels[i + 2] = (hueIdx * 31 + 100) & 0xff;
+      pixels[i + 3] = 255;
+    }
+  }
+}
+
+describe('watermarkDetectDalle', () => {
+  it('returns detected=false on a solid-color image', () => {
+    const out = watermarkDetectDalle(blankImage([200, 100, 50]), W, H);
+    expect(out.detected).toBe(false);
+    expect(out.mask).toBeNull();
+  });
+
+  it('returns detected=false on a low-variance grayscale gradient', () => {
+    // Smooth horizontal gradient: 256 distinct values total but quantized
+    // to 16 brightness levels — well below MIN_UNIQUE_COLORS=15 *across
+    // RGB combinations* in any 100-px slice (gradient is monotonic).
+    const px = new Uint8ClampedArray(W * H * 4);
+    for (let y = 0; y < H; y++) {
+      for (let x = 0; x < W; x++) {
+        const v = Math.floor((x / W) * 255);
+        const i = (y * W + x) * 4;
+        px[i] = v;
+        px[i + 1] = v;
+        px[i + 2] = v;
+        px[i + 3] = 255;
+      }
+    }
+    const out = watermarkDetectDalle(px, W, H);
+    expect(out.detected).toBe(false);
+    expect(out.mask).toBeNull();
+  });
+
+  it('detects a synthetic multicolor stripe in the bottom-right band', () => {
+    const px = blankImage([255, 255, 255]);
+    const yStart = H - DALLE_WATERMARK_PARAMS.SCAN_HEIGHT;
+    const yEnd = H - 1;
+    paintWatermarkStripe(px, yStart, yEnd);
+
+    const out = watermarkDetectDalle(px, W, H);
+    expect(out.detected).toBe(true);
+    expect(out.mask).not.toBeNull();
+    expect(out.centerX).toBeGreaterThan(W / 2);
+    expect(out.centerY).toBeGreaterThan(H - DALLE_WATERMARK_PARAMS.SCAN_HEIGHT - 1);
+  });
+
+  it('mask covers the detected band plus MASK_MARGIN on each side', () => {
+    const px = blankImage([255, 255, 255]);
+    const yStart = H - DALLE_WATERMARK_PARAMS.SCAN_HEIGHT;
+    const yEnd = H - 1;
+    paintWatermarkStripe(px, yStart, yEnd);
+
+    const out = watermarkDetectDalle(px, W, H);
+    expect(out.detected).toBe(true);
+    const mask = out.mask!;
+    const margin = DALLE_WATERMARK_PARAMS.MASK_MARGIN;
+    // Top edge: pixel at (xCenter, yStart - margin) should be in mask.
+    const xCenter = out.centerX!;
+    expect(mask[(yStart - margin) * W + xCenter]).toBe(1);
+    // Bottom edge: last row inside the image is in the mask.
+    expect(mask[(H - 1) * W + xCenter]).toBe(1);
+    // Outside the mask region: a pixel well above the band is not.
+    expect(mask[5 * W + xCenter]).toBe(0);
+  });
+
+  it('mask only covers the rightmost scanW + margin columns', () => {
+    const px = blankImage([255, 255, 255]);
+    paintWatermarkStripe(px, H - DALLE_WATERMARK_PARAMS.SCAN_HEIGHT, H - 1);
+    const out = watermarkDetectDalle(px, W, H);
+    expect(out.detected).toBe(true);
+    const mask = out.mask!;
+    // Pixel in the left third of the image is never masked.
+    const yMiddle = H - 5;
+    expect(mask[yMiddle * W + 10]).toBe(0);
+    // Pixel in the rightmost stripe is masked.
+    expect(mask[yMiddle * W + (W - 5)]).toBe(1);
+  });
+
+  it('handles narrow images by clamping scanW to floor(width / 3)', () => {
+    const narrowW = 30;
+    const narrowH = 40;
+    const px = new Uint8ClampedArray(narrowW * narrowH * 4);
+    for (let i = 0; i < narrowW * narrowH; i++) {
+      px[i * 4] = 200;
+      px[i * 4 + 1] = 200;
+      px[i * 4 + 2] = 200;
+      px[i * 4 + 3] = 255;
+    }
+    // A solid image — we just want to verify the detector doesn't blow
+    // up when scanW gets clamped to width/3 = 10.
+    expect(() => watermarkDetectDalle(px, narrowW, narrowH)).not.toThrow();
+    const out = watermarkDetectDalle(px, narrowW, narrowH);
+    expect(out.detected).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

Adds unit coverage for two CV modules that were exercised only through `ml-pipeline.integration.test.ts` end-to-end. Closes #195.

## What's tested

### `watermark-dalle.test.ts` (6 tests)

- Solid color image → `detected: false`
- Low-variance grayscale gradient → not detected (color quantization reduces it below `MIN_UNIQUE_COLORS`)
- Synthetic 16-hue stripe in bottom-right → detected with correct `centerX` / `centerY`
- Mask geometry: covers band + `MASK_MARGIN` above/below
- Mask scope: only rightmost `scanW + margin` columns are masked
- Narrow image (W=30) doesn't crash when `scanW` clamps to `floor(W/3)`

### `inpaint-telea.test.ts` (8 tests)

- Output buffer length matches input
- Empty mask → byte-for-byte identical output
- Pixels outside mask never mutated
- Alpha=255 inside mask, original alpha preserved outside
- Solid-color hole reconstructs **exactly** the surrounding color (tight equality invariant)
- 2-color split: reconstructed RGB stays within source envelope (no extrapolation outside `[min, max]`)
- Custom radius (3, 9) doesn't throw
- Mask covering > 50% of canvas terminates in < 5s with reasonable reconstruction (regression guard against infinite loops)

## Why structural invariants instead of expected outputs

Telea's Fast Marching Method is propagation-order dependent. Hand-computing exact reconstructed RGBA for non-trivial masks is fragile — a tiny tie-break change in heap ordering would break expected values without changing visual quality. Asserting structural invariants (mask-only mutation, value envelope, alpha contract, termination time) gives meaningful coverage without brittle expected outputs.

## Validation

| Gate | Result |
|------|--------|
| `npm run typecheck` | ✅ green |
| `npm test` | ✅ **928/928** (914 + 14 new) |
| New tests run in <1s | ✅ |

Closes #195.