### PR TITLE
feat(events): migrate all dispatchers + listeners to typed event-bus (#217)

### DIFF
--- a/src/components/ar-app.ts
+++ b/src/components/ar-app.ts
@@ -11,7 +11,7 @@ import type { ArEditor } from './ar-editor';
 import type { ArDropzone } from './ar-dropzone';
 import type { ArBatchGrid } from './ar-batch-grid';
 import { BatchOrchestrator, type BatchStageCallback } from '../controllers/batch-orchestrator';
-import { on } from '../lib/event-bus';
+import { emit, on } from '../lib/event-bus';
 import {
   refineEdges,
   dropOrphanBlobs,
@@ -1165,11 +1165,10 @@ export class ArApp extends HTMLElement {
     // the shadow-root level so legacy listeners (progress component,
     // tests) still work.
     const bubbleCancel = (): void => {
-      this.dispatchEvent(
-        new CustomEvent('ar:cancel-processing', { bubbles: true, composed: true }),
-      );
+      emit(this, 'ar:cancel-processing', undefined, { bubbles: true, composed: true });
     };
-    this.shadowRoot!.addEventListener(
+    on(
+      this.shadowRoot!,
       'ar:cancel-processing',
       () => {
         if (this.processingAbortController && !this.processingAbortController.signal.aborted) {
@@ -1189,11 +1188,11 @@ export class ArApp extends HTMLElement {
     // the existing retryFromError() path; report opens a pre-filled
     // GitHub issue URL with browser + session hints; reload is
     // handled by ar-progress itself (location.reload).
-    this.progress.addEventListener('ar:stage-retry', () => this.retryFromError(), { signal });
-    this.progress.addEventListener(
+    on(this.progress, 'ar:stage-retry', () => this.retryFromError(), { signal });
+    on(
+      this.progress,
       'ar:stage-report',
-      (ev) => {
-        const stage = (ev as CustomEvent<{ stage: string }>).detail.stage;
+      ({ stage }) => {
         const ua = encodeURIComponent(navigator.userAgent);
         const title = encodeURIComponent(`[stage:${stage}] pipeline error`);
         const body = encodeURIComponent(
@@ -1232,10 +1231,10 @@ export class ArApp extends HTMLElement {
     // the same AbortSignal so cleanup is automatic on disconnect.
     this.installer.attach(signal);
 
-    this.shadowRoot!.addEventListener(
+    on(
+      this.shadowRoot!,
       'ar:image-loaded',
-      async (e: Event) => {
-        const detail = (e as CustomEvent).detail;
+      async (detail) => {
         this.currentFileName = detail.file.name || 'image.png';
 
         // If currently processing, abort the in-flight pipeline and reset
@@ -1254,19 +1253,10 @@ export class ArApp extends HTMLElement {
       { signal },
     );
 
-    this.shadowRoot!.addEventListener(
+    on(
+      this.shadowRoot!,
       'ar:images-loaded',
-      async (e: Event) => {
-        const detail = (e as CustomEvent).detail as {
-          images: Array<{
-            file: File;
-            imageData: ImageData;
-            originalImageData: ImageData;
-            originalWidth: number;
-            originalHeight: number;
-            wasDownsampled: boolean;
-          }>;
-        };
+      async (detail) => {
         if (this.isProcessing) {
           this.processingAborted = true;
           this.isProcessing = false;
@@ -1277,16 +1267,17 @@ export class ArApp extends HTMLElement {
       { signal },
     );
 
-    this.shadowRoot!.addEventListener(
+    on(
+      this.shadowRoot!,
       'batch:item-click',
-      (e: Event) => {
-        const detail = (e as CustomEvent).detail as { id: string; state: string };
-        this.openBatchDetail(detail.id);
+      ({ id }) => {
+        this.openBatchDetail(id);
       },
       { signal },
     );
 
-    this.shadowRoot!.addEventListener(
+    on(
+      this.shadowRoot!,
       'batch:download-zip',
       async () => {
         await this.batch.downloadZip();
@@ -1294,7 +1285,8 @@ export class ArApp extends HTMLElement {
       { signal },
     );
 
-    this.shadowRoot!.addEventListener(
+    on(
+      this.shadowRoot!,
       'batch:cancel',
       () => {
         this.resetToIdle();
@@ -1315,7 +1307,8 @@ export class ArApp extends HTMLElement {
       discardBtn.addEventListener('click', () => this.discardBatchItem(), { signal });
     }
 
-    this.shadowRoot!.addEventListener(
+    on(
+      this.shadowRoot!,
       'ar:process-another',
       () => {
         this.resetToIdle();
@@ -1364,7 +1357,8 @@ export class ArApp extends HTMLElement {
     );
 
     // Editor cancel - discard edits, close editor
-    this.shadowRoot!.addEventListener(
+    on(
+      this.shadowRoot!,
       'ar:editor-cancel',
       () => {
         (this.shadowRoot!.querySelector('#editor-section') as HTMLElement).style.display = 'none';
@@ -1374,10 +1368,10 @@ export class ArApp extends HTMLElement {
     );
 
     // Editor done - update viewer and download with edited result
-    this.shadowRoot!.addEventListener(
+    on(
+      this.shadowRoot!,
       'ar:editor-done',
-      async (e: Event) => {
-        const rawEdited = (e as CustomEvent).detail.imageData as ImageData;
+      async ({ imageData: rawEdited }) => {
         // Refine: foreground decontamination + quintic alpha sharpening so manual
         // brush strokes inherit the same studio-quality edge as the main pipeline.
         // Topology cleanup is skipped — keepLargestComponent would discard manual
@@ -1430,7 +1424,8 @@ export class ArApp extends HTMLElement {
     );
 
     // Advanced editor — cancel
-    this.shadowRoot!.addEventListener(
+    on(
+      this.shadowRoot!,
       'ar:advanced-cancel',
       () => {
         const btn = this.shadowRoot!.querySelector('#advanced-cta') as HTMLElement | null;
@@ -1440,16 +1435,16 @@ export class ArApp extends HTMLElement {
     );
 
     // Advanced editor — done
-    this.shadowRoot!.addEventListener(
+    on(
+      this.shadowRoot!,
       'ar:advanced-done',
-      async (e: Event) => {
-        const detail = (e as CustomEvent<{ imageData: ImageData }>).detail;
+      async ({ imageData }) => {
         const btn = this.shadowRoot!.querySelector('#advanced-cta') as HTMLElement | null;
         btn?.removeAttribute('data-active');
 
         // Same reasoning as the basic editor: skip topology cleanup so the
         // user's lasso crops / restores survive the refinement pass.
-        const refined = await refineEdges(this.pipeline, detail.imageData, {
+        const refined = await refineEdges(this.pipeline, imageData, {
           skipTopologyCleanup: true,
         });
         const blob = await exportPng(refined);
@@ -1660,7 +1655,7 @@ export class ArApp extends HTMLElement {
         // Notify the post-process CTA module so it can decide whether
         // to surface a star/tip/review ask. Light DOM listener — fires
         // and forgets, no return contract.
-        document.dispatchEvent(new CustomEvent('ar:nuke-success'));
+        emit(document, 'ar:nuke-success', undefined);
       }
     }
   }

--- a/src/components/ar-batch-grid.ts
+++ b/src/components/ar-batch-grid.ts
@@ -1,7 +1,7 @@
 import { t } from '../i18n';
 import type { BatchItem, BatchItemState } from '../types/batch';
 import { ArBatchItem } from './ar-batch-item';
-import { on } from '../lib/event-bus';
+import { emit, on } from '../lib/event-bus';
 
 /**
  * Presentational container for the batch workflow. Holds BatchItem
@@ -134,21 +134,11 @@ export class ArBatchGrid extends HTMLElement {
     `;
 
     this.shadowRoot!.querySelector('#zip-btn')!.addEventListener('click', () => {
-      this.dispatchEvent(
-        new CustomEvent('batch:download-zip', {
-          bubbles: true,
-          composed: true,
-        }),
-      );
+      emit(this, 'batch:download-zip', undefined, { bubbles: true, composed: true });
     });
 
     this.shadowRoot!.querySelector('#cancel-btn')!.addEventListener('click', () => {
-      this.dispatchEvent(
-        new CustomEvent('batch:cancel', {
-          bubbles: true,
-          composed: true,
-        }),
-      );
+      emit(this, 'batch:cancel', undefined, { bubbles: true, composed: true });
     });
   }
 

--- a/src/components/ar-batch-item.ts
+++ b/src/components/ar-batch-item.ts
@@ -1,6 +1,6 @@
 import { t } from '../i18n';
 import type { BatchItemState } from '../types/batch';
-import { on } from '../lib/event-bus';
+import { emit, on } from '../lib/event-bus';
 
 /**
  * A single slot in the batch grid. Renders a thumbnail plus a state badge
@@ -26,12 +26,11 @@ export class ArBatchItem extends HTMLElement {
       // Pending slots are non-interactive. Processing IS clickable so the
       // user can open the live progress console for the current item.
       if (this.itemState === 'pending') return;
-      this.dispatchEvent(
-        new CustomEvent('batch:item-click', {
-          bubbles: true,
-          composed: true,
-          detail: { id: this.itemId, state: this.itemState },
-        }),
+      emit(
+        this,
+        'batch:item-click',
+        { id: this.itemId, state: this.itemState },
+        { bubbles: true, composed: true },
       );
     });
     this.shadowRoot!.addEventListener('keydown', (e) => {
@@ -39,12 +38,11 @@ export class ArBatchItem extends HTMLElement {
       if (ke.key !== 'Enter' && ke.key !== ' ') return;
       if (this.itemState === 'pending') return;
       ke.preventDefault();
-      this.dispatchEvent(
-        new CustomEvent('batch:item-click', {
-          bubbles: true,
-          composed: true,
-          detail: { id: this.itemId, state: this.itemState },
-        }),
+      emit(
+        this,
+        'batch:item-click',
+        { id: this.itemId, state: this.itemState },
+        { bubbles: true, composed: true },
       );
     });
     this.abortController = new AbortController();

--- a/src/components/ar-download.ts
+++ b/src/components/ar-download.ts
@@ -1,7 +1,7 @@
 import { exportPng, exportWebp, generateOutputFilename } from '../utils/image-io';
 import { t, getLocale } from '../i18n';
 import type { ExportFormat } from '../types/image';
-import { on } from '../lib/event-bus';
+import { emit, on } from '../lib/event-bus';
 
 export class ArDownload extends HTMLElement {
   private pngBlobUrl: string | null = null;
@@ -314,7 +314,7 @@ export class ArDownload extends HTMLElement {
     `;
 
     this.shadowRoot!.querySelector('#another-btn')!.addEventListener('click', () => {
-      this.dispatchEvent(new CustomEvent('ar:process-another', { bubbles: true, composed: true }));
+      emit(this, 'ar:process-another', undefined, { bubbles: true, composed: true });
     });
 
     // Web Share API (#74) removed in #150 — the user wanted it gone

--- a/src/components/ar-dropzone.ts
+++ b/src/components/ar-dropzone.ts
@@ -1,7 +1,7 @@
 import { loadImage, isSupportedFormat } from '../utils/image-io';
 import { t } from '../i18n';
 import { getBatchLimit } from '../types/batch';
-import { on } from '../lib/event-bus';
+import { emit, on } from '../lib/event-bus';
 
 export class ArDropzone extends HTMLElement {
   private fileInput!: HTMLInputElement;
@@ -447,19 +447,18 @@ export class ArDropzone extends HTMLElement {
 
     try {
       const result = await loadImage(file);
-      this.dispatchEvent(
-        new CustomEvent('ar:image-loaded', {
-          bubbles: true,
-          composed: true,
-          detail: {
-            file,
-            imageData: result.imageData,
-            originalImageData: result.originalImageData,
-            originalWidth: result.originalWidth,
-            originalHeight: result.originalHeight,
-            wasDownsampled: result.wasDownsampled,
-          },
-        }),
+      emit(
+        this,
+        'ar:image-loaded',
+        {
+          file,
+          imageData: result.imageData,
+          originalImageData: result.originalImageData,
+          originalWidth: result.originalWidth,
+          originalHeight: result.originalHeight,
+          wasDownsampled: result.wasDownsampled,
+        },
+        { bubbles: true, composed: true },
       );
     } catch (err) {
       const msg = err instanceof Error ? err.message : 'Failed to load image.';
@@ -528,13 +527,7 @@ export class ArDropzone extends HTMLElement {
       this.showError(t('batch.limitExceeded', { limit: String(limit) }));
     }
 
-    this.dispatchEvent(
-      new CustomEvent('ar:images-loaded', {
-        bubbles: true,
-        composed: true,
-        detail: { images: loaded },
-      }),
-    );
+    emit(this, 'ar:images-loaded', { images: loaded }, { bubbles: true, composed: true });
   }
 
   private showError(message?: string): void {

--- a/src/components/ar-editor-advanced.ts
+++ b/src/components/ar-editor-advanced.ts
@@ -39,6 +39,7 @@ import { t } from '../i18n';
 import { type Point } from './lasso-simplify';
 import { LassoModel } from '../lib/lasso-model';
 import { HistoryManager } from '../lib/history-manager';
+import { emit } from '../lib/event-bus';
 
 const PAD_RATIO = 0.25;
 const DEFAULT_BRUSH = 24;
@@ -2152,7 +2153,7 @@ export class ArEditorAdvanced extends HTMLElement {
 
   private cancel(): void {
     this.removeAttribute('active');
-    this.dispatchEvent(new CustomEvent('ar:advanced-cancel', { bubbles: true, composed: true }));
+    emit(this, 'ar:advanced-cancel', undefined, { bubbles: true, composed: true });
   }
 
   private commit(): void {
@@ -2161,13 +2162,7 @@ export class ArEditorAdvanced extends HTMLElement {
       .getContext('2d')!
       .getImageData(0, 0, this.current.width, this.current.height);
     this.removeAttribute('active');
-    this.dispatchEvent(
-      new CustomEvent('ar:advanced-done', {
-        detail: { imageData: out },
-        bubbles: true,
-        composed: true,
-      }),
-    );
+    emit(this, 'ar:advanced-done', { imageData: out }, { bubbles: true, composed: true });
   }
 }
 

--- a/src/components/ar-editor.ts
+++ b/src/components/ar-editor.ts
@@ -7,7 +7,7 @@
 import { t } from '../i18n';
 import { BrushStroke, type BrushShape, type BrushTool } from '../lib/brush-stroke';
 import { HistoryManager } from '../lib/history-manager';
-import { on } from '../lib/event-bus';
+import { emit, on } from '../lib/event-bus';
 
 /** Generate a CSS cursor data URL that matches the brush shape, size and tool */
 function makeBrushCursor(
@@ -892,12 +892,7 @@ export class ArEditor extends HTMLElement {
     this.shadowRoot!.querySelector('#cancel-btn')!.addEventListener(
       'click',
       () => {
-        this.dispatchEvent(
-          new CustomEvent('ar:editor-cancel', {
-            bubbles: true,
-            composed: true,
-          }),
-        );
+        emit(this, 'ar:editor-cancel', undefined, { bubbles: true, composed: true });
       },
       { signal },
     );
@@ -906,12 +901,11 @@ export class ArEditor extends HTMLElement {
     this.shadowRoot!.querySelector('#done-btn')!.addEventListener(
       'click',
       () => {
-        this.dispatchEvent(
-          new CustomEvent('ar:editor-done', {
-            bubbles: true,
-            composed: true,
-            detail: { imageData: this.getResultImageData() },
-          }),
+        emit(
+          this,
+          'ar:editor-done',
+          { imageData: this.getResultImageData() },
+          { bubbles: true, composed: true },
         );
       },
       { signal },

--- a/src/components/ar-progress.ts
+++ b/src/components/ar-progress.ts
@@ -1,6 +1,6 @@
 import type { PipelineStage, StageStatus } from '../types/pipeline';
 import { t } from '../i18n';
-import { on } from '../lib/event-bus';
+import { emit, on } from '../lib/event-bus';
 
 interface StageInfo {
   stage: PipelineStage;
@@ -51,13 +51,9 @@ export class ArProgress extends HTMLElement {
       if (!target) return;
       const stage = target.getAttribute('data-stage') ?? '';
       if (target.classList.contains('stage-action-retry')) {
-        this.dispatchEvent(
-          new CustomEvent('ar:stage-retry', { bubbles: true, composed: true, detail: { stage } }),
-        );
+        emit(this, 'ar:stage-retry', { stage }, { bubbles: true, composed: true });
       } else if (target.classList.contains('stage-action-report')) {
-        this.dispatchEvent(
-          new CustomEvent('ar:stage-report', { bubbles: true, composed: true, detail: { stage } }),
-        );
+        emit(this, 'ar:stage-report', { stage }, { bubbles: true, composed: true });
       } else if (target.classList.contains('stage-action-reload')) {
         location.reload();
       }

--- a/src/i18n/index.ts
+++ b/src/i18n/index.ts
@@ -4,6 +4,8 @@
  * emite evento custom cuando cambia el locale.
  */
 
+import { emit } from '../lib/event-bus';
+
 type Translations = Record<string, Record<string, string>>;
 
 const translations: Translations = {
@@ -1551,9 +1553,7 @@ export function setLocale(locale: string): void {
   document.documentElement.dir = getDirection(locale);
 
   // Emit event so components re-render
-  document.dispatchEvent(new CustomEvent('nukebg:locale-changed', {
-    detail: { locale },
-  }));
+  emit(document, 'nukebg:locale-changed', { locale });
 }
 
 /** Gets the active locale */

--- a/src/sw-register.ts
+++ b/src/sw-register.ts
@@ -1,3 +1,5 @@
+import { emit } from './lib/event-bus';
+
 /** Deferred install prompt captured from beforeinstallprompt */
 let deferredPrompt: BeforeInstallPromptEvent | null = null;
 
@@ -33,14 +35,14 @@ if ('serviceWorker' in navigator) {
 
           newWorker.addEventListener('statechange', () => {
             if (newWorker.state === 'installed' && navigator.serviceWorker.controller) {
-              document.dispatchEvent(new CustomEvent('nukebg:sw-update-available'));
+              emit(document, 'nukebg:sw-update-available', undefined);
             }
           });
         };
 
         // Check if there's already a waiting worker
         if (registration.waiting && navigator.serviceWorker.controller) {
-          document.dispatchEvent(new CustomEvent('nukebg:sw-update-available'));
+          emit(document, 'nukebg:sw-update-available', undefined);
         }
 
         registration.addEventListener('updatefound', onUpdateFound);
@@ -54,6 +56,6 @@ if ('serviceWorker' in navigator) {
   window.addEventListener('beforeinstallprompt', (e) => {
     e.preventDefault();
     deferredPrompt = e as BeforeInstallPromptEvent;
-    document.dispatchEvent(new CustomEvent('nukebg:pwa-installable'));
+    emit(document, 'nukebg:pwa-installable', undefined);
   });
 }


### PR DESCRIPTION
## Summary

Follows up the foundation PR (#220). Migrates every remaining \`dispatchEvent(new CustomEvent(...))\` to \`emit(target, name, detail, opts)\` and every cross-component \`addEventListener\` to \`on(target, name, handler, { signal })\`. Drops the last 6 \`(e as CustomEvent<...>).detail\` casts at consumer sites.

## What this closes

The acceptance criteria of #217:

- ✅ Zero \`as CustomEvent<...>\` casts in any consumer (only 2 remain inside \`src/lib/event-bus.ts\` — one comment, one internal helper impl)
- ✅ All cross-component subscriptions use \`{ signal }\`
- ✅ \`emit('ar:image-loded', ...)\` is now a compile error
- ✅ Public event surface (names + payloads) unchanged at runtime
- ✅ No manual \`removeEventListener\` in any \`disconnectedCallback\` for the migrated events

## Migrated

**Dispatchers (10 files):**
- \`ar-batch-grid.ts\`, \`ar-batch-item.ts\`, \`ar-download.ts\`, \`ar-dropzone.ts\`, \`ar-progress.ts\`, \`ar-editor.ts\`, \`ar-editor-advanced.ts\`, \`ar-app.ts\` (3 dispatch sites)
- \`sw-register.ts\`, \`i18n/index.ts\`

**Listeners (in \`ar-app.ts\`):**
- 11 listeners on \`this.shadowRoot\` and \`this.progress\` migrated to \`on()\` with destructured detail

## Validation

| Gate | Result |
|------|--------|
| \`npm run typecheck\` | ✅ green |
| \`npm test\` | ✅ **935/935** |
| \`npm run build\` | ✅ green |

## Bundle delta

| Metric | Before #220 | This PR | Cumulative since v2.9.5 |
|--------|-------------|---------|--------------------------|
| index.js raw | 459.49 kB | **458.80 kB** | **−8.11 kB / −1.74%** |
| index.js gzip | 124.50 kB | **124.49 kB** | **−1.17 kB / −0.93%** |

The typed bus is *strictly leaner* than the manual dispatch + cast pattern.

Closes #217.