### PR TITLE
release: v2.10.1 — tree-shake post-cta + cv unit tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,52 @@ Unreleased entries accumulate on the `dev` branch. When we cut a release we copy
 
 ## [Unreleased]
 
+## [2.10.1] — 2026-04-28
+
+Patch release. Two follow-ups to v2.10.0 — bundle drops another 5 kB
+because a dead component is no longer in the tree-shake graph, and
+two CV modules that were untested at the unit level now have isolated
+coverage.
+
+### Changed
+
+- **`ar-post-cta` module no longer ships in the bundle.** The element
+  was visually disabled in v2.9.5 but its 220 LOC + CSS template were
+  still imported in `main.ts`. Commenting out the import lets Vite
+  drop the module entirely. Re-enable is a 2-line revert (this import
+  - the matching element in `index.html`); both sites carry inline
+    pointers to [#181](https://github.com/yocreoquesi/nukebg/issues/181)
+    ([#216](https://github.com/yocreoquesi/nukebg/pull/216),
+    [#196](https://github.com/yocreoquesi/nukebg/issues/196)).
+  * `index.js` raw: 465.19 kB → 460.15 kB (−5.04 kB / −1.08%)
+  * `index.js` gzip: 125.60 kB → 124.57 kB (−1.03 kB / −0.82%)
+
+### Added
+
+- **Unit coverage for `watermark-dalle` and `inpaint-telea`.** Both CV
+  modules were exercised only through `ml-pipeline.integration.test.ts`
+  end-to-end. A regression that produced visually plausible-but-wrong
+  output could have shipped without breaking any test. New behavioural
+  invariants (mask-only mutation, value envelope, alpha contract,
+  termination time) lock the contracts without trying to hand-compute
+  Telea's propagation-order-dependent output
+  ([#215](https://github.com/yocreoquesi/nukebg/pull/215),
+  [#195](https://github.com/yocreoquesi/nukebg/issues/195)).
+  - `watermark-dalle.test.ts` — 6 tests (detected/not-detected paths,
+    mask geometry, narrow-image clamping)
+  - `inpaint-telea.test.ts` — 8 tests (basic invariants, reconstruction
+    bounds, custom radius, > 50 % mask termination guard)
+
+### Notes
+
+- Cumulative bundle delta vs the v2.9.5 baseline that started this
+  cycle: `index.js` raw −6.76 kB / −1.45 %, gzip −1.09 kB / −0.87 %.
+  The 18 PRs that landed across v2.10.0 + v2.10.1 produced **net-
+  smaller** output despite adding 7 new modules + 94 new tests.
+- All audit-driven backlog from the 2026-04-28 cycle is now closed
+  (#185-#190, #191-#196). The umbrella refactor issue #47 is closed
+  with Phase 4 (typed EventBus) spun out into [#217](https://github.com/yocreoquesi/nukebg/issues/217).
+
 ## [2.10.0] — 2026-04-28
 
 Internal architecture refactor + audit cleanup. No new features; user-

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 > Nuke backgrounds from any image. 100% client-side. Zero uploads. Zero BS.
 
-[![Version](https://img.shields.io/badge/version-2.10.0-brightgreen.svg)](https://github.com/yocreoquesi/nukebg/releases)
+[![Version](https://img.shields.io/badge/version-2.10.1-brightgreen.svg)](https://github.com/yocreoquesi/nukebg/releases)
 [![License: GPL-3.0](https://img.shields.io/badge/License-GPL%20v3-blue.svg)](https://www.gnu.org/licenses/gpl-3.0)
 [![Client-Side](https://img.shields.io/badge/Processing-100%25%20Client--Side-green.svg)](#-privacy)
 

--- a/index.html
+++ b/index.html
@@ -151,7 +151,7 @@
           "PNG export with true alpha transparency"
         ],
         "screenshot": "https://nukebg.app/og-image.png",
-        "softwareVersion": "2.10.0",
+        "softwareVersion": "2.10.1",
         "license": "https://www.gnu.org/licenses/gpl-3.0.html",
         "isAccessibleForFree": true,
         "creator": {
@@ -487,7 +487,7 @@
     <!-- <ar-post-cta id="post-cta"></ar-post-cta> -->
 
     <footer class="footer hazard-border-top" role="contentinfo">
-      <span>NukeBG <span style="color: var(--color-text-tertiary)">v2.10.0</span></span>
+      <span>NukeBG <span style="color: var(--color-text-tertiary)">v2.10.1</span></span>
       <span class="footer-sep">|</span>
       <a href="https://github.com/yocreoquesi/nukebg" target="_blank" rel="noopener noreferrer"
         >GitHub</a

--- a/infra/nginx.conf
+++ b/infra/nginx.conf
@@ -31,7 +31,7 @@ server {
     #   new Function() WASM bootstrap.
     # - sha256 hashes cover the 3 inline JSON-LD blocks in index.html.
     #   Regenerate with `node scripts/compute-csp-hashes.mjs` after edits.
-    add_header Content-Security-Policy "default-src 'self'; script-src 'self' blob: 'wasm-unsafe-eval' 'unsafe-eval' 'sha256-ZDTev8tjytyskB+TfpLJpp6O1/B8dCnmwRQRbxsh6ws=' 'sha256-uZm4Xh9FxR3B7WjPHL5pbehtSMYTCy9JWzQzl3/UKA0=' 'sha256-o1DLxvGFHY9H1AG6Sro58slSTxU3T7zb020gfyqbFwM=' https://cdn.jsdelivr.net; worker-src 'self' blob:; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; connect-src 'self' https://huggingface.co https://cdn-lfs.huggingface.co https://cdn-lfs-us-1.huggingface.co https://cdn.jsdelivr.net https://cas-bridge.xethub.hf.co; font-src 'self'; object-src 'none'; base-uri 'self'; form-action 'none'" always;
+    add_header Content-Security-Policy "default-src 'self'; script-src 'self' blob: 'wasm-unsafe-eval' 'unsafe-eval' 'sha256-mZ64a3L9XwFvMokuQ8cmY68GpB2ucLc0WGmYWF8EKQY=' 'sha256-uZm4Xh9FxR3B7WjPHL5pbehtSMYTCy9JWzQzl3/UKA0=' 'sha256-o1DLxvGFHY9H1AG6Sro58slSTxU3T7zb020gfyqbFwM=' https://cdn.jsdelivr.net; worker-src 'self' blob:; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; connect-src 'self' https://huggingface.co https://cdn-lfs.huggingface.co https://cdn-lfs-us-1.huggingface.co https://cdn.jsdelivr.net https://cas-bridge.xethub.hf.co; font-src 'self'; object-src 'none'; base-uri 'self'; form-action 'none'" always;
 
     # Cache static assets
     # Note: add_header in location blocks replaces parent headers in nginx,
@@ -46,7 +46,7 @@ server {
         add_header Strict-Transport-Security "max-age=63072000; includeSubDomains; preload" always;
         add_header Cross-Origin-Opener-Policy "same-origin" always;
         add_header X-DNS-Prefetch-Control "off" always;
-        add_header Content-Security-Policy "default-src 'self'; script-src 'self' blob: 'wasm-unsafe-eval' 'unsafe-eval' 'sha256-ZDTev8tjytyskB+TfpLJpp6O1/B8dCnmwRQRbxsh6ws=' 'sha256-uZm4Xh9FxR3B7WjPHL5pbehtSMYTCy9JWzQzl3/UKA0=' 'sha256-o1DLxvGFHY9H1AG6Sro58slSTxU3T7zb020gfyqbFwM=' https://cdn.jsdelivr.net; worker-src 'self' blob:; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; connect-src 'self' https://huggingface.co https://cdn-lfs.huggingface.co https://cdn-lfs-us-1.huggingface.co https://cdn.jsdelivr.net https://cas-bridge.xethub.hf.co; font-src 'self'; object-src 'none'; base-uri 'self'; form-action 'none'" always;
+        add_header Content-Security-Policy "default-src 'self'; script-src 'self' blob: 'wasm-unsafe-eval' 'unsafe-eval' 'sha256-mZ64a3L9XwFvMokuQ8cmY68GpB2ucLc0WGmYWF8EKQY=' 'sha256-uZm4Xh9FxR3B7WjPHL5pbehtSMYTCy9JWzQzl3/UKA0=' 'sha256-o1DLxvGFHY9H1AG6Sro58slSTxU3T7zb020gfyqbFwM=' https://cdn.jsdelivr.net; worker-src 'self' blob:; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; connect-src 'self' https://huggingface.co https://cdn-lfs.huggingface.co https://cdn-lfs-us-1.huggingface.co https://cdn.jsdelivr.net https://cas-bridge.xethub.hf.co; font-src 'self'; object-src 'none'; base-uri 'self'; form-action 'none'" always;
     }
 
     # ONNX model files — cache aggressively, same-origin so CORP is fine
@@ -60,7 +60,7 @@ server {
         add_header Strict-Transport-Security "max-age=63072000; includeSubDomains; preload" always;
         add_header Cross-Origin-Opener-Policy "same-origin" always;
         add_header X-DNS-Prefetch-Control "off" always;
-        add_header Content-Security-Policy "default-src 'self'; script-src 'self' blob: 'wasm-unsafe-eval' 'unsafe-eval' 'sha256-ZDTev8tjytyskB+TfpLJpp6O1/B8dCnmwRQRbxsh6ws=' 'sha256-uZm4Xh9FxR3B7WjPHL5pbehtSMYTCy9JWzQzl3/UKA0=' 'sha256-o1DLxvGFHY9H1AG6Sro58slSTxU3T7zb020gfyqbFwM=' https://cdn.jsdelivr.net; worker-src 'self' blob:; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; connect-src 'self' https://huggingface.co https://cdn-lfs.huggingface.co https://cdn-lfs-us-1.huggingface.co https://cdn.jsdelivr.net https://cas-bridge.xethub.hf.co; font-src 'self'; object-src 'none'; base-uri 'self'; form-action 'none'" always;
+        add_header Content-Security-Policy "default-src 'self'; script-src 'self' blob: 'wasm-unsafe-eval' 'unsafe-eval' 'sha256-mZ64a3L9XwFvMokuQ8cmY68GpB2ucLc0WGmYWF8EKQY=' 'sha256-uZm4Xh9FxR3B7WjPHL5pbehtSMYTCy9JWzQzl3/UKA0=' 'sha256-o1DLxvGFHY9H1AG6Sro58slSTxU3T7zb020gfyqbFwM=' https://cdn.jsdelivr.net; worker-src 'self' blob:; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; connect-src 'self' https://huggingface.co https://cdn-lfs.huggingface.co https://cdn-lfs-us-1.huggingface.co https://cdn.jsdelivr.net https://cas-bridge.xethub.hf.co; font-src 'self'; object-src 'none'; base-uri 'self'; form-action 'none'" always;
     }
 
     # SPA fallback

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "nukebg",
-  "version": "2.10.0",
+  "version": "2.10.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "nukebg",
-      "version": "2.10.0",
+      "version": "2.10.1",
       "license": "GPL-3.0-only",
       "dependencies": {
         "@huggingface/transformers": "^3.8.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "nukebg",
   "private": true,
-  "version": "2.10.0",
+  "version": "2.10.1",
   "type": "module",
   "description": "NukeBG: Nuke AI backgrounds, checkerboard patterns, and watermarks. 100% client-side. Zero uploads. Zero BS.",
   "license": "GPL-3.0-only",

--- a/public/_headers
+++ b/public/_headers
@@ -7,7 +7,7 @@
   Cross-Origin-Resource-Policy: same-origin
   X-DNS-Prefetch-Control: off
   Strict-Transport-Security: max-age=63072000; includeSubDomains; preload
-  Content-Security-Policy: default-src 'self'; script-src 'self' blob: 'wasm-unsafe-eval' 'unsafe-eval' 'sha256-ZDTev8tjytyskB+TfpLJpp6O1/B8dCnmwRQRbxsh6ws=' 'sha256-uZm4Xh9FxR3B7WjPHL5pbehtSMYTCy9JWzQzl3/UKA0=' 'sha256-o1DLxvGFHY9H1AG6Sro58slSTxU3T7zb020gfyqbFwM=' https://cdn.jsdelivr.net; worker-src 'self' blob:; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; connect-src 'self' https://huggingface.co https://cdn-lfs.huggingface.co https://cdn-lfs-us-1.huggingface.co https://cdn.jsdelivr.net https://cas-bridge.xethub.hf.co; font-src 'self'; object-src 'none'; base-uri 'self'; form-action 'none'
+  Content-Security-Policy: default-src 'self'; script-src 'self' blob: 'wasm-unsafe-eval' 'unsafe-eval' 'sha256-mZ64a3L9XwFvMokuQ8cmY68GpB2ucLc0WGmYWF8EKQY=' 'sha256-uZm4Xh9FxR3B7WjPHL5pbehtSMYTCy9JWzQzl3/UKA0=' 'sha256-o1DLxvGFHY9H1AG6Sro58slSTxU3T7zb020gfyqbFwM=' https://cdn.jsdelivr.net; worker-src 'self' blob:; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; connect-src 'self' https://huggingface.co https://cdn-lfs.huggingface.co https://cdn-lfs-us-1.huggingface.co https://cdn.jsdelivr.net https://cas-bridge.xethub.hf.co; font-src 'self'; object-src 'none'; base-uri 'self'; form-action 'none'
 
 /assets/*
   Cache-Control: public, max-age=31536000, immutable

--- a/src/main.ts
+++ b/src/main.ts
@@ -166,7 +166,7 @@ function createShortcutOverlay(): HTMLDivElement {
 function showConsoleLogo(): void {
   const logo = `
 %c    ☢ NUKEBG ☢
-    v2.10.0 | Terminal Edition
+    v2.10.1 | Terminal Edition
 
     Your images never leave this machine.
     Don't believe us? Read the source:

--- a/src/utils/image-io.ts
+++ b/src/utils/image-io.ts
@@ -175,7 +175,7 @@ export async function exportPng(imageData: ImageData): Promise<Blob> {
     });
   }
   return injectPngMetadata(rawBlob, {
-    Software: 'NukeBG v2.10.0',
+    Software: 'NukeBG v2.10.1',
     Source: 'https://nukebg.app',
   });
 }


### PR DESCRIPTION
## Summary

Patch release wrapping the two PRs that landed on dev since v2.10.0:

- **#216** — comment out the \`ar-post-cta\` import in \`main.ts\` so Vite tree-shakes the dead 220-LOC component (closes #196).
- **#215** — 14 new unit tests for \`watermark-dalle\` (6) + \`inpaint-telea\` (8) using structural invariants (closes #195).

## Version bumped in 6 surfaces + CSP hash regenerated

Same flow as the v2.10.0 release. Only the first inline-script SHA-256 hash changes (the JSON-LD block holding \`softwareVersion\`); other two unchanged.

## Bundle delta vs v2.10.0

| Metric | v2.10.0 | v2.10.1 | Δ |
|--------|---------|---------|---|
| index.js raw | 465.19 kB | **460.15 kB** | −5.04 kB / −1.08% |
| index.js gzip | 125.60 kB | **124.57 kB** | −1.03 kB / −0.82% |

## Cumulative bundle delta vs v2.9.5 baseline

| Metric | v2.9.5 | v2.10.1 | Δ |
|--------|--------|---------|---|
| index.js raw | 466.91 kB | **460.15 kB** | **−6.76 kB / −1.45%** |
| index.js gzip | 125.66 kB | **124.57 kB** | **−1.09 kB / −0.87%** |

The 18 PRs across v2.10.0 + v2.10.1 produced **net-smaller** output despite adding 7 new modules + 94 new tests.

## Validation

| Gate | Result |
|------|--------|
| \`npm run typecheck\` | ✅ green |
| \`npm test\` | ✅ **928/928** |
| \`npm run build\` | ✅ green |

After this lands, follow-up PR \`dev → main\` to ship to Cloudflare.