### PR TITLE
release: v2.10.2 — typed event-bus + pipeline correctness fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,77 @@ Unreleased entries accumulate on the `dev` branch. When we cut a release we copy
 
 ## [Unreleased]
 
+## [2.10.2] — 2026-04-28
+
+Patch release. Six PRs landed since v2.10.1 — typed event-bus migration,
+two pipeline correctness fixes (watermark false-positive + disconnected
+subject preservation), one sparkle halo coverage fix, and the CI flake
+fix from #160.
+
+### Fixed
+
+- **Watermark detector no longer false-positives on real photos.** The
+  legacy color-deviation \`watermarkDetect\` flagged motostest.jpeg and
+  selfie-clean-corner.png as containing Gemini sparkle when they don't.
+  Cause: it counted bright clustered pixels in the bottom-right without
+  any shape gate. Retired in favor of the existing shape-based
+  \`sparkleDetect\` (6 strict gates: 4-arm symmetry, narrow-arm
+  isolation, center peak vs outer ring, etc.) and \`watermarkDetectDalle\`
+  (multicolor bar). Together they cover both real watermark families
+  without the false-positive surface
+  ([#223](https://github.com/yocreoquesi/nukebg/pull/223)).
+- **Disconnected real subject parts no longer get dropped as orphan
+  blobs.** \`coche.jpg\` lost its right side after segmentation because
+  RMBG produced a mask split into two disconnected blobs (a sun-glare
+  chrome stripe down the middle), and the previous \`dropOrphanBlobs\`
+  kept only the single largest. Switched to a 1%-of-largest threshold:
+  tiny false-positive specks (50-px sky reflections) still die; real
+  disconnected subject parts (5K-30K px) survive
+  ([#224](https://github.com/yocreoquesi/nukebg/pull/224)).
+- **Sparkle inpaint mask covers the natural halo again.** Follow-up to
+  #223. After retiring the legacy detector its halo logic went with it,
+  leaving the shape detector's tight 1.15× radius mask. Telea then
+  inpainted too small an area; near-white halo pixels survived and RMBG
+  classified them as background — visible as transparent dots around
+  inpainted sparkles. Bumped \`MASK_RADIUS_MULTIPLIER\` 1.15 → 1.5 to
+  cover the typical halo
+  ([#225](https://github.com/yocreoquesi/nukebg/pull/225)).
+- **e2e \`coche-capture\` no longer flakes on CI cold-start.** Renamed
+  to \`z-coche-capture.spec.ts\` so Playwright's alphabetical scheduling
+  runs it last. Football (11 KB fixture) and motostest (565 KB) absorb
+  the cold-start ML warmup; coche then runs warm in well under a minute
+  ([#222](https://github.com/yocreoquesi/nukebg/pull/222), closes
+  [#160](https://github.com/yocreoquesi/nukebg/issues/160)).
+
+### Changed
+
+- **Cross-component custom events now go through a typed event-bus.**
+  New \`src/lib/event-bus.ts\` exposes a \`NukeBgEventMap\` covering all
+  15 \`ar:_\` / \`batch:_\` / \`nukebg:\*\` events plus typed \`emit()\` and
+  \`on()\` helpers. \`on()\` requires an \`AbortSignal\` so cleanup ties to
+  component lifecycle; the manual \`boundLocaleHandler\` +
+  \`removeEventListener\` pattern across 9 components is gone. Every
+  consumer-side \`(e as CustomEvent<...>).detail\` cast retired — the
+  bus types the detail by event name. Public event surface unchanged
+  at runtime ([#220](https://github.com/yocreoquesi/nukebg/pull/220),
+  [#221](https://github.com/yocreoquesi/nukebg/pull/221), closes
+  [#217](https://github.com/yocreoquesi/nukebg/issues/217) and the
+  outstanding Phase 4 of [#47](https://github.com/yocreoquesi/nukebg/issues/47)).
+
+### Notes
+
+- Test count: 928 → 937 across the cycle (event-bus tests + 2 new
+  dropOrphanBlobs regression-guards).
+- Bundle \`index.js\` raw: 460.15 → 458.99 kB (−1.16 kB; the typed bus is
+  strictly leaner than the manual pattern, the sparkle radius bump from
+  #225 nudged 0.19 kB back).
+- Known limitation tracked in
+  [#226](https://github.com/yocreoquesi/nukebg/issues/226): RMBG-1.4
+  occasionally mis-segments the lower portion of thin chrome features
+  near subject edges (motostest front brake disc). Predates this cycle
+  by ~1 month; out-of-scope for the post-process layer until a better
+  permissive model is available (semi-annual model-market scan).
+
 ## [2.10.1] — 2026-04-28
 
 Patch release. Two follow-ups to v2.10.0 — bundle drops another 5 kB

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 > Nuke backgrounds from any image. 100% client-side. Zero uploads. Zero BS.
 
-[![Version](https://img.shields.io/badge/version-2.10.1-brightgreen.svg)](https://github.com/yocreoquesi/nukebg/releases)
+[![Version](https://img.shields.io/badge/version-2.10.2-brightgreen.svg)](https://github.com/yocreoquesi/nukebg/releases)
 [![License: GPL-3.0](https://img.shields.io/badge/License-GPL%20v3-blue.svg)](https://www.gnu.org/licenses/gpl-3.0)
 [![Client-Side](https://img.shields.io/badge/Processing-100%25%20Client--Side-green.svg)](#-privacy)
 

--- a/index.html
+++ b/index.html
@@ -151,7 +151,7 @@
           "PNG export with true alpha transparency"
         ],
         "screenshot": "https://nukebg.app/og-image.png",
-        "softwareVersion": "2.10.1",
+        "softwareVersion": "2.10.2",
         "license": "https://www.gnu.org/licenses/gpl-3.0.html",
         "isAccessibleForFree": true,
         "creator": {
@@ -487,7 +487,7 @@
     <!-- <ar-post-cta id="post-cta"></ar-post-cta> -->
 
     <footer class="footer hazard-border-top" role="contentinfo">
-      <span>NukeBG <span style="color: var(--color-text-tertiary)">v2.10.1</span></span>
+      <span>NukeBG <span style="color: var(--color-text-tertiary)">v2.10.2</span></span>
       <span class="footer-sep">|</span>
       <a href="https://github.com/yocreoquesi/nukebg" target="_blank" rel="noopener noreferrer"
         >GitHub</a

--- a/infra/nginx.conf
+++ b/infra/nginx.conf
@@ -31,7 +31,7 @@ server {
     #   new Function() WASM bootstrap.
     # - sha256 hashes cover the 3 inline JSON-LD blocks in index.html.
     #   Regenerate with `node scripts/compute-csp-hashes.mjs` after edits.
-    add_header Content-Security-Policy "default-src 'self'; script-src 'self' blob: 'wasm-unsafe-eval' 'unsafe-eval' 'sha256-mZ64a3L9XwFvMokuQ8cmY68GpB2ucLc0WGmYWF8EKQY=' 'sha256-uZm4Xh9FxR3B7WjPHL5pbehtSMYTCy9JWzQzl3/UKA0=' 'sha256-o1DLxvGFHY9H1AG6Sro58slSTxU3T7zb020gfyqbFwM=' https://cdn.jsdelivr.net; worker-src 'self' blob:; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; connect-src 'self' https://huggingface.co https://cdn-lfs.huggingface.co https://cdn-lfs-us-1.huggingface.co https://cdn.jsdelivr.net https://cas-bridge.xethub.hf.co; font-src 'self'; object-src 'none'; base-uri 'self'; form-action 'none'" always;
+    add_header Content-Security-Policy "default-src 'self'; script-src 'self' blob: 'wasm-unsafe-eval' 'unsafe-eval' 'sha256-suL/7MXuEJxulF14znTnwjBHbgB7E1bNMb9DQbFnvao=' 'sha256-uZm4Xh9FxR3B7WjPHL5pbehtSMYTCy9JWzQzl3/UKA0=' 'sha256-o1DLxvGFHY9H1AG6Sro58slSTxU3T7zb020gfyqbFwM=' https://cdn.jsdelivr.net; worker-src 'self' blob:; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; connect-src 'self' https://huggingface.co https://cdn-lfs.huggingface.co https://cdn-lfs-us-1.huggingface.co https://cdn.jsdelivr.net https://cas-bridge.xethub.hf.co; font-src 'self'; object-src 'none'; base-uri 'self'; form-action 'none'" always;
 
     # Cache static assets
     # Note: add_header in location blocks replaces parent headers in nginx,
@@ -46,7 +46,7 @@ server {
         add_header Strict-Transport-Security "max-age=63072000; includeSubDomains; preload" always;
         add_header Cross-Origin-Opener-Policy "same-origin" always;
         add_header X-DNS-Prefetch-Control "off" always;
-        add_header Content-Security-Policy "default-src 'self'; script-src 'self' blob: 'wasm-unsafe-eval' 'unsafe-eval' 'sha256-mZ64a3L9XwFvMokuQ8cmY68GpB2ucLc0WGmYWF8EKQY=' 'sha256-uZm4Xh9FxR3B7WjPHL5pbehtSMYTCy9JWzQzl3/UKA0=' 'sha256-o1DLxvGFHY9H1AG6Sro58slSTxU3T7zb020gfyqbFwM=' https://cdn.jsdelivr.net; worker-src 'self' blob:; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; connect-src 'self' https://huggingface.co https://cdn-lfs.huggingface.co https://cdn-lfs-us-1.huggingface.co https://cdn.jsdelivr.net https://cas-bridge.xethub.hf.co; font-src 'self'; object-src 'none'; base-uri 'self'; form-action 'none'" always;
+        add_header Content-Security-Policy "default-src 'self'; script-src 'self' blob: 'wasm-unsafe-eval' 'unsafe-eval' 'sha256-suL/7MXuEJxulF14znTnwjBHbgB7E1bNMb9DQbFnvao=' 'sha256-uZm4Xh9FxR3B7WjPHL5pbehtSMYTCy9JWzQzl3/UKA0=' 'sha256-o1DLxvGFHY9H1AG6Sro58slSTxU3T7zb020gfyqbFwM=' https://cdn.jsdelivr.net; worker-src 'self' blob:; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; connect-src 'self' https://huggingface.co https://cdn-lfs.huggingface.co https://cdn-lfs-us-1.huggingface.co https://cdn.jsdelivr.net https://cas-bridge.xethub.hf.co; font-src 'self'; object-src 'none'; base-uri 'self'; form-action 'none'" always;
     }
 
     # ONNX model files — cache aggressively, same-origin so CORP is fine
@@ -60,7 +60,7 @@ server {
         add_header Strict-Transport-Security "max-age=63072000; includeSubDomains; preload" always;
         add_header Cross-Origin-Opener-Policy "same-origin" always;
         add_header X-DNS-Prefetch-Control "off" always;
-        add_header Content-Security-Policy "default-src 'self'; script-src 'self' blob: 'wasm-unsafe-eval' 'unsafe-eval' 'sha256-mZ64a3L9XwFvMokuQ8cmY68GpB2ucLc0WGmYWF8EKQY=' 'sha256-uZm4Xh9FxR3B7WjPHL5pbehtSMYTCy9JWzQzl3/UKA0=' 'sha256-o1DLxvGFHY9H1AG6Sro58slSTxU3T7zb020gfyqbFwM=' https://cdn.jsdelivr.net; worker-src 'self' blob:; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; connect-src 'self' https://huggingface.co https://cdn-lfs.huggingface.co https://cdn-lfs-us-1.huggingface.co https://cdn.jsdelivr.net https://cas-bridge.xethub.hf.co; font-src 'self'; object-src 'none'; base-uri 'self'; form-action 'none'" always;
+        add_header Content-Security-Policy "default-src 'self'; script-src 'self' blob: 'wasm-unsafe-eval' 'unsafe-eval' 'sha256-suL/7MXuEJxulF14znTnwjBHbgB7E1bNMb9DQbFnvao=' 'sha256-uZm4Xh9FxR3B7WjPHL5pbehtSMYTCy9JWzQzl3/UKA0=' 'sha256-o1DLxvGFHY9H1AG6Sro58slSTxU3T7zb020gfyqbFwM=' https://cdn.jsdelivr.net; worker-src 'self' blob:; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; connect-src 'self' https://huggingface.co https://cdn-lfs.huggingface.co https://cdn-lfs-us-1.huggingface.co https://cdn.jsdelivr.net https://cas-bridge.xethub.hf.co; font-src 'self'; object-src 'none'; base-uri 'self'; form-action 'none'" always;
     }
 
     # SPA fallback

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "nukebg",
-  "version": "2.10.1",
+  "version": "2.10.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "nukebg",
-      "version": "2.10.1",
+      "version": "2.10.2",
       "license": "GPL-3.0-only",
       "dependencies": {
         "@huggingface/transformers": "^3.8.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "nukebg",
   "private": true,
-  "version": "2.10.1",
+  "version": "2.10.2",
   "type": "module",
   "description": "NukeBG: Nuke AI backgrounds, checkerboard patterns, and watermarks. 100% client-side. Zero uploads. Zero BS.",
   "license": "GPL-3.0-only",

--- a/public/_headers
+++ b/public/_headers
@@ -7,7 +7,7 @@
   Cross-Origin-Resource-Policy: same-origin
   X-DNS-Prefetch-Control: off
   Strict-Transport-Security: max-age=63072000; includeSubDomains; preload
-  Content-Security-Policy: default-src 'self'; script-src 'self' blob: 'wasm-unsafe-eval' 'unsafe-eval' 'sha256-mZ64a3L9XwFvMokuQ8cmY68GpB2ucLc0WGmYWF8EKQY=' 'sha256-uZm4Xh9FxR3B7WjPHL5pbehtSMYTCy9JWzQzl3/UKA0=' 'sha256-o1DLxvGFHY9H1AG6Sro58slSTxU3T7zb020gfyqbFwM=' https://cdn.jsdelivr.net; worker-src 'self' blob:; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; connect-src 'self' https://huggingface.co https://cdn-lfs.huggingface.co https://cdn-lfs-us-1.huggingface.co https://cdn.jsdelivr.net https://cas-bridge.xethub.hf.co; font-src 'self'; object-src 'none'; base-uri 'self'; form-action 'none'
+  Content-Security-Policy: default-src 'self'; script-src 'self' blob: 'wasm-unsafe-eval' 'unsafe-eval' 'sha256-suL/7MXuEJxulF14znTnwjBHbgB7E1bNMb9DQbFnvao=' 'sha256-uZm4Xh9FxR3B7WjPHL5pbehtSMYTCy9JWzQzl3/UKA0=' 'sha256-o1DLxvGFHY9H1AG6Sro58slSTxU3T7zb020gfyqbFwM=' https://cdn.jsdelivr.net; worker-src 'self' blob:; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; connect-src 'self' https://huggingface.co https://cdn-lfs.huggingface.co https://cdn-lfs-us-1.huggingface.co https://cdn.jsdelivr.net https://cas-bridge.xethub.hf.co; font-src 'self'; object-src 'none'; base-uri 'self'; form-action 'none'
 
 /assets/*
   Cache-Control: public, max-age=31536000, immutable

--- a/src/main.ts
+++ b/src/main.ts
@@ -166,7 +166,7 @@ function createShortcutOverlay(): HTMLDivElement {
 function showConsoleLogo(): void {
   const logo = `
 %c    ☢ NUKEBG ☢
