### PR TITLE
fix(pipeline): dropOrphanBlobs keeps disconnected real subject parts

### DIFF
--- a/src/pipeline/finalize.ts
+++ b/src/pipeline/finalize.ts
@@ -262,16 +262,75 @@ export function fillSubjectHoles(
  * Caveat: inappropriate for classes where legitimate subject lives in
  * multiple disconnected components (signatures with accent dots, icon sets).
  * Callers must gate by content type.
+ *
+ * Threshold policy: a blob survives if its size is ≥ max(2, largest *
+ * KEEP_RATIO). The earlier "keep only the single largest" rule was too
+ * aggressive — RMBG occasionally splits a real subject into two
+ * disconnected blobs (e.g. a car body separated by a sun-glare chrome
+ * stripe down the middle), and the smaller half got mis-killed as an
+ * "orphan". 1% of largest preserves real disconnected subject parts
+ * while still dropping the small false-positive specks the function
+ * was added to clean. The hard floor of 2 px is just a sanity gate
+ * for tiny canvases (test fixtures); on real-world inputs the relative
+ * threshold dominates.
  */
+const ORPHAN_KEEP_RATIO = 0.01; // ≥1% of the largest blob
+
 export function dropOrphanBlobs(img: ImageData): ImageData {
   const { data, width, height } = img;
   const n = width * height;
   const bin = new Uint8Array(n);
   for (let i = 0; i < n; i++) bin[i] = data[i * 4 + 3] > 0 ? 1 : 0;
-  keepLargestComponent(bin, width, height);
+
+  // Label connected components (8-connectivity, BFS) and record sizes.
+  const labels = new Int32Array(n);
+  const queue = new Int32Array(n);
+  const sizes: number[] = [0]; // id 0 = background
+  let nextId = 0;
+
+  for (let i = 0; i < n; i++) {
+    if (bin[i] === 0 || labels[i] !== 0) continue;
+    nextId++;
+    labels[i] = nextId;
+    let head = 0;
+    let tail = 0;
+    queue[tail++] = i;
+    let size = 0;
+    while (head < tail) {
+      const idx = queue[head++];
+      size++;
+      const x = idx % width;
+      const y = (idx - x) / width;
+      for (let dy = -1; dy <= 1; dy++) {
+        for (let dx = -1; dx <= 1; dx++) {
+          if (dx === 0 && dy === 0) continue;
+          const nx = x + dx;
+          const ny = y + dy;
+          if (nx < 0 || nx >= width || ny < 0 || ny >= height) continue;
+          const ni = ny * width + nx;
+          if (bin[ni] && labels[ni] === 0) {
+            labels[ni] = nextId;
+            queue[tail++] = ni;
+          }
+        }
+      }
+    }
+    sizes.push(size);
+  }
+
+  if (nextId < 2) return img; // 0 or 1 blob → nothing to drop
+
+  let maxSize = 0;
+  for (let id = 1; id <= nextId; id++) {
+    if (sizes[id] > maxSize) maxSize = sizes[id];
+  }
+  const threshold = Math.max(2, Math.floor(maxSize * ORPHAN_KEEP_RATIO));
+
   const out = new Uint8ClampedArray(data);
   for (let i = 0; i < n; i++) {
-    if (!bin[i]) out[i * 4 + 3] = 0;
+    if (bin[i] && sizes[labels[i]] < threshold) {
+      out[i * 4 + 3] = 0;
+    }
   }
   return new ImageData(out, width, height);
 }

--- a/tests/pipeline/finalize.test.ts
+++ b/tests/pipeline/finalize.test.ts
@@ -361,6 +361,62 @@ describe('dropOrphanBlobs', () => {
     dropOrphanBlobs(new ImageData(data, w, h));
     expect(Array.from(data)).toEqual(snapshot);
   });
+
+  it('preserves a substantial second blob (regression: coche right-side cropping)', () => {
+    // Reproduces the bug pattern: a real subject split by RMBG into two
+    // disconnected blobs. The smaller half must survive when it's a real
+    // chunk of the subject (not a tiny speck). Earlier the function
+    // dropped EVERY non-largest blob — even ones that were ~30% of main.
+    //
+    // 100x100 canvas. Left half body (50x100=5000 px) + right half body
+    // (40x100=4000 px) separated by a 10-px-wide α=0 stripe. Expected:
+    // both blobs survive (4000 ≥ max(2, 5000*0.01)=50).
+    const w = 100,
+      h = 100;
+    const data = new Uint8ClampedArray(w * h * 4);
+    for (let y = 0; y < h; y++) {
+      for (let x = 0; x < w; x++) {
+        const i = (y * w + x) * 4;
+        data[i] = 200;
+        data[i + 1] = 100;
+        data[i + 2] = 50;
+        // Body covers all rows; gap from x=45..54 is α=0.
+        data[i + 3] = x >= 45 && x <= 54 ? 0 : 255;
+      }
+    }
+
+    const out = dropOrphanBlobs(new ImageData(data, w, h));
+
+    // Left blob (largest) survives
+    expect(out.data[(50 * w + 10) * 4 + 3]).toBe(255);
+    // Right blob (smaller but substantial) ALSO survives — the regression
+    expect(out.data[(50 * w + 80) * 4 + 3]).toBe(255);
+  });
+
+  it('still drops tiny orphan specks under the relative threshold', () => {
+    // 100x100 canvas. Big body 50x50 (2500 px) + a 5-pixel speck. Speck
+    // size 5 < threshold max(2, 2500*0.01)=25 → dropped.
+    const w = 100,
+      h = 100;
+    const data = new Uint8ClampedArray(w * h * 4);
+    for (let y = 10; y < 60; y++) {
+      for (let x = 10; x < 60; x++) {
+        data[(y * w + x) * 4 + 3] = 255;
+      }
+    }
+    // 5-pixel horizontal speck at bottom-right corner.
+    for (let x = 90; x < 95; x++) {
+      data[(95 * w + x) * 4 + 3] = 255;
+    }
+
+    const out = dropOrphanBlobs(new ImageData(data, w, h));
+    // Body intact
+    expect(out.data[(30 * w + 30) * 4 + 3]).toBe(255);
+    // Speck dropped
+    for (let x = 90; x < 95; x++) {
+      expect(out.data[(95 * w + x) * 4 + 3]).toBe(0);
+    }
+  });
 });
 
 describe('fillSubjectHoles', () => {


### PR DESCRIPTION
## Summary

Manual dev testing surfaced: **coche.jpg loses its right side** after RMBG segmentation. The right half is identified as background and cropped out.

## Root cause

The user's exact memory of the original change was right — \`dropOrphanBlobs\` (commit \`fc3a8d8\`) was added to clean up tiny false-positive alpha blobs (sky reflections, watermark fragments). It calls \`keepLargestComponent\`, which keeps **only the single largest connected blob** and zeros everything else.

When RMBG produces a mask where a real subject is **split into two disconnected blobs** — typical with a chrome stripe, glare, or shadow down the middle of a car — the smaller half gets dropped as an "orphan", even when it's clearly part of the subject.

## Fix

Switch from "single largest only" to a **threshold rule**:

```
keep blob if size ≥ max(2, largest * 1%)
```

- Tiny false-positive specks (50-px sky reflection): below threshold → dropped ✓
- Real disconnected subject parts (5K-30K px disconnected mirror, half a car): above threshold → kept ✓
- The hard floor of 2 px is just a sanity gate for the unit-test canvases (5×5, 7×7); on real-world inputs the relative threshold dominates.

For a typical 1024×768 image with a 200K-px main subject, threshold = 2000 px. A 50-px sky speck still dies; a 5000-px disconnected mirror now survives.

## Tests

Added 2 regression-guarding tests in \`tests/pipeline/finalize.test.ts\`:

1. **"preserves a substantial second blob"** — 100×100 canvas, body split into two halves by a 10-px α=0 stripe. Locks the new behavior. With the old code: smaller half dropped. With the new: both kept.
2. **"still drops tiny orphan specks under the relative threshold"** — 100×100 canvas with a 2500-px body and a 5-px speck. Threshold = 25 (1% of 2500); speck size 5 < threshold → dropped. Proves the anti-speck intent of the original function still holds.

Existing tests on 5×5/7×7 canvases keep passing (the absolute floor of 2 covers them).

## Validation

| Gate | Result |
|------|--------|
| \`npm run typecheck\` | ✅ green |
| \`npm test\` | ✅ **937/937** (935 + 2 new) |

## Known limit

If RMBG produces a real subject split into a main blob + a 0.5%-of-largest disconnected piece (e.g. a thin antenna or a small wheel), it'd still get dropped (below 1% relative threshold). The trade-off is intentional: real subjects under 1% of the main body are too easy to confuse with false-positive specks. If we hit that case in practice we can revisit the threshold.

Reported during manual dev testing, 2026-04-28.