### PR TITLE
cleanup(post-cta): comment out import to tree-shake dead component (#196)

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -20,7 +20,12 @@ import './components/ar-batch-item';
 import './components/ar-batch-grid';
 import './components/ar-app';
 import './components/ar-reactor';
-import './components/ar-post-cta';
+// ar-post-cta import is commented out alongside the matching <ar-post-cta>
+// element in index.html (#181 disabled the CTA until rotation/centering
+// logic lands). With no import, Vite tree-shakes the component out of
+// the bundle entirely — saves ~220 LOC of dead code on every page load.
+// To re-enable: uncomment this line + the element in index.html.
+// import './components/ar-post-cta';
 
 // Register Service Worker
 import './sw-register';


### PR DESCRIPTION
## Summary

\`ar-post-cta\` has been visually disabled since [#181](https://github.com/yocreoquesi/nukebg/issues/181) — the element is commented out in \`index.html\` — but the component code (220 LOC + CSS template) was still in the bundle because \`main.ts\` imported it unconditionally.

Commenting out the import lets Vite drop the module entirely.

## Trade-off

Re-enabling requires uncommenting **two** lines (this one + the element in \`index.html\`). Both are documented inline with \`#181\` references so a future revert is easy to spot.

## Bundle delta

| Metric | Before | After | Δ |
|--------|--------|-------|---|
| index.js raw | 465.19 kB | **460.15 kB** | −5.04 kB / −1.08% |
| index.js gzip | 125.60 kB | **124.57 kB** | −1.03 kB / −0.82% |

Vs. v2.9.5 baseline: total reduction now **−6.76 kB raw / −1.09 kB gzip** across all the work this stretch.

## Test coverage preserved

\`tests/components/host-hidden-honor.test.ts:31\` imports \`ar-post-cta\` directly. The host-hidden-honor invariant still runs against the component in isolation.

## Validation

| Gate | Result |
|------|--------|
| \`npm run typecheck\` | ✅ green |
| \`npm test\` | ✅ **928/928** |
| \`npm run build\` | ✅ green, module absent from dist/assets |

Closes #196.