### PR TITLE
release: v2.10.1 — tree-shake post-cta + cv unit tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,52 @@ Unreleased entries accumulate on the `dev` branch. When we cut a release we copy
 
 ## [Unreleased]
 
+## [2.10.1] — 2026-04-28
+
+Patch release. Two follow-ups to v2.10.0 — bundle drops another 5 kB
+because a dead component is no longer in the tree-shake graph, and
+two CV modules that were untested at the unit level now have isolated
+coverage.
+
+### Changed
+
+- **`ar-post-cta` module no longer ships in the bundle.** The element
+  was visually disabled in v2.9.5 but its 220 LOC + CSS template were
+  still imported in `main.ts`. Commenting out the import lets Vite
+  drop the module entirely. Re-enable is a 2-line revert (this import
+  - the matching element in `index.html`); both sites carry inline
+    pointers to [#181](https://github.com/yocreoquesi/nukebg/issues/181)
+    ([#216](https://github.com/yocreoquesi/nukebg/pull/216),
+    [#196](https://github.com/yocreoquesi/nukebg/issues/196)).
+  * `index.js` raw: 465.19 kB → 460.15 kB (−5.04 kB / −1.08%)
+  * `index.js` gzip: 125.60 kB → 124.57 kB (−1.03 kB / −0.82%)
+
+### Added
+
+- **Unit coverage for `watermark-dalle` and `inpaint-telea`.** Both CV
+  modules were exercised only through `ml-pipeline.integration.test.ts`
+  end-to-end. A regression that produced visually plausible-but-wrong
+  output could have shipped without breaking any test. New behavioural
+  invariants (mask-only mutation, value envelope, alpha contract,
+  termination time) lock the contracts without trying to hand-compute
+  Telea's propagation-order-dependent output
+  ([#215](https://github.com/yocreoquesi/nukebg/pull/215),
+  [#195](https://github.com/yocreoquesi/nukebg/issues/195)).
+  - `watermark-dalle.test.ts` — 6 tests (detected/not-detected paths,
+    mask geometry, narrow-image clamping)
+  - `inpaint-telea.test.ts` — 8 tests (basic invariants, reconstruction
+    bounds, custom radius, > 50 % mask termination guard)
+
+### Notes
+
+- Cumulative bundle delta vs the v2.9.5 baseline that started this
+  cycle: `index.js` raw −6.76 kB / −1.45 %, gzip −1.09 kB / −0.87 %.
+  The 18 PRs that landed across v2.10.0 + v2.10.1 produced **net-
+  smaller** output despite adding 7 new modules + 94 new tests.
+- All audit-driven backlog from the 2026-04-28 cycle is now closed
+  (#185-#190, #191-#196). The umbrella refactor issue #47 is closed
+  with Phase 4 (typed EventBus) spun out into [#217](https://github.com/yocreoquesi/nukebg/issues/217).
+
 ## [2.10.0] — 2026-04-28
 
 Internal architecture refactor + audit cleanup. No new features; user-

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 > Nuke backgrounds from any image. 100% client-side. Zero uploads. Zero BS.
 
-[![Version](https://img.shields.io/badge/version-2.10.0-brightgreen.svg)](https://github.com/yocreoquesi/nukebg/releases)
+[![Version](https://img.shields.io/badge/version-2.10.1-brightgreen.svg)](https://github.com/yocreoquesi/nukebg/releases)
 [![License: GPL-3.0](https://img.shields.io/badge/License-GPL%20v3-blue.svg)](https://www.gnu.org/licenses/gpl-3.0)
 [![Client-Side](https://img.shields.io/badge/Processing-100%25%20Client--Side-green.svg)](#-privacy)
 

--- a/index.html
+++ b/index.html
@@ -151,7 +151,7 @@
           "PNG export with true alpha transparency"
         ],
         "screenshot": "https://nukebg.app/og-image.png",
-        "softwareVersion": "2.10.0",
+        "softwareVersion": "2.10.1",
         "license": "https://www.gnu.org/licenses/gpl-3.0.html",
         "isAccessibleForFree": true,
         "creator": {
@@ -487,7 +487,7 @@
     <!-- <ar-post-cta id="post-cta"></ar-post-cta> -->
 
     <footer class="footer hazard-border-top" role="contentinfo">
-      <span>NukeBG <span style="color: var(--color-text-tertiary)">v2.10.0</span></span>
+      <span>NukeBG <span style="color: var(--color-text-tertiary)">v2.10.1</span></span>
       <span class="footer-sep">|</span>
       <a href="https://github.com/yocreoquesi/nukebg" target="_blank" rel="noopener noreferrer"
         >GitHub</a

--- a/infra/nginx.conf
+++ b/infra/nginx.conf
@@ -31,7 +31,7 @@ server {
     #   new Function() WASM bootstrap.
     # - sha256 hashes cover the 3 inline JSON-LD blocks in index.html.
     #   Regenerate with `node scripts/compute-csp-hashes.mjs` after edits.
-    add_header Content-Security-Policy "default-src 'self'; script-src 'self' blob: 'wasm-unsafe-eval' 'unsafe-eval' 'sha256-ZDTev8tjytyskB+TfpLJpp6O1/B8dCnmwRQRbxsh6ws=' 'sha256-uZm4Xh9FxR3B7WjPHL5pbehtSMYTCy9JWzQzl3/UKA0=' 'sha256-o1DLxvGFHY9H1AG6Sro58slSTxU3T7zb020gfyqbFwM=' https://cdn.jsdelivr.net; worker-src 'self' blob:; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; connect-src 'self' https://huggingface.co https://cdn-lfs.huggingface.co https://cdn-lfs-us-1.huggingface.co https://cdn.jsdelivr.net https://cas-bridge.xethub.hf.co; font-src 'self'; object-src 'none'; base-uri 'self'; form-action 'none'" always;
+    add_header Content-Security-Policy "default-src 'self'; script-src 'self' blob: 'wasm-unsafe-eval' 'unsafe-eval' 'sha256-mZ64a3L9XwFvMokuQ8cmY68GpB2ucLc0WGmYWF8EKQY=' 'sha256-uZm4Xh9FxR3B7WjPHL5pbehtSMYTCy9JWzQzl3/UKA0=' 'sha256-o1DLxvGFHY9H1AG6Sro58slSTxU3T7zb020gfyqbFwM=' https://cdn.jsdelivr.net; worker-src 'self' blob:; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; connect-src 'self' https://huggingface.co https://cdn-lfs.huggingface.co https://cdn-lfs-us-1.huggingface.co https://cdn.jsdelivr.net https://cas-bridge.xethub.hf.co; font-src 'self'; object-src 'none'; base-uri 'self'; form-action 'none'" always;
 
     # Cache static assets
     # Note: add_header in location blocks replaces parent headers in nginx,
@@ -46,7 +46,7 @@ server {
         add_header Strict-Transport-Security "max-age=63072000; includeSubDomains; preload" always;
         add_header Cross-Origin-Opener-Policy "same-origin" always;
         add_header X-DNS-Prefetch-Control "off" always;
-        add_header Content-Security-Policy "default-src 'self'; script-src 'self' blob: 'wasm-unsafe-eval' 'unsafe-eval' 'sha256-ZDTev8tjytyskB+TfpLJpp6O1/B8dCnmwRQRbxsh6ws=' 'sha256-uZm4Xh9FxR3B7WjPHL5pbehtSMYTCy9JWzQzl3/UKA0=' 'sha256-o1DLxvGFHY9H1AG6Sro58slSTxU3T7zb020gfyqbFwM=' https://cdn.jsdelivr.net; worker-src 'self' blob:; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; connect-src 'self' https://huggingface.co https://cdn-lfs.huggingface.co https://cdn-lfs-us-1.huggingface.co https://cdn.jsdelivr.net https://cas-bridge.xethub.hf.co; font-src 'self'; object-src 'none'; base-uri 'self'; form-action 'none'" always;
+        add_header Content-Security-Policy "default-src 'self'; script-src 'self' blob: 'wasm-unsafe-eval' 'unsafe-eval' 'sha256-mZ64a3L9XwFvMokuQ8cmY68GpB2ucLc0WGmYWF8EKQY=' 'sha256-uZm4Xh9FxR3B7WjPHL5pbehtSMYTCy9JWzQzl3/UKA0=' 'sha256-o1DLxvGFHY9H1AG6Sro58slSTxU3T7zb020gfyqbFwM=' https://cdn.jsdelivr.net; worker-src 'self' blob:; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; connect-src 'self' https://huggingface.co https://cdn-lfs.huggingface.co https://cdn-lfs-us-1.huggingface.co https://cdn.jsdelivr.net https://cas-bridge.xethub.hf.co; font-src 'self'; object-src 'none'; base-uri 'self'; form-action 'none'" always;
     }
 
     # ONNX model files — cache aggressively, same-origin so CORP is fine
@@ -60,7 +60,7 @@ server {
         add_header Strict-Transport-Security "max-age=63072000; includeSubDomains; preload" always;
         add_header Cross-Origin-Opener-Policy "same-origin" always;
         add_header X-DNS-Prefetch-Control "off" always;
-        add_header Content-Security-Policy "default-src 'self'; script-src 'self' blob: 'wasm-unsafe-eval' 'unsafe-eval' 'sha256-ZDTev8tjytyskB+TfpLJpp6O1/B8dCnmwRQRbxsh6ws=' 'sha256-uZm4Xh9FxR3B7WjPHL5pbehtSMYTCy9JWzQzl3/UKA0=' 'sha256-o1DLxvGFHY9H1AG6Sro58slSTxU3T7zb020gfyqbFwM=' https://cdn.jsdelivr.net; worker-src 'self' blob:; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; connect-src 'self' https://huggingface.co https://cdn-lfs.huggingface.co https://cdn-lfs-us-1.huggingface.co https://cdn.jsdelivr.net https://cas-bridge.xethub.hf.co; font-src 'self'; object-src 'none'; base-uri 'self'; form-action 'none'" always;
+        add_header Content-Security-Policy "default-src 'self'; script-src 'self' blob: 'wasm-unsafe-eval' 'unsafe-eval' 'sha256-mZ64a3L9XwFvMokuQ8cmY68GpB2ucLc0WGmYWF8EKQY=' 'sha256-uZm4Xh9FxR3B7WjPHL5pbehtSMYTCy9JWzQzl3/UKA0=' 'sha256-o1DLxvGFHY9H1AG6Sro58slSTxU3T7zb020gfyqbFwM=' https://cdn.jsdelivr.net; worker-src 'self' blob:; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; connect-src 'self' https://huggingface.co https://cdn-lfs.huggingface.co https://cdn-lfs-us-1.huggingface.co https://cdn.jsdelivr.net https://cas-bridge.xethub.hf.co; font-src 'self'; object-src 'none'; base-uri 'self'; form-action 'none'" always;
     }
 
     # SPA fallback

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "nukebg",
-  "version": "2.10.0",
+  "version": "2.10.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "nukebg",
-      "version": "2.10.0",
+      "version": "2.10.1",
       "license": "GPL-3.0-only",
       "dependencies": {
         "@huggingface/transformers": "^3.8.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "nukebg",
   "private": true,
-  "version": "2.10.0",
+  "version": "2.10.1",
   "type": "module",
   "description": "NukeBG: Nuke AI backgrounds, checkerboard patterns, and watermarks. 100% client-side. Zero uploads. Zero BS.",
   "license": "GPL-3.0-only",

--- a/public/_headers
+++ b/public/_headers
@@ -7,7 +7,7 @@
   Cross-Origin-Resource-Policy: same-origin
   X-DNS-Prefetch-Control: off
   Strict-Transport-Security: max-age=63072000; includeSubDomains; preload
-  Content-Security-Policy: default-src 'self'; script-src 'self' blob: 'wasm-unsafe-eval' 'unsafe-eval' 'sha256-ZDTev8tjytyskB+TfpLJpp6O1/B8dCnmwRQRbxsh6ws=' 'sha256-uZm4Xh9FxR3B7WjPHL5pbehtSMYTCy9JWzQzl3/UKA0=' 'sha256-o1DLxvGFHY9H1AG6Sro58slSTxU3T7zb020gfyqbFwM=' https://cdn.jsdelivr.net; worker-src 'self' blob:; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; connect-src 'self' https://huggingface.co https://cdn-lfs.huggingface.co https://cdn-lfs-us-1.huggingface.co https://cdn.jsdelivr.net https://cas-bridge.xethub.hf.co; font-src 'self'; object-src 'none'; base-uri 'self'; form-action 'none'
+  Content-Security-Policy: default-src 'self'; script-src 'self' blob: 'wasm-unsafe-eval' 'unsafe-eval' 'sha256-mZ64a3L9XwFvMokuQ8cmY68GpB2ucLc0WGmYWF8EKQY=' 'sha256-uZm4Xh9FxR3B7WjPHL5pbehtSMYTCy9JWzQzl3/UKA0=' 'sha256-o1DLxvGFHY9H1AG6Sro58slSTxU3T7zb020gfyqbFwM=' https://cdn.jsdelivr.net; worker-src 'self' blob:; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; connect-src 'self' https://huggingface.co https://cdn-lfs.huggingface.co https://cdn-lfs-us-1.huggingface.co https://cdn.jsdelivr.net https://cas-bridge.xethub.hf.co; font-src 'self'; object-src 'none'; base-uri 'self'; form-action 'none'
 
 /assets/*
   Cache-Control: public, max-age=31536000, immutable

--- a/src/main.ts
+++ b/src/main.ts
@@ -20,7 +20,12 @@ import './components/ar-batch-item';
 import './components/ar-batch-grid';
 import './components/ar-app';
 import './components/ar-reactor';
-import './components/ar-post-cta';
+// ar-post-cta import is commented out alongside the matching <ar-post-cta>
+// element in index.html (#181 disabled the CTA until rotation/centering
+// logic lands). With no import, Vite tree-shakes the component out of
+// the bundle entirely — saves ~220 LOC of dead code on every page load.
+// To re-enable: uncomment this line + the element in index.html.
+// import './components/ar-post-cta';
 
 // Register Service Worker
 import './sw-register';

--- a/src/main.ts
+++ b/src/main.ts
@@ -166,7 +166,7 @@ function createShortcutOverlay(): HTMLDivElement {
 function showConsoleLogo(): void {
   const logo = `
 %c    ☢ NUKEBG ☢
-    v2.10.0 | Terminal Edition
+    v2.10.1 | Terminal Edition
 
     Your images never leave this machine.
     Don't believe us? Read the source:

--- a/src/utils/image-io.ts
+++ b/src/utils/image-io.ts
@@ -175,7 +175,7 @@ export async function exportPng(imageData: ImageData): Promise<Blob> {
     });
   }
   return injectPngMetadata(rawBlob, {
-    Software: 'NukeBG v2.10.0',
+    Software: 'NukeBG v2.10.1',
     Source: 'https://nukebg.app',
   });
 }

--- a/tests/workers/cv/inpaint-telea.test.ts
+++ b/tests/workers/cv/inpaint-telea.test.ts
@@ -1,0 +1,195 @@
+import { describe, it, expect } from 'vitest';
+import { inpaintTelea } from '../../../src/workers/cv/inpaint-telea';
+
+/**
+ * Behavioural tests for inpaintTelea (#195).
+ *
+ * Telea's Fast Marching Method is propagation-order dependent, so we
+ * assert structural invariants (output bounds, mask-only mutation,
+ * within-source value range) rather than trying to hand-compute the
+ * exact reconstructed RGBA.
+ */
+
+function solidImage(w: number, h: number, rgb: [number, number, number]): Uint8ClampedArray {
+  const out = new Uint8ClampedArray(w * h * 4);
+  for (let i = 0; i < w * h; i++) {
+    out[i * 4] = rgb[0];
+    out[i * 4 + 1] = rgb[1];
+    out[i * 4 + 2] = rgb[2];
+    out[i * 4 + 3] = 255;
+  }
+  return out;
+}
+
+function rgbAt(
+  px: Uint8ClampedArray,
+  x: number,
+  y: number,
+  w: number,
+): [number, number, number, number] {
+  const i = (y * w + x) * 4;
+  return [px[i], px[i + 1], px[i + 2], px[i + 3]];
+}
+
+describe('inpaintTelea', () => {
+  describe('basic invariants', () => {
+    it('returns a buffer of the same length as input', () => {
+      const w = 16;
+      const h = 16;
+      const px = solidImage(w, h, [100, 50, 200]);
+      const mask = new Uint8Array(w * h);
+      mask[8 * w + 8] = 1;
+
+      const out = inpaintTelea(px, w, h, mask);
+      expect(out.length).toBe(px.length);
+    });
+
+    it('returns input unchanged when mask is all zeros', () => {
+      const w = 16;
+      const h = 16;
+      const px = solidImage(w, h, [42, 99, 200]);
+      const mask = new Uint8Array(w * h);
+      const out = inpaintTelea(px, w, h, mask);
+      // Pixel-for-pixel equality (no mask = no work)
+      for (let i = 0; i < px.length; i++) {
+        expect(out[i]).toBe(px[i]);
+      }
+    });
+
+    it('does not mutate pixels outside the mask', () => {
+      const w = 20;
+      const h = 20;
+      const px = solidImage(w, h, [200, 100, 50]);
+      const mask = new Uint8Array(w * h);
+      // 3x3 mask in the middle
+      for (let dy = -1; dy <= 1; dy++) {
+        for (let dx = -1; dx <= 1; dx++) {
+          mask[(10 + dy) * w + (10 + dx)] = 1;
+        }
+      }
+      const out = inpaintTelea(px, w, h, mask);
+      // Far corner unchanged
+      expect(rgbAt(out, 0, 0, w)).toEqual([200, 100, 50, 255]);
+      expect(rgbAt(out, w - 1, h - 1, w)).toEqual([200, 100, 50, 255]);
+      // Pixel adjacent to but outside mask unchanged
+      expect(rgbAt(out, 10, 7, w)).toEqual([200, 100, 50, 255]);
+    });
+
+    it('writes alpha=255 inside the mask region', () => {
+      const w = 16;
+      const h = 16;
+      const px = solidImage(w, h, [128, 128, 128]);
+      // Drop alpha to 100 outside (Telea promises opaque output INSIDE
+      // the mask only — outside is preserved verbatim).
+      for (let i = 0; i < w * h; i++) px[i * 4 + 3] = 100;
+      const mask = new Uint8Array(w * h);
+      mask[8 * w + 8] = 1;
+
+      const out = inpaintTelea(px, w, h, mask);
+      // Inside mask: alpha forced to 255
+      expect(out[(8 * w + 8) * 4 + 3]).toBe(255);
+      // Outside mask: alpha preserved (100, not 255)
+      expect(out[(0 * w + 0) * 4 + 3]).toBe(100);
+    });
+  });
+
+  describe('reconstruction bounds', () => {
+    it('reconstructs masked pixels within the [min, max] of source RGB', () => {
+      // Solid 100/50/200 background with a 3x3 hole. Reconstruction
+      // should produce values in [100, 100] / [50, 50] / [200, 200] —
+      // i.e., reproduce the surrounding solid color (or stay within it).
+      const w = 16;
+      const h = 16;
+      const px = solidImage(w, h, [100, 50, 200]);
+      const mask = new Uint8Array(w * h);
+      for (let dy = -1; dy <= 1; dy++) {
+        for (let dx = -1; dx <= 1; dx++) {
+          mask[(8 + dy) * w + (8 + dx)] = 1;
+        }
+      }
+      const out = inpaintTelea(px, w, h, mask);
+      // Every masked pixel should land at exactly (100, 50, 200) since
+      // every neighbor is the same color. Tight invariant.
+      for (let dy = -1; dy <= 1; dy++) {
+        for (let dx = -1; dx <= 1; dx++) {
+          const [r, g, b, a] = rgbAt(out, 8 + dx, 8 + dy, w);
+          expect(r).toBe(100);
+          expect(g).toBe(50);
+          expect(b).toBe(200);
+          expect(a).toBe(255);
+        }
+      }
+    });
+
+    it('keeps reconstructed RGB inside source RGB envelope on a 2-color split', () => {
+      // Left half red, right half blue, with a vertical-line hole down
+      // the middle. Reconstruction must yield colors in [red, blue]
+      // envelope per channel — never extrapolate outside.
+      const w = 20;
+      const h = 16;
+      const px = new Uint8ClampedArray(w * h * 4);
+      for (let y = 0; y < h; y++) {
+        for (let x = 0; x < w; x++) {
+          const i = (y * w + x) * 4;
+          const isLeft = x < w / 2;
+          px[i] = isLeft ? 200 : 0;
+          px[i + 1] = 0;
+          px[i + 2] = isLeft ? 0 : 200;
+          px[i + 3] = 255;
+        }
+      }
+      const mask = new Uint8Array(w * h);
+      const xMid = Math.floor(w / 2);
+      for (let y = 4; y < h - 4; y++) mask[y * w + xMid] = 1;
+
+      const out = inpaintTelea(px, w, h, mask);
+      for (let y = 4; y < h - 4; y++) {
+        const [r, g, b] = rgbAt(out, xMid, y, w);
+        expect(r).toBeGreaterThanOrEqual(0);
+        expect(r).toBeLessThanOrEqual(200);
+        expect(g).toBe(0); // both sides have G=0; reconstruction must not invent
+        expect(b).toBeGreaterThanOrEqual(0);
+        expect(b).toBeLessThanOrEqual(200);
+      }
+    });
+  });
+
+  describe('robustness', () => {
+    it('honors a custom radius without throwing', () => {
+      const w = 16;
+      const h = 16;
+      const px = solidImage(w, h, [50, 50, 50]);
+      const mask = new Uint8Array(w * h);
+      mask[8 * w + 8] = 1;
+      expect(() => inpaintTelea(px, w, h, mask, 3)).not.toThrow();
+      expect(() => inpaintTelea(px, w, h, mask, 9)).not.toThrow();
+    });
+
+    it('survives a mask covering > 50% of the canvas (slow but should not infinite-loop)', () => {
+      const w = 16;
+      const h = 16;
+      const px = solidImage(w, h, [128, 64, 192]);
+      const mask = new Uint8Array(w * h);
+      // Mask everything except the outer 2-pixel ring
+      for (let y = 2; y < h - 2; y++) {
+        for (let x = 2; x < w - 2; x++) {
+          mask[y * w + x] = 1;
+        }
+      }
+      const before = Date.now();
+      const out = inpaintTelea(px, w, h, mask);
+      const elapsed = Date.now() - before;
+      expect(elapsed).toBeLessThan(5000);
+      // The masked center is in a ring of solid 128/64/192 — should
+      // reconstruct very close to that color.
+      const [r, g, b, a] = rgbAt(out, 8, 8, w);
+      expect(r).toBeGreaterThanOrEqual(120);
+      expect(r).toBeLessThanOrEqual(136);
+      expect(g).toBeGreaterThanOrEqual(56);
+      expect(g).toBeLessThanOrEqual(72);
+      expect(b).toBeGreaterThanOrEqual(184);
+      expect(b).toBeLessThanOrEqual(200);
+      expect(a).toBe(255);
+    });
+  });
+});

--- a/tests/workers/cv/watermark-dalle.test.ts
+++ b/tests/workers/cv/watermark-dalle.test.ts
@@ -1,0 +1,138 @@
+import { describe, it, expect } from 'vitest';
+import { watermarkDetectDalle } from '../../../src/workers/cv/watermark-dalle';
+import { DALLE_WATERMARK_PARAMS } from '../../../src/pipeline/constants';
+
+/**
+ * Behavioural tests for watermarkDetectDalle (#195).
+ *
+ * The detector scans the bottom-right corner for a horizontal stripe with
+ * high color variance — the multicolor DALL-E 3 signature bar. Tests
+ * cover the four gates the algorithm uses:
+ *   1. minUniqueColors  — at least N quantized colors per scan row
+ *   2. contrastThreshold — bar row has > 2× more colors than reference row
+ *   3. minChannelSpread — bar row has > 200 R+G+B range
+ *   4. mask geometry — covers detected band + MASK_MARGIN pixels
+ */
+
+const W = 300;
+const H = 40;
+
+function blankImage(rgb: [number, number, number] = [255, 255, 255]): Uint8ClampedArray {
+  const out = new Uint8ClampedArray(W * H * 4);
+  for (let i = 0; i < W * H; i++) {
+    out[i * 4] = rgb[0];
+    out[i * 4 + 1] = rgb[1];
+    out[i * 4 + 2] = rgb[2];
+    out[i * 4 + 3] = 255;
+  }
+  return out;
+}
+
+/** Paint a horizontal multicolor stripe across rows [yStart, yEnd] in the
+ *  rightmost 100 px (>= scanW for W=300). Uses 16 distinct hues so the
+ *  quantized-color count clears MIN_UNIQUE_COLORS=15 with margin, and
+ *  spans full RGB range so MIN_CHANNEL_SPREAD=200 is satisfied. */
+function paintWatermarkStripe(pixels: Uint8ClampedArray, yStart: number, yEnd: number): void {
+  const xStart = W - 100;
+  for (let y = yStart; y <= yEnd; y++) {
+    for (let x = xStart; x < W; x++) {
+      const i = (y * W + x) * 4;
+      // Cycle through 16 distinct hues by stepping x in groups.
+      const hueIdx = ((x - xStart) >> 2) & 0x0f;
+      pixels[i] = (hueIdx * 17) & 0xff; // 0, 17, 34, ..., 255
+      pixels[i + 1] = (hueIdx * 23 + 50) & 0xff;
+      pixels[i + 2] = (hueIdx * 31 + 100) & 0xff;
+      pixels[i + 3] = 255;
+    }
+  }
+}
+
+describe('watermarkDetectDalle', () => {
+  it('returns detected=false on a solid-color image', () => {
+    const out = watermarkDetectDalle(blankImage([200, 100, 50]), W, H);
+    expect(out.detected).toBe(false);
+    expect(out.mask).toBeNull();
+  });
+
+  it('returns detected=false on a low-variance grayscale gradient', () => {
+    // Smooth horizontal gradient: 256 distinct values total but quantized
+    // to 16 brightness levels — well below MIN_UNIQUE_COLORS=15 *across
+    // RGB combinations* in any 100-px slice (gradient is monotonic).
+    const px = new Uint8ClampedArray(W * H * 4);
+    for (let y = 0; y < H; y++) {
+      for (let x = 0; x < W; x++) {
+        const v = Math.floor((x / W) * 255);
+        const i = (y * W + x) * 4;
+        px[i] = v;
+        px[i + 1] = v;
+        px[i + 2] = v;
+        px[i + 3] = 255;
+      }
+    }
+    const out = watermarkDetectDalle(px, W, H);
+    expect(out.detected).toBe(false);
+    expect(out.mask).toBeNull();
+  });
+
+  it('detects a synthetic multicolor stripe in the bottom-right band', () => {
+    const px = blankImage([255, 255, 255]);
+    const yStart = H - DALLE_WATERMARK_PARAMS.SCAN_HEIGHT;
+    const yEnd = H - 1;
+    paintWatermarkStripe(px, yStart, yEnd);
+
+    const out = watermarkDetectDalle(px, W, H);
+    expect(out.detected).toBe(true);
+    expect(out.mask).not.toBeNull();
+    expect(out.centerX).toBeGreaterThan(W / 2);
+    expect(out.centerY).toBeGreaterThan(H - DALLE_WATERMARK_PARAMS.SCAN_HEIGHT - 1);
+  });
+
+  it('mask covers the detected band plus MASK_MARGIN on each side', () => {
+    const px = blankImage([255, 255, 255]);
+    const yStart = H - DALLE_WATERMARK_PARAMS.SCAN_HEIGHT;
+    const yEnd = H - 1;
+    paintWatermarkStripe(px, yStart, yEnd);
+
+    const out = watermarkDetectDalle(px, W, H);
+    expect(out.detected).toBe(true);
+    const mask = out.mask!;
+    const margin = DALLE_WATERMARK_PARAMS.MASK_MARGIN;
+    // Top edge: pixel at (xCenter, yStart - margin) should be in mask.
+    const xCenter = out.centerX!;
+    expect(mask[(yStart - margin) * W + xCenter]).toBe(1);
+    // Bottom edge: last row inside the image is in the mask.
+    expect(mask[(H - 1) * W + xCenter]).toBe(1);
+    // Outside the mask region: a pixel well above the band is not.
+    expect(mask[5 * W + xCenter]).toBe(0);
+  });
+
+  it('mask only covers the rightmost scanW + margin columns', () => {
+    const px = blankImage([255, 255, 255]);
+    paintWatermarkStripe(px, H - DALLE_WATERMARK_PARAMS.SCAN_HEIGHT, H - 1);
+    const out = watermarkDetectDalle(px, W, H);
+    expect(out.detected).toBe(true);
+    const mask = out.mask!;
+    // Pixel in the left third of the image is never masked.
+    const yMiddle = H - 5;
+    expect(mask[yMiddle * W + 10]).toBe(0);
+    // Pixel in the rightmost stripe is masked.
+    expect(mask[yMiddle * W + (W - 5)]).toBe(1);
+  });
+
+  it('handles narrow images by clamping scanW to floor(width / 3)', () => {
+    const narrowW = 30;
+    const narrowH = 40;
+    const px = new Uint8ClampedArray(narrowW * narrowH * 4);
+    for (let i = 0; i < narrowW * narrowH; i++) {
+      px[i * 4] = 200;
+      px[i * 4 + 1] = 200;
+      px[i * 4 + 2] = 200;
+      px[i * 4 + 3] = 255;
+    }
+    // A solid image — we just want to verify the detector doesn't blow
+    // up when scanW gets clamped to width/3 = 10.
+    expect(() => watermarkDetectDalle(px, narrowW, narrowH)).not.toThrow();
+    const out = watermarkDetectDalle(px, narrowW, narrowH);
+    expect(out.detected).toBe(false);
+  });
+});


### PR DESCRIPTION
Ships v2.10.1 to production. 4 commits since v2.10.0 (the version bump squash + #215 + #216 + the release commit).

## Highlights

- **Bundle drops another 5 kB.** \`index.js\` 465.19 → 460.15 kB raw / 125.60 → 124.57 kB gzip. Cumulative across v2.10.0 + v2.10.1 vs the v2.9.5 baseline: **−6.76 kB raw / −1.09 kB gzip** despite the 7 new modules + 94 new tests added in v2.10.0.
- **Two CV modules now have unit coverage.** \`watermark-dalle\` (6 tests) + \`inpaint-telea\` (8 tests) were exercised only end-to-end before. New tests use structural invariants (mask-only mutation, reconstruction envelope, alpha contract, termination time) instead of brittle expected outputs.
- **\`ar-post-cta\` no longer ships.** The visually-disabled component is tree-shaken out of the bundle. Re-enable when #181 lands is a 2-line revert.

## Validation gates

| Gate | Result |
|------|--------|
| \`npm run typecheck\` | ✅ green |
| \`npm test\` | ✅ **928/928** |
| \`npm run build\` | ✅ green |

## Risk

Patch-only release. No public surface changes. \`ar-post-cta\` element was already not rendered in the HTML — this just removes the dead module from the bundle.

## Roll-back

\`git revert\` this merge commit, OR \`git reset --hard\` to the v2.10.0 commit on main (\`c4fc30c\`). Both safe.

## CHANGELOG

https://github.com/yocreoquesi/nukebg/blob/dev/CHANGELOG.md#2101--2026-04-28