### PR TITLE
fix(pipeline): retire color-deviation watermarkDetect to kill false positives

### DIFF
--- a/src/pipeline/orchestrator.ts
+++ b/src/pipeline/orchestrator.ts
@@ -2,7 +2,6 @@ import type {
   PipelineStage,
   StageStatus,
   PipelineResult,
-  BgColorResult,
   WatermarkResult,
   ImageContentType,
 } from '../types/pipeline';
@@ -579,19 +578,14 @@ export class PipelineOrchestrator {
     let t = performance.now();
     this.emit('detect-background', 'running', 'Analyzing image...');
 
-    // Run bg detection and content classification in parallel
-    const [bgInfo, classifyResult] = await Promise.all([
-      this.cvCall<BgColorResult>('detect-bg-colors', {
-        pixels: new Uint8ClampedArray(imageData.data),
-        width,
-        height,
-      }),
-      this.cvCall<ClassifyImageResult>('classify-image', {
-        pixels: new Uint8ClampedArray(imageData.data),
-        width,
-        height,
-      }),
-    ]);
+    // bg-color detection retired alongside watermarkDetect (its only
+    // consumer) — see watermark-scan stage below for context. Classifier
+    // still runs.
+    const classifyResult = await this.cvCall<ClassifyImageResult>('classify-image', {
+      pixels: new Uint8ClampedArray(imageData.data),
+      width,
+      height,
+    });
 
     const contentType: ImageContentType = classifyResult.type;
     stageTiming['detect-background'] = performance.now() - t;
@@ -635,14 +629,14 @@ export class PipelineOrchestrator {
       t = performance.now();
       this.emit('watermark-scan', 'running', 'Checking for watermarks...');
 
-      const [wmGemini, wmDalle, wmSparkle] = await Promise.all([
-        this.cvCall<WatermarkResult>('watermark-detect', {
-          pixels: new Uint8ClampedArray(imageData.data),
-          width,
-          height,
-          colorA: bgInfo.colorA,
-          colorB: bgInfo.colorB,
-        }),
+      // Color-deviation watermarkDetect retired: it had no shape gate so it
+      // false-positived on real photos with bright clustered features in
+      // the bottom-right (motorbike chrome, skin highlights in portraits,
+      // etc.). The shape-based sparkleDetect handles Gemini sparkles
+      // robustly; watermarkDetectDalle handles the multicolor bar.
+      // Reference: motostest + selfie-clean-corner regression triage,
+      // 2026-04-28.
+      const [wmDalle, wmSparkle] = await Promise.all([
         this.cvCall<WatermarkResult>('watermark-detect-dalle', {
           pixels: new Uint8ClampedArray(imageData.data),
           width,
@@ -655,15 +649,14 @@ export class PipelineOrchestrator {
         }),
       ]);
 
-      const anyWatermark = wmGemini.detected || wmDalle.detected || wmSparkle.detected;
+      const anyWatermark = wmDalle.detected || wmSparkle.detected;
       const combinedMask = PipelineOrchestrator.combineMasks(
-        [wmGemini.mask, wmDalle.mask, wmSparkle.mask],
+        [wmDalle.mask, wmSparkle.mask],
         width * height,
       );
 
       if (anyWatermark && combinedMask) {
         const sources: string[] = [];
-        if (wmGemini.detected) sources.push('Gemini');
         if (wmDalle.detected) sources.push('DALL-E');
         if (wmSparkle.detected) sources.push('Gemini-shape');
         this.emit('watermark-scan', 'done', `Watermark detected [${sources.join(', ')}]`);


### PR DESCRIPTION
## Summary

Manual dev testing surfaced two false-positive watermark detections:
- **motostest.jpeg** — flagged a watermark in the bottom-right where there is none. Bright motorcycle chrome triggered the legacy color-deviation detector.
- **selfie-clean-corner.png** — same path. Skin highlights in the corner trip it.

Both are real photos; the fixture name "clean-corner" makes the bug self-documenting.

## Root cause

The legacy \`watermarkDetect\` (Gemini color-deviation) counts pixels that:
1. Deviate from the two background reference colors (\`colorA\`, \`colorB\`)
2. Match a near-white sparkle palette
3. Cluster within a generous distance of their centroid

It **never checks shape**, so any tight cluster of bright pixels in the bottom-right fires it. Real-world photos with bright clustered features in the corner false-positive routinely.

## Fix

Drop the legacy \`watermarkDetect\` cvCall from the orchestrator's Stage 2. Keep:
- **\`sparkleDetect\`** (shape-based, 6 strict gates: 4-arm symmetry, narrow-arm isolation, center peak, etc.) — handles real Gemini sparkle ✦.
- **\`watermarkDetectDalle\`** — handles the multicolor-bar variant.

Together they cover both real watermark families without the false-positive surface.

Verified against the fixture set:

| Fixture | Before | After |
|---------|--------|-------|
| motostest.jpeg | ❌ false positive | ✅ no detect |
| selfie-clean-corner.png | ❌ false positive | ✅ no detect |
| selfie-sparkle-full.png | ✅ detected (color + shape) | ✅ detected (shape) |
| coche.jpg | ✅ no detect | ✅ no detect |
| football.webp | ✅ no detect | ✅ no detect |
| trump-clean.png | ✅ no detect | ✅ no detect |

## Knock-on cleanups

- Drop \`detect-bg-colors\` cvCall — its only consumer was \`watermarkDetect\`. Saves a worker round-trip.
- Drop the \`bgInfo\` destructure + \`BgColorResult\` import.
- Update \`watermark-scan\` emit sources list to drop the now-unreachable \`Gemini\` label.

Worker-side files (\`watermark-detect.ts\`, \`detect-bg-colors.ts\`, \`simple-flood-fill.ts\`) left in place. They're no longer wired to the pipeline; dead-code cleanup is a separate concern.

## Validation

| Gate | Result |
|------|--------|
| \`npm run typecheck\` | ✅ green |
| \`npm test\` | ✅ **935/935** |
| Manual fixture sweep | ✅ no regressions on positive cases |

Reported during manual dev testing, 2026-04-28.