### PR TITLE
ci(e2e): rename coche-capture so it runs last after warmup specs (#160)

### DIFF
--- a/e2e/z-coche-capture.spec.ts
+++ b/e2e/z-coche-capture.spec.ts
@@ -9,13 +9,13 @@ const OUT_DIR = resolve(__dirname, '../.halo-check');
 
 test.describe.configure({ mode: 'serial' });
 
+// File renamed `z-coche-capture` so Playwright's alphabetical scheduling
+// puts it LAST in the pipeline e2e suite (#160). The smaller-fixture
+// specs (football 11 KB, motostest 565 KB) now absorb the cold-start ML
+// warmup; coche runs warm in well under a minute. 240s budget = 4x slack
+// vs typical warm runs.
 test('capture coche output + mirror console/network', async ({ page }, testInfo) => {
-  // First spec in serial mode → pays full cold-start ML warmup
-  // (model download + WASM init + first inference). On CI runners this
-  // routinely takes 4–5 minutes; the previous 200s/240s budget timed
-  // out consistently. The follow-up specs (football, motostest) reuse
-  // the warm pipeline and finish well under their own budgets.
-  test.setTimeout(360_000);
+  test.setTimeout(240_000);
   mkdirSync(OUT_DIR, { recursive: true });
 
   const logs: string[] = [];
@@ -28,7 +28,7 @@ test('capture coche output + mirror console/network', async ({ page }, testInfo)
   await fileInput.setInputFiles(FIXTURE);
 
   const downloadBtn = page.locator('ar-download').locator('#dl-png');
-  await expect(downloadBtn).toHaveAttribute('href', /^blob:/, { timeout: 300_000 });
+  await expect(downloadBtn).toHaveAttribute('href', /^blob:/, { timeout: 180_000 });
 
   const outPath = resolve(OUT_DIR, `coche.png`);
   const downloadPromise = page.waitForEvent('download');


### PR DESCRIPTION
## Summary

Reorders the Playwright pipeline e2e suite so the smaller-fixture specs absorb the cold-start ML warmup before coche-capture runs.

\`\`\`
Before: coche (cold, 360s budget) → football → motostest → ...
After:  football (cold) → motostest → ... → z-coche (warm, 240s)
\`\`\`

Playwright sorts spec files alphabetically. Renaming \`coche-capture.spec.ts\` → \`z-coche-capture.spec.ts\` puts it last in the run order. Football (11 KB fixture) and motostest (565 KB) pay the WASM init + first-inference cost up front; by the time coche fires, the model and ONNX session are hot and the timing matches a typical 30-60s warm run.

## Timeout changes

| | Before | After | Reason |
|--|--------|-------|--------|
| Test timeout | 360s | **240s** | warm run, no cold-start absorption needed |
| Download-blob wait | 300s | **180s** | same |

3-4x slack over warm-run baselines still leaves room for genuine regressions to surface. Cold-start variance no longer flakes.

## Why renaming the file is the cleanest lever

Playwright's \`testMatch\` is for filtering, not ordering. \`globalSetup\` doesn't help because the model lives in the page's worker, not on disk between runs. Renaming the file is the most direct way to control execution order without adding workflow complexity.

## Risk

If something else in the pipeline e2e suite is itself dependent on coche running first, this would break it. Audited the other specs — none reference coche by name or order.

## Validation

The actual fix lands in CI when the e2e job runs on this PR's merge commit. Until then we can only verify the rename + timeout edits compile + lint clean.

| Gate | Result |
|------|--------|
| \`npm run typecheck\` | ✅ green |
| Local lint | ✅ green |

## Roll-back

If still flakes after the next 2-3 CI runs, follow-up is to cache the Playwright \`userDataDir\` between runs (workflow change). For now: revert this rename and bump the timeout back to 360s.

Closes #160.