-    v2.10.1 | Terminal Edition
+    v2.10.2 | Terminal Edition
 
     Your images never leave this machine.
     Don't believe us? Read the source:

--- a/src/utils/image-io.ts
+++ b/src/utils/image-io.ts
@@ -175,7 +175,7 @@ export async function exportPng(imageData: ImageData): Promise<Blob> {
     });
   }
   return injectPngMetadata(rawBlob, {
-    Software: 'NukeBG v2.10.1',
+    Software: 'NukeBG v2.10.2',
     Source: 'https://nukebg.app',
   });
 }


### PR DESCRIPTION
## Summary

Patch release wrapping six PRs since v2.10.1:

- **#220, #221** close #217 — typed event-bus + AbortSignal cleanup (Phase 4 of #47)
- **#222** closes #160 — coche-capture e2e flake fix
- **#223** — retired color-deviation watermarkDetect (false-positives on motostest, selfie-clean-corner)
- **#224** — dropOrphanBlobs threshold preserves disconnected real subject parts (fixes coche right-side cropping reported during manual dev testing)
- **#225** — sparkle MASK_RADIUS_MULTIPLIER bump 1.15→1.5 covers the natural halo (regression from #223 surfaced on selfie-sparkle-full)

Version bumped in 6 surfaces + CSP hash regenerated for the JSON-LD softwareVersion change. Same flow as v2.10.0 / v2.10.1.

## Validation

| Gate | Result |
|------|--------|
| \`npm run typecheck\` | ✅ green |
| \`npm test\` | ✅ **937/937** |
| \`npm run build\` | ✅ green |

## Bundle delta

Vs v2.10.1: \`index.js\` 460.15 → **458.99 kB** raw / 124.57 → 124.59 kB gzip — the typed bus is strictly leaner; the sparkle radius bump nudged 0.19 kB back.

## Known limitation

Tracked in #226: RMBG-1.4 mis-segments the lower portion of thin chrome features (motostest front brake disc). Predates this cycle by ~1 month; out-of-scope until a better permissive model is available. Documented in CHANGELOG notes.

After this lands, follow-up PR \`dev → main\` to deploy.