### PR TITLE
fix(sparkle): bump mask radius 1.15→1.5 to cover natural halo

### DIFF
--- a/src/pipeline/constants.ts
+++ b/src/pipeline/constants.ts
@@ -59,9 +59,17 @@ export const SPARKLE_PARAMS = {
    *  neighbors. Real Gemini sparkle arms are narrow lines — perpendicular
    *  samples land in dark gap territory. */
   MAX_PERP_ARM_RATIO: 0.8,
-  /** Mask radius multiplier (applied to detected sparkle radius). Tight fit
-   *  minimises the area Telea has to reconstruct — less "flat patch" look. */
-  MASK_RADIUS_MULTIPLIER: 1.15,
+  /** Mask radius multiplier (applied to detected sparkle radius).
+   *
+   *  Bumped 1.15 → 1.5 (#223 follow-up) after the legacy color-deviation
+   *  watermarkDetect was retired — that detector contributed a wider halo
+   *  mask (up to 2.0× radius gated by sparkle palette). At 1.15× the new
+   *  combined mask was too tight: residual near-white halo pixels just
+   *  outside the shape were left untouched by Telea, then RMBG correctly
+   *  classified them as background — visible as transparent dots around
+   *  the inpainted sparkle. 1.5× covers the natural halo without the
+   *  "flat patch" look becoming distracting. */
+  MASK_RADIUS_MULTIPLIER: 1.5,
 } as const;
 
 export const DALLE_WATERMARK_PARAMS = {


### PR DESCRIPTION
## Summary

Follow-up to #223. Manual dev testing on \`selfie-sparkle-full.png\` shows transparent dots around where the sparkle used to be — a regression from retiring the legacy color-deviation \`watermarkDetect\`.

## Why this happened

The legacy \`watermarkDetect\` (retired in #223 because it false-positived on real photos) contributed a wider mask via its halo logic:
- inner core: 1.3 × radius
- outer halo ring: up to 2.0 × radius, but only adding pixels matching the sparkle palette

After retirement, the combined mask reduced to just \`sparkleDetect\`'s tight 1.15 × radius. Telea inpainted that smaller area; the near-white halo pixels just outside survived. Then RMBG ran on the post-inpaint image and correctly classified those residual near-white pixels as background — visible as transparent dots in the result.

## Fix

Bump \`SPARKLE_PARAMS.MASK_RADIUS_MULTIPLIER\` from 1.15 to 1.5. Telea now reconstructs a slightly larger area, eliminating the residual halo. The "flat patch" look that motivated the original 1.15 becomes slightly more visible but remains well below the legacy 2.0 halo radius — should be a reasonable middle ground.

If this still leaves residual halo on edge cases, the next step is to port the legacy palette-gated halo expansion into \`sparkleDetect\` itself (anchored to a confirmed sparkle, not as a primary detector — that's what gave the false positives).

## Validation

| Gate | Result |
|------|--------|
| \`npm run typecheck\` | ✅ green |
| \`npm test\` | ✅ **937/937** (no unit test exercises the multiplier; selfie-sparkle-full is covered via e2e) |

Reported during manual dev testing, 2026-04-28.