### PR TITLE
release: v2.10.2 — typed event-bus + pipeline correctness fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,77 @@ Unreleased entries accumulate on the `dev` branch. When we cut a release we copy
 
 ## [Unreleased]
 
+## [2.10.2] — 2026-04-28
+
+Patch release. Six PRs landed since v2.10.1 — typed event-bus migration,
+two pipeline correctness fixes (watermark false-positive + disconnected
+subject preservation), one sparkle halo coverage fix, and the CI flake
+fix from #160.
+
+### Fixed
+
+- **Watermark detector no longer false-positives on real photos.** The
+  legacy color-deviation \`watermarkDetect\` flagged motostest.jpeg and
+  selfie-clean-corner.png as containing Gemini sparkle when they don't.
+  Cause: it counted bright clustered pixels in the bottom-right without
+  any shape gate. Retired in favor of the existing shape-based
+  \`sparkleDetect\` (6 strict gates: 4-arm symmetry, narrow-arm
+  isolation, center peak vs outer ring, etc.) and \`watermarkDetectDalle\`
+  (multicolor bar). Together they cover both real watermark families
+  without the false-positive surface
+  ([#223](https://github.com/yocreoquesi/nukebg/pull/223)).
+- **Disconnected real subject parts no longer get dropped as orphan
+  blobs.** \`coche.jpg\` lost its right side after segmentation because
+  RMBG produced a mask split into two disconnected blobs (a sun-glare
+  chrome stripe down the middle), and the previous \`dropOrphanBlobs\`
+  kept only the single largest. Switched to a 1%-of-largest threshold:
+  tiny false-positive specks (50-px sky reflections) still die; real
+  disconnected subject parts (5K-30K px) survive
+  ([#224](https://github.com/yocreoquesi/nukebg/pull/224)).
+- **Sparkle inpaint mask covers the natural halo again.** Follow-up to
+  #223. After retiring the legacy detector its halo logic went with it,
+  leaving the shape detector's tight 1.15× radius mask. Telea then
+  inpainted too small an area; near-white halo pixels survived and RMBG
+  classified them as background — visible as transparent dots around
+  inpainted sparkles. Bumped \`MASK_RADIUS_MULTIPLIER\` 1.15 → 1.5 to
+  cover the typical halo
+  ([#225](https://github.com/yocreoquesi/nukebg/pull/225)).
+- **e2e \`coche-capture\` no longer flakes on CI cold-start.** Renamed
+  to \`z-coche-capture.spec.ts\` so Playwright's alphabetical scheduling
+  runs it last. Football (11 KB fixture) and motostest (565 KB) absorb
+  the cold-start ML warmup; coche then runs warm in well under a minute
+  ([#222](https://github.com/yocreoquesi/nukebg/pull/222), closes
+  [#160](https://github.com/yocreoquesi/nukebg/issues/160)).
+
+### Changed
+
+- **Cross-component custom events now go through a typed event-bus.**
+  New \`src/lib/event-bus.ts\` exposes a \`NukeBgEventMap\` covering all
+  15 \`ar:_\` / \`batch:_\` / \`nukebg:\*\` events plus typed \`emit()\` and
+  \`on()\` helpers. \`on()\` requires an \`AbortSignal\` so cleanup ties to
+  component lifecycle; the manual \`boundLocaleHandler\` +
+  \`removeEventListener\` pattern across 9 components is gone. Every
+  consumer-side \`(e as CustomEvent<...>).detail\` cast retired — the
+  bus types the detail by event name. Public event surface unchanged
+  at runtime ([#220](https://github.com/yocreoquesi/nukebg/pull/220),
+  [#221](https://github.com/yocreoquesi/nukebg/pull/221), closes
+  [#217](https://github.com/yocreoquesi/nukebg/issues/217) and the
+  outstanding Phase 4 of [#47](https://github.com/yocreoquesi/nukebg/issues/47)).
+
+### Notes
+
+- Test count: 928 → 937 across the cycle (event-bus tests + 2 new
+  dropOrphanBlobs regression-guards).
+- Bundle \`index.js\` raw: 460.15 → 458.99 kB (−1.16 kB; the typed bus is
+  strictly leaner than the manual pattern, the sparkle radius bump from
+  #225 nudged 0.19 kB back).
+- Known limitation tracked in
+  [#226](https://github.com/yocreoquesi/nukebg/issues/226): RMBG-1.4
+  occasionally mis-segments the lower portion of thin chrome features
+  near subject edges (motostest front brake disc). Predates this cycle
+  by ~1 month; out-of-scope for the post-process layer until a better
+  permissive model is available (semi-annual model-market scan).
+
 ## [2.10.1] — 2026-04-28
 
 Patch release. Two follow-ups to v2.10.0 — bundle drops another 5 kB

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 > Nuke backgrounds from any image. 100% client-side. Zero uploads. Zero BS.
 
-[![Version](https://img.shields.io/badge/version-2.10.1-brightgreen.svg)](https://github.com/yocreoquesi/nukebg/releases)
+[![Version](https://img.shields.io/badge/version-2.10.2-brightgreen.svg)](https://github.com/yocreoquesi/nukebg/releases)
 [![License: GPL-3.0](https://img.shields.io/badge/License-GPL%20v3-blue.svg)](https://www.gnu.org/licenses/gpl-3.0)
 [![Client-Side](https://img.shields.io/badge/Processing-100%25%20Client--Side-green.svg)](#-privacy)
 

--- a/e2e/z-coche-capture.spec.ts
+++ b/e2e/z-coche-capture.spec.ts
@@ -9,13 +9,13 @@ const OUT_DIR = resolve(__dirname, '../.halo-check');
 
 test.describe.configure({ mode: 'serial' });
 
+// File renamed `z-coche-capture` so Playwright's alphabetical scheduling
+// puts it LAST in the pipeline e2e suite (#160). The smaller-fixture
+// specs (football 11 KB, motostest 565 KB) now absorb the cold-start ML
+// warmup; coche runs warm in well under a minute. 240s budget = 4x slack
+// vs typical warm runs.
 test('capture coche output + mirror console/network', async ({ page }, testInfo) => {
-  // First spec in serial mode → pays full cold-start ML warmup
-  // (model download + WASM init + first inference). On CI runners this
-  // routinely takes 4–5 minutes; the previous 200s/240s budget timed
-  // out consistently. The follow-up specs (football, motostest) reuse
-  // the warm pipeline and finish well under their own budgets.
-  test.setTimeout(360_000);
+  test.setTimeout(240_000);
   mkdirSync(OUT_DIR, { recursive: true });
 
   const logs: string[] = [];
@@ -28,7 +28,7 @@ test('capture coche output + mirror console/network', async ({ page }, testInfo)
   await fileInput.setInputFiles(FIXTURE);
 
   const downloadBtn = page.locator('ar-download').locator('#dl-png');
-  await expect(downloadBtn).toHaveAttribute('href', /^blob:/, { timeout: 300_000 });
+  await expect(downloadBtn).toHaveAttribute('href', /^blob:/, { timeout: 180_000 });
 
   const outPath = resolve(OUT_DIR, `coche.png`);
   const downloadPromise = page.waitForEvent('download');

--- a/index.html
+++ b/index.html
@@ -151,7 +151,7 @@
           "PNG export with true alpha transparency"
         ],
         "screenshot": "https://nukebg.app/og-image.png",
-        "softwareVersion": "2.10.1",
+        "softwareVersion": "2.10.2",
         "license": "https://www.gnu.org/licenses/gpl-3.0.html",
         "isAccessibleForFree": true,
         "creator": {
@@ -487,7 +487,7 @@
     <!-- <ar-post-cta id="post-cta"></ar-post-cta> -->
 
     <footer class="footer hazard-border-top" role="contentinfo">
-      <span>NukeBG <span style="color: var(--color-text-tertiary)">v2.10.1</span></span>
+      <span>NukeBG <span style="color: var(--color-text-tertiary)">v2.10.2</span></span>
       <span class="footer-sep">|</span>
       <a href="https://github.com/yocreoquesi/nukebg" target="_blank" rel="noopener noreferrer"
         >GitHub</a

--- a/infra/nginx.conf
+++ b/infra/nginx.conf
@@ -31,7 +31,7 @@ server {
     #   new Function() WASM bootstrap.
     # - sha256 hashes cover the 3 inline JSON-LD blocks in index.html.
     #   Regenerate with `node scripts/compute-csp-hashes.mjs` after edits.
-    add_header Content-Security-Policy "default-src 'self'; script-src 'self' blob: 'wasm-unsafe-eval' 'unsafe-eval' 'sha256-mZ64a3L9XwFvMokuQ8cmY68GpB2ucLc0WGmYWF8EKQY=' 'sha256-uZm4Xh9FxR3B7WjPHL5pbehtSMYTCy9JWzQzl3/UKA0=' 'sha256-o1DLxvGFHY9H1AG6Sro58slSTxU3T7zb020gfyqbFwM=' https://cdn.jsdelivr.net; worker-src 'self' blob:; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; connect-src 'self' https://huggingface.co https://cdn-lfs.huggingface.co https://cdn-lfs-us-1.huggingface.co https://cdn.jsdelivr.net https://cas-bridge.xethub.hf.co; font-src 'self'; object-src 'none'; base-uri 'self'; form-action 'none'" always;
+    add_header Content-Security-Policy "default-src 'self'; script-src 'self' blob: 'wasm-unsafe-eval' 'unsafe-eval' 'sha256-suL/7MXuEJxulF14znTnwjBHbgB7E1bNMb9DQbFnvao=' 'sha256-uZm4Xh9FxR3B7WjPHL5pbehtSMYTCy9JWzQzl3/UKA0=' 'sha256-o1DLxvGFHY9H1AG6Sro58slSTxU3T7zb020gfyqbFwM=' https://cdn.jsdelivr.net; worker-src 'self' blob:; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; connect-src 'self' https://huggingface.co https://cdn-lfs.huggingface.co https://cdn-lfs-us-1.huggingface.co https://cdn.jsdelivr.net https://cas-bridge.xethub.hf.co; font-src 'self'; object-src 'none'; base-uri 'self'; form-action 'none'" always;
 
     # Cache static assets
     # Note: add_header in location blocks replaces parent headers in nginx,
@@ -46,7 +46,7 @@ server {
         add_header Strict-Transport-Security "max-age=63072000; includeSubDomains; preload" always;
         add_header Cross-Origin-Opener-Policy "same-origin" always;
         add_header X-DNS-Prefetch-Control "off" always;
-        add_header Content-Security-Policy "default-src 'self'; script-src 'self' blob: 'wasm-unsafe-eval' 'unsafe-eval' 'sha256-mZ64a3L9XwFvMokuQ8cmY68GpB2ucLc0WGmYWF8EKQY=' 'sha256-uZm4Xh9FxR3B7WjPHL5pbehtSMYTCy9JWzQzl3/UKA0=' 'sha256-o1DLxvGFHY9H1AG6Sro58slSTxU3T7zb020gfyqbFwM=' https://cdn.jsdelivr.net; worker-src 'self' blob:; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; connect-src 'self' https://huggingface.co https://cdn-lfs.huggingface.co https://cdn-lfs-us-1.huggingface.co https://cdn.jsdelivr.net https://cas-bridge.xethub.hf.co; font-src 'self'; object-src 'none'; base-uri 'self'; form-action 'none'" always;
+        add_header Content-Security-Policy "default-src 'self'; script-src 'self' blob: 'wasm-unsafe-eval' 'unsafe-eval' 'sha256-suL/7MXuEJxulF14znTnwjBHbgB7E1bNMb9DQbFnvao=' 'sha256-uZm4Xh9FxR3B7WjPHL5pbehtSMYTCy9JWzQzl3/UKA0=' 'sha256-o1DLxvGFHY9H1AG6Sro58slSTxU3T7zb020gfyqbFwM=' https://cdn.jsdelivr.net; worker-src 'self' blob:; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; connect-src 'self' https://huggingface.co https://cdn-lfs.huggingface.co https://cdn-lfs-us-1.huggingface.co https://cdn.jsdelivr.net https://cas-bridge.xethub.hf.co; font-src 'self'; object-src 'none'; base-uri 'self'; form-action 'none'" always;
     }
 
     # ONNX model files — cache aggressively, same-origin so CORP is fine
@@ -60,7 +60,7 @@ server {
         add_header Strict-Transport-Security "max-age=63072000; includeSubDomains; preload" always;
         add_header Cross-Origin-Opener-Policy "same-origin" always;
         add_header X-DNS-Prefetch-Control "off" always;
-        add_header Content-Security-Policy "default-src 'self'; script-src 'self' blob: 'wasm-unsafe-eval' 'unsafe-eval' 'sha256-mZ64a3L9XwFvMokuQ8cmY68GpB2ucLc0WGmYWF8EKQY=' 'sha256-uZm4Xh9FxR3B7WjPHL5pbehtSMYTCy9JWzQzl3/UKA0=' 'sha256-o1DLxvGFHY9H1AG6Sro58slSTxU3T7zb020gfyqbFwM=' https://cdn.jsdelivr.net; worker-src 'self' blob:; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; connect-src 'self' https://huggingface.co https://cdn-lfs.huggingface.co https://cdn-lfs-us-1.huggingface.co https://cdn.jsdelivr.net https://cas-bridge.xethub.hf.co; font-src 'self'; object-src 'none'; base-uri 'self'; form-action 'none'" always;
+        add_header Content-Security-Policy "default-src 'self'; script-src 'self' blob: 'wasm-unsafe-eval' 'unsafe-eval' 'sha256-suL/7MXuEJxulF14znTnwjBHbgB7E1bNMb9DQbFnvao=' 'sha256-uZm4Xh9FxR3B7WjPHL5pbehtSMYTCy9JWzQzl3/UKA0=' 'sha256-o1DLxvGFHY9H1AG6Sro58slSTxU3T7zb020gfyqbFwM=' https://cdn.jsdelivr.net; worker-src 'self' blob:; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; connect-src 'self' https://huggingface.co https://cdn-lfs.huggingface.co https://cdn-lfs-us-1.huggingface.co https://cdn.jsdelivr.net https://cas-bridge.xethub.hf.co; font-src 'self'; object-src 'none'; base-uri 'self'; form-action 'none'" always;
     }
 
     # SPA fallback

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "nukebg",
-  "version": "2.10.1",
+  "version": "2.10.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "nukebg",
-      "version": "2.10.1",
+      "version": "2.10.2",
       "license": "GPL-3.0-only",
       "dependencies": {
         "@huggingface/transformers": "^3.8.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "nukebg",
   "private": true,
-  "version": "2.10.1",
+  "version": "2.10.2",
   "type": "module",
   "description": "NukeBG: Nuke AI backgrounds, checkerboard patterns, and watermarks. 100% client-side. Zero uploads. Zero BS.",
   "license": "GPL-3.0-only",

--- a/public/_headers
+++ b/public/_headers
@@ -7,7 +7,7 @@
   Cross-Origin-Resource-Policy: same-origin
   X-DNS-Prefetch-Control: off
   Strict-Transport-Security: max-age=63072000; includeSubDomains; preload
-  Content-Security-Policy: default-src 'self'; script-src 'self' blob: 'wasm-unsafe-eval' 'unsafe-eval' 'sha256-mZ64a3L9XwFvMokuQ8cmY68GpB2ucLc0WGmYWF8EKQY=' 'sha256-uZm4Xh9FxR3B7WjPHL5pbehtSMYTCy9JWzQzl3/UKA0=' 'sha256-o1DLxvGFHY9H1AG6Sro58slSTxU3T7zb020gfyqbFwM=' https://cdn.jsdelivr.net; worker-src 'self' blob:; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; connect-src 'self' https://huggingface.co https://cdn-lfs.huggingface.co https://cdn-lfs-us-1.huggingface.co https://cdn.jsdelivr.net https://cas-bridge.xethub.hf.co; font-src 'self'; object-src 'none'; base-uri 'self'; form-action 'none'
+  Content-Security-Policy: default-src 'self'; script-src 'self' blob: 'wasm-unsafe-eval' 'unsafe-eval' 'sha256-suL/7MXuEJxulF14znTnwjBHbgB7E1bNMb9DQbFnvao=' 'sha256-uZm4Xh9FxR3B7WjPHL5pbehtSMYTCy9JWzQzl3/UKA0=' 'sha256-o1DLxvGFHY9H1AG6Sro58slSTxU3T7zb020gfyqbFwM=' https://cdn.jsdelivr.net; worker-src 'self' blob:; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; connect-src 'self' https://huggingface.co https://cdn-lfs.huggingface.co https://cdn-lfs-us-1.huggingface.co https://cdn.jsdelivr.net https://cas-bridge.xethub.hf.co; font-src 'self'; object-src 'none'; base-uri 'self'; form-action 'none'
 
 /assets/*
   Cache-Control: public, max-age=31536000, immutable

--- a/src/components/ar-app.ts
+++ b/src/components/ar-app.ts
@@ -11,6 +11,7 @@ import type { ArEditor } from './ar-editor';
 import type { ArDropzone } from './ar-dropzone';
 import type { ArBatchGrid } from './ar-batch-grid';
 import { BatchOrchestrator, type BatchStageCallback } from '../controllers/batch-orchestrator';
+import { on } from '../lib/event-bus';
 import {
   refineEdges,
   dropOrphanBlobs,
@@ -42,7 +43,6 @@ export class ArApp extends HTMLElement {
   private processingAbortController: AbortController | null = null;
   private preEditResult: ImageData | null = null;
   private cachedEditResult: ImageData | null = null;
-  private boundLocaleHandler: (() => void) | null = null;
   private abortController: AbortController | null = null;
   /** Owns PWA install button + guide wiring. Initialized in
    *  setupComponents() once the install-btn / install-guide nodes
@@ -139,8 +139,6 @@ export class ArApp extends HTMLElement {
   }
 
   disconnectedCallback(): void {
-    if (this.boundLocaleHandler)
-      document.removeEventListener('nukebg:locale-changed', this.boundLocaleHandler);
     this.abortController?.abort();
     this.abortController = null;
   }
@@ -1160,11 +1158,7 @@ export class ArApp extends HTMLElement {
     // component-lifecycle cleanup via AbortSignal.
     const signal = this.abortController!.signal;
 
-    // Listen for locale changes
-    this.boundLocaleHandler = () => {
-      this.updateTexts();
-    };
-    document.addEventListener('nukebg:locale-changed', this.boundLocaleHandler);
+    on(document, 'nukebg:locale-changed', () => this.updateTexts(), { signal });
 
     // Cancel button lives in the command bar (#71). The same
     // ar:cancel-processing event is dispatched from there and caught at

--- a/src/components/ar-app.ts
+++ b/src/components/ar-app.ts
@@ -11,7 +11,7 @@ import type { ArEditor } from './ar-editor';
 import type { ArDropzone } from './ar-dropzone';
 import type { ArBatchGrid } from './ar-batch-grid';
 import { BatchOrchestrator, type BatchStageCallback } from '../controllers/batch-orchestrator';
-import { on } from '../lib/event-bus';
+import { emit, on } from '../lib/event-bus';
 import {
   refineEdges,
   dropOrphanBlobs,
@@ -1165,11 +1165,10 @@ export class ArApp extends HTMLElement {
     // the shadow-root level so legacy listeners (progress component,
     // tests) still work.
     const bubbleCancel = (): void => {
-      this.dispatchEvent(
-        new CustomEvent('ar:cancel-processing', { bubbles: true, composed: true }),
-      );
+      emit(this, 'ar:cancel-processing', undefined, { bubbles: true, composed: true });
     };
-    this.shadowRoot!.addEventListener(
+    on(
+      this.shadowRoot!,
       'ar:cancel-processing',
       () => {
         if (this.processingAbortController && !this.processingAbortController.signal.aborted) {
@@ -1189,11 +1188,11 @@ export class ArApp extends HTMLElement {
     // the existing retryFromError() path; report opens a pre-filled
     // GitHub issue URL with browser + session hints; reload is
     // handled by ar-progress itself (location.reload).
-    this.progress.addEventListener('ar:stage-retry', () => this.retryFromError(), { signal });
-    this.progress.addEventListener(
+    on(this.progress, 'ar:stage-retry', () => this.retryFromError(), { signal });
+    on(
+      this.progress,
       'ar:stage-report',
-      (ev) => {
-        const stage = (ev as CustomEvent<{ stage: string }>).detail.stage;
+      ({ stage }) => {
         const ua = encodeURIComponent(navigator.userAgent);
         const title = encodeURIComponent(`[stage:${stage}] pipeline error`);
         const body = encodeURIComponent(
@@ -1232,10 +1231,10 @@ export class ArApp extends HTMLElement {
     // the same AbortSignal so cleanup is automatic on disconnect.
     this.installer.attach(signal);
 
-    this.shadowRoot!.addEventListener(
+    on(
+      this.shadowRoot!,
       'ar:image-loaded',
-      async (e: Event) => {
-        const detail = (e as CustomEvent).detail;
+      async (detail) => {
         this.currentFileName = detail.file.name || 'image.png';
 
         // If currently processing, abort the in-flight pipeline and reset
@@ -1254,19 +1253,10 @@ export class ArApp extends HTMLElement {
       { signal },
     );
 
-    this.shadowRoot!.addEventListener(
+    on(
+      this.shadowRoot!,
       'ar:images-loaded',
-      async (e: Event) => {
-        const detail = (e as CustomEvent).detail as {
-          images: Array<{
-            file: File;
-            imageData: ImageData;
-            originalImageData: ImageData;
-            originalWidth: number;
-            originalHeight: number;
-            wasDownsampled: boolean;
-          }>;
-        };
+      async (detail) => {
         if (this.isProcessing) {
           this.processingAborted = true;
           this.isProcessing = false;
@@ -1277,16 +1267,17 @@ export class ArApp extends HTMLElement {
       { signal },
     );
 
-    this.shadowRoot!.addEventListener(
+    on(
+      this.shadowRoot!,
       'batch:item-click',
-      (e: Event) => {
-        const detail = (e as CustomEvent).detail as { id: string; state: string };
-        this.openBatchDetail(detail.id);
+      ({ id }) => {
+        this.openBatchDetail(id);
       },
       { signal },
     );
 
-    this.shadowRoot!.addEventListener(
+    on(
+      this.shadowRoot!,
       'batch:download-zip',
       async () => {
         await this.batch.downloadZip();
@@ -1294,7 +1285,8 @@ export class ArApp extends HTMLElement {
       { signal },
     );
 
-    this.shadowRoot!.addEventListener(
+    on(
+      this.shadowRoot!,
       'batch:cancel',
       () => {
         this.resetToIdle();
@@ -1315,7 +1307,8 @@ export class ArApp extends HTMLElement {
       discardBtn.addEventListener('click', () => this.discardBatchItem(), { signal });
     }
 
-    this.shadowRoot!.addEventListener(
+    on(
+      this.shadowRoot!,
       'ar:process-another',
       () => {
         this.resetToIdle();
@@ -1364,7 +1357,8 @@ export class ArApp extends HTMLElement {
     );
 
     // Editor cancel - discard edits, close editor
-    this.shadowRoot!.addEventListener(
+    on(
+      this.shadowRoot!,
       'ar:editor-cancel',
       () => {
         (this.shadowRoot!.querySelector('#editor-section') as HTMLElement).style.display = 'none';
@@ -1374,10 +1368,10 @@ export class ArApp extends HTMLElement {
     );
 
     // Editor done - update viewer and download with edited result
-    this.shadowRoot!.addEventListener(
+    on(
+      this.shadowRoot!,
       'ar:editor-done',
-      async (e: Event) => {
-        const rawEdited = (e as CustomEvent).detail.imageData as ImageData;
+      async ({ imageData: rawEdited }) => {
         // Refine: foreground decontamination + quintic alpha sharpening so manual
         // brush strokes inherit the same studio-quality edge as the main pipeline.
         // Topology cleanup is skipped — keepLargestComponent would discard manual
@@ -1430,7 +1424,8 @@ export class ArApp extends HTMLElement {
     );
 
     // Advanced editor — cancel
-    this.shadowRoot!.addEventListener(
+    on(
+      this.shadowRoot!,
       'ar:advanced-cancel',
       () => {
         const btn = this.shadowRoot!.querySelector('#advanced-cta') as HTMLElement | null;
@@ -1440,16 +1435,16 @@ export class ArApp extends HTMLElement {
     );
 
     // Advanced editor — done
-    this.shadowRoot!.addEventListener(
+    on(
+      this.shadowRoot!,
       'ar:advanced-done',
-      async (e: Event) => {
-        const detail = (e as CustomEvent<{ imageData: ImageData }>).detail;
+      async ({ imageData }) => {
         const btn = this.shadowRoot!.querySelector('#advanced-cta') as HTMLElement | null;
         btn?.removeAttribute('data-active');
 
         // Same reasoning as the basic editor: skip topology cleanup so the
         // user's lasso crops / restores survive the refinement pass.
-        const refined = await refineEdges(this.pipeline, detail.imageData, {
+        const refined = await refineEdges(this.pipeline, imageData, {
           skipTopologyCleanup: true,
         });
         const blob = await exportPng(refined);
@@ -1660,7 +1655,7 @@ export class ArApp extends HTMLElement {
         // Notify the post-process CTA module so it can decide whether
         // to surface a star/tip/review ask. Light DOM listener — fires
         // and forgets, no return contract.
-        document.dispatchEvent(new CustomEvent('ar:nuke-success'));
+        emit(document, 'ar:nuke-success', undefined);
       }
     }
   }

--- a/src/components/ar-batch-grid.ts
+++ b/src/components/ar-batch-grid.ts
@@ -1,7 +1,7 @@
 import { t } from '../i18n';
 import type { BatchItem, BatchItemState } from '../types/batch';
 import { ArBatchItem } from './ar-batch-item';
-import { on } from '../lib/event-bus';
+import { emit, on } from '../lib/event-bus';
 
 /**
  * Presentational container for the batch workflow. Holds BatchItem
@@ -134,21 +134,11 @@ export class ArBatchGrid extends HTMLElement {
     `;
 
     this.shadowRoot!.querySelector('#zip-btn')!.addEventListener('click', () => {
-      this.dispatchEvent(
-        new CustomEvent('batch:download-zip', {
-          bubbles: true,
-          composed: true,
-        }),
-      );
+      emit(this, 'batch:download-zip', undefined, { bubbles: true, composed: true });
     });
 
     this.shadowRoot!.querySelector('#cancel-btn')!.addEventListener('click', () => {
-      this.dispatchEvent(
-        new CustomEvent('batch:cancel', {
-          bubbles: true,
-          composed: true,
-        }),
-      );
+      emit(this, 'batch:cancel', undefined, { bubbles: true, composed: true });
     });
   }
 

--- a/src/components/ar-batch-grid.ts
+++ b/src/components/ar-batch-grid.ts
@@ -1,6 +1,7 @@
 import { t } from '../i18n';
 import type { BatchItem, BatchItemState } from '../types/batch';
 import { ArBatchItem } from './ar-batch-item';
+import { on } from '../lib/event-bus';
 
 /**
  * Presentational container for the batch workflow. Holds BatchItem
@@ -10,7 +11,7 @@ import { ArBatchItem } from './ar-batch-item';
 export class ArBatchGrid extends HTMLElement {
   private items: BatchItem[] = [];
   private itemEls = new Map<string, ArBatchItem>();
-  private boundLocaleHandler: (() => void) | null = null;
+  private abortController: AbortController | null = null;
   private currentIndex = 0;
 
   constructor() {
@@ -20,15 +21,15 @@ export class ArBatchGrid extends HTMLElement {
 
   connectedCallback(): void {
     this.render();
-    this.boundLocaleHandler = () => this.updateHeader();
-    document.addEventListener('nukebg:locale-changed', this.boundLocaleHandler);
+    this.abortController = new AbortController();
+    on(document, 'nukebg:locale-changed', () => this.updateHeader(), {
+      signal: this.abortController.signal,
+    });
   }
 
   disconnectedCallback(): void {
-    if (this.boundLocaleHandler) {
-      document.removeEventListener('nukebg:locale-changed', this.boundLocaleHandler);
-      this.boundLocaleHandler = null;
-    }
+    this.abortController?.abort();
+    this.abortController = null;
   }
 
   setItems(items: BatchItem[]): void {

--- a/src/components/ar-batch-item.ts
+++ b/src/components/ar-batch-item.ts
@@ -1,5 +1,6 @@
 import { t } from '../i18n';
 import type { BatchItemState } from '../types/batch';
+import { on } from '../lib/event-bus';
 
 /**
  * A single slot in the batch grid. Renders a thumbnail plus a state badge
@@ -11,7 +12,7 @@ export class ArBatchItem extends HTMLElement {
   private itemState: BatchItemState = 'pending';
   private thumbnailUrl: string | null = null;
   private originalName = '';
-  private boundLocaleHandler: (() => void) | null = null;
+  private abortController: AbortController | null = null;
 
   constructor() {
     super();
@@ -46,15 +47,15 @@ export class ArBatchItem extends HTMLElement {
         }),
       );
     });
-    this.boundLocaleHandler = () => this.updateView();
-    document.addEventListener('nukebg:locale-changed', this.boundLocaleHandler);
+    this.abortController = new AbortController();
+    on(document, 'nukebg:locale-changed', () => this.updateView(), {
+      signal: this.abortController.signal,
+    });
   }
 
   disconnectedCallback(): void {
-    if (this.boundLocaleHandler) {
-      document.removeEventListener('nukebg:locale-changed', this.boundLocaleHandler);
-      this.boundLocaleHandler = null;
-    }
+    this.abortController?.abort();
+    this.abortController = null;
   }
 
   setItem(

--- a/src/components/ar-batch-item.ts
+++ b/src/components/ar-batch-item.ts
@@ -1,6 +1,6 @@
 import { t } from '../i18n';
 import type { BatchItemState } from '../types/batch';
-import { on } from '../lib/event-bus';
+import { emit, on } from '../lib/event-bus';
 
 /**
  * A single slot in the batch grid. Renders a thumbnail plus a state badge
@@ -26,12 +26,11 @@ export class ArBatchItem extends HTMLElement {
       // Pending slots are non-interactive. Processing IS clickable so the
       // user can open the live progress console for the current item.
       if (this.itemState === 'pending') return;
-      this.dispatchEvent(
-        new CustomEvent('batch:item-click', {
-          bubbles: true,
-          composed: true,
-          detail: { id: this.itemId, state: this.itemState },
-        }),
+      emit(
+        this,
+        'batch:item-click',
+        { id: this.itemId, state: this.itemState },
+        { bubbles: true, composed: true },
       );
     });
     this.shadowRoot!.addEventListener('keydown', (e) => {
@@ -39,12 +38,11 @@ export class ArBatchItem extends HTMLElement {
       if (ke.key !== 'Enter' && ke.key !== ' ') return;
       if (this.itemState === 'pending') return;
       ke.preventDefault();
-      this.dispatchEvent(
-        new CustomEvent('batch:item-click', {
-          bubbles: true,
-          composed: true,
-          detail: { id: this.itemId, state: this.itemState },
-        }),
+      emit(
+        this,
+        'batch:item-click',
+        { id: this.itemId, state: this.itemState },
+        { bubbles: true, composed: true },
       );
     });
     this.abortController = new AbortController();

--- a/src/components/ar-download.ts
+++ b/src/components/ar-download.ts
@@ -1,6 +1,7 @@
 import { exportPng, exportWebp, generateOutputFilename } from '../utils/image-io';
 import { t, getLocale } from '../i18n';
 import type { ExportFormat } from '../types/image';
+import { on } from '../lib/event-bus';
 
 export class ArDownload extends HTMLElement {
   private pngBlobUrl: string | null = null;
@@ -11,7 +12,7 @@ export class ArDownload extends HTMLElement {
   private selectedFormat: ExportFormat = 'png';
   private pngFilename = 'image.png';
   private webpFilename = 'image.webp';
-  private boundLocaleHandler: (() => void) | null = null;
+  private abortController: AbortController | null = null;
 
   constructor() {
     super();
@@ -20,10 +21,10 @@ export class ArDownload extends HTMLElement {
 
   connectedCallback(): void {
     this.render();
-    this.boundLocaleHandler = () => {
-      this.updateTexts();
-    };
-    document.addEventListener('nukebg:locale-changed', this.boundLocaleHandler);
+    this.abortController = new AbortController();
+    on(document, 'nukebg:locale-changed', () => this.updateTexts(), {
+      signal: this.abortController.signal,
+    });
   }
 
   private updateTexts(): void {
@@ -47,8 +48,8 @@ export class ArDownload extends HTMLElement {
   disconnectedCallback(): void {
     if (this.pngBlobUrl) URL.revokeObjectURL(this.pngBlobUrl);
     if (this.webpBlobUrl) URL.revokeObjectURL(this.webpBlobUrl);
-    if (this.boundLocaleHandler)
-      document.removeEventListener('nukebg:locale-changed', this.boundLocaleHandler);
+    this.abortController?.abort();
+    this.abortController = null;
   }
 
   async setResult(

--- a/src/components/ar-download.ts
+++ b/src/components/ar-download.ts
@@ -1,7 +1,7 @@
 import { exportPng, exportWebp, generateOutputFilename } from '../utils/image-io';
 import { t, getLocale } from '../i18n';
 import type { ExportFormat } from '../types/image';
-import { on } from '../lib/event-bus';
+import { emit, on } from '../lib/event-bus';
 
 export class ArDownload extends HTMLElement {
   private pngBlobUrl: string | null = null;
@@ -314,7 +314,7 @@ export class ArDownload extends HTMLElement {
     `;
 
     this.shadowRoot!.querySelector('#another-btn')!.addEventListener('click', () => {
-      this.dispatchEvent(new CustomEvent('ar:process-another', { bubbles: true, composed: true }));
+      emit(this, 'ar:process-another', undefined, { bubbles: true, composed: true });
     });
 
     // Web Share API (#74) removed in #150 — the user wanted it gone

--- a/src/components/ar-dropzone.ts
+++ b/src/components/ar-dropzone.ts
@@ -1,7 +1,7 @@
 import { loadImage, isSupportedFormat } from '../utils/image-io';
 import { t } from '../i18n';
 import { getBatchLimit } from '../types/batch';
-import { on } from '../lib/event-bus';
+import { emit, on } from '../lib/event-bus';
 
 export class ArDropzone extends HTMLElement {
   private fileInput!: HTMLInputElement;
@@ -447,19 +447,18 @@ export class ArDropzone extends HTMLElement {
 
     try {
       const result = await loadImage(file);
-      this.dispatchEvent(
-        new CustomEvent('ar:image-loaded', {
-          bubbles: true,
-          composed: true,
-          detail: {
-            file,
-            imageData: result.imageData,
-            originalImageData: result.originalImageData,
-            originalWidth: result.originalWidth,
-            originalHeight: result.originalHeight,
-            wasDownsampled: result.wasDownsampled,
-          },
-        }),
+      emit(
+        this,
+        'ar:image-loaded',
+        {
+          file,
+          imageData: result.imageData,
+          originalImageData: result.originalImageData,
+          originalWidth: result.originalWidth,
+          originalHeight: result.originalHeight,
+          wasDownsampled: result.wasDownsampled,
+        },
+        { bubbles: true, composed: true },
       );
     } catch (err) {
       const msg = err instanceof Error ? err.message : 'Failed to load image.';
@@ -528,13 +527,7 @@ export class ArDropzone extends HTMLElement {
       this.showError(t('batch.limitExceeded', { limit: String(limit) }));
     }
 
-    this.dispatchEvent(
-      new CustomEvent('ar:images-loaded', {
-        bubbles: true,
-        composed: true,
-        detail: { images: loaded },
-      }),
-    );
+    emit(this, 'ar:images-loaded', { images: loaded }, { bubbles: true, composed: true });
   }
 
   private showError(message?: string): void {

--- a/src/components/ar-dropzone.ts
+++ b/src/components/ar-dropzone.ts
@@ -1,12 +1,12 @@
 import { loadImage, isSupportedFormat } from '../utils/image-io';
 import { t } from '../i18n';
 import { getBatchLimit } from '../types/batch';
+import { on } from '../lib/event-bus';
 
 export class ArDropzone extends HTMLElement {
   private fileInput!: HTMLInputElement;
   private dropArea!: HTMLDivElement;
-  private boundLocaleHandler: (() => void) | null = null;
-  private boundPasteHandler: ((e: ClipboardEvent) => void) | null = null;
+  private abortController: AbortController | null = null;
 
   constructor() {
     super();
@@ -316,11 +316,10 @@ export class ArDropzone extends HTMLElement {
   }
 
   private setupEvents(): void {
-    // Listen for locale changes
-    this.boundLocaleHandler = () => {
-      this.updateTexts();
-    };
-    document.addEventListener('nukebg:locale-changed', this.boundLocaleHandler);
+    this.abortController = new AbortController();
+    const signal = this.abortController.signal;
+
+    on(document, 'nukebg:locale-changed', () => this.updateTexts(), { signal });
 
     // Click to open file picker. The OS picker exposes the camera as
     // one of the source options on mobile, so a dedicated camera CTA
@@ -360,25 +359,27 @@ export class ArDropzone extends HTMLElement {
     });
 
     // Paste from clipboard
-    this.boundPasteHandler = (e: ClipboardEvent) => {
-      if (this.dropArea.classList.contains('dropzone-disabled')) return;
-      const items = e.clipboardData?.items;
-      if (!items) return;
-      for (const item of items) {
-        if (item.type.startsWith('image/')) {
-          const file = item.getAsFile();
-          if (file) this.handleFile(file);
-          break;
+    document.addEventListener(
+      'paste',
+      (e: ClipboardEvent) => {
+        if (this.dropArea.classList.contains('dropzone-disabled')) return;
+        const items = e.clipboardData?.items;
+        if (!items) return;
+        for (const item of items) {
+          if (item.type.startsWith('image/')) {
+            const file = item.getAsFile();
+            if (file) this.handleFile(file);
+            break;
+          }
         }
-      }
-    };
-    document.addEventListener('paste', this.boundPasteHandler);
+      },
+      { signal },
+    );
   }
 
   disconnectedCallback(): void {
-    if (this.boundLocaleHandler)
-      document.removeEventListener('nukebg:locale-changed', this.boundLocaleHandler);
-    if (this.boundPasteHandler) document.removeEventListener('paste', this.boundPasteHandler);
+    this.abortController?.abort();
+    this.abortController = null;
   }
 
   /** Enable or disable the dropzone (used to block interaction until model is ready) */

--- a/src/components/ar-editor-advanced.ts
+++ b/src/components/ar-editor-advanced.ts
@@ -39,6 +39,7 @@ import { t } from '../i18n';
 import { type Point } from './lasso-simplify';
 import { LassoModel } from '../lib/lasso-model';
 import { HistoryManager } from '../lib/history-manager';
+import { emit } from '../lib/event-bus';
 
 const PAD_RATIO = 0.25;
 const DEFAULT_BRUSH = 24;
@@ -2152,7 +2153,7 @@ export class ArEditorAdvanced extends HTMLElement {
 
   private cancel(): void {
     this.removeAttribute('active');
-    this.dispatchEvent(new CustomEvent('ar:advanced-cancel', { bubbles: true, composed: true }));
+    emit(this, 'ar:advanced-cancel', undefined, { bubbles: true, composed: true });
   }
 
   private commit(): void {
@@ -2161,13 +2162,7 @@ export class ArEditorAdvanced extends HTMLElement {
       .getContext('2d')!
       .getImageData(0, 0, this.current.width, this.current.height);
     this.removeAttribute('active');
-    this.dispatchEvent(
-      new CustomEvent('ar:advanced-done', {
-        detail: { imageData: out },
-        bubbles: true,
-        composed: true,
-      }),
-    );
+    emit(this, 'ar:advanced-done', { imageData: out }, { bubbles: true, composed: true });
   }
 }
 

--- a/src/components/ar-editor.ts
+++ b/src/components/ar-editor.ts
@@ -7,6 +7,7 @@
 import { t } from '../i18n';
 import { BrushStroke, type BrushShape, type BrushTool } from '../lib/brush-stroke';
 import { HistoryManager } from '../lib/history-manager';
+import { on } from '../lib/event-bus';
 
 /** Generate a CSS cursor data URL that matches the brush shape, size and tool */
 function makeBrushCursor(
@@ -90,7 +91,6 @@ export class ArEditor extends HTMLElement {
   // just alpha); alpha-only snapshots can't undo color changes. Cap = 12
   // so large images (up to 4096² ≈ 67 MB per entry) don't blow RAM.
   private history = new HistoryManager<Uint8ClampedArray>(12);
-  private boundLocaleHandler: (() => void) | null = null;
   private abortController: AbortController | null = null;
 
   constructor() {
@@ -103,15 +103,12 @@ export class ArEditor extends HTMLElement {
     this.render();
     this.setupCanvas();
     this.setupEvents();
-    this.boundLocaleHandler = () => {
-      this.updateTexts();
-    };
-    document.addEventListener('nukebg:locale-changed', this.boundLocaleHandler);
+    on(document, 'nukebg:locale-changed', () => this.updateTexts(), {
+      signal: this.abortController.signal,
+    });
   }
 
   disconnectedCallback(): void {
-    if (this.boundLocaleHandler)
-      document.removeEventListener('nukebg:locale-changed', this.boundLocaleHandler);
     this.abortController?.abort();
     this.abortController = null;
   }

--- a/src/components/ar-editor.ts
+++ b/src/components/ar-editor.ts
@@ -7,7 +7,7 @@
 import { t } from '../i18n';
 import { BrushStroke, type BrushShape, type BrushTool } from '../lib/brush-stroke';
 import { HistoryManager } from '../lib/history-manager';
-import { on } from '../lib/event-bus';
+import { emit, on } from '../lib/event-bus';
 
 /** Generate a CSS cursor data URL that matches the brush shape, size and tool */
 function makeBrushCursor(
@@ -892,12 +892,7 @@ export class ArEditor extends HTMLElement {
     this.shadowRoot!.querySelector('#cancel-btn')!.addEventListener(
       'click',
       () => {
-        this.dispatchEvent(
-          new CustomEvent('ar:editor-cancel', {
-            bubbles: true,
-            composed: true,
-          }),
-        );
+        emit(this, 'ar:editor-cancel', undefined, { bubbles: true, composed: true });
       },
       { signal },
     );
@@ -906,12 +901,11 @@ export class ArEditor extends HTMLElement {
     this.shadowRoot!.querySelector('#done-btn')!.addEventListener(
       'click',
       () => {
-        this.dispatchEvent(
-          new CustomEvent('ar:editor-done', {
-            bubbles: true,
-            composed: true,
-            detail: { imageData: this.getResultImageData() },
-          }),
+        emit(
+          this,
+          'ar:editor-done',
+          { imageData: this.getResultImageData() },
+          { bubbles: true, composed: true },
         );
       },
       { signal },

--- a/src/components/ar-privacy.ts
+++ b/src/components/ar-privacy.ts
@@ -1,7 +1,8 @@
 import { t } from '../i18n';
+import { on } from '../lib/event-bus';
 
 export class ArPrivacy extends HTMLElement {
-  private boundLocaleHandler: (() => void) | null = null;
+  private abortController: AbortController | null = null;
 
   constructor() {
     super();
@@ -10,15 +11,15 @@ export class ArPrivacy extends HTMLElement {
 
   connectedCallback(): void {
     this.renderContent();
-    this.boundLocaleHandler = () => {
-      this.updateTexts();
-    };
-    document.addEventListener('nukebg:locale-changed', this.boundLocaleHandler);
+    this.abortController = new AbortController();
+    on(document, 'nukebg:locale-changed', () => this.updateTexts(), {
+      signal: this.abortController.signal,
+    });
   }
 
   disconnectedCallback(): void {
-    if (this.boundLocaleHandler)
-      document.removeEventListener('nukebg:locale-changed', this.boundLocaleHandler);
+    this.abortController?.abort();
+    this.abortController = null;
   }
 
   private updateTexts(): void {

--- a/src/components/ar-progress.ts
+++ b/src/components/ar-progress.ts
@@ -1,6 +1,6 @@
 import type { PipelineStage, StageStatus } from '../types/pipeline';
 import { t } from '../i18n';
-import { on } from '../lib/event-bus';
+import { emit, on } from '../lib/event-bus';
 
 interface StageInfo {
   stage: PipelineStage;
@@ -51,13 +51,9 @@ export class ArProgress extends HTMLElement {
       if (!target) return;
       const stage = target.getAttribute('data-stage') ?? '';
       if (target.classList.contains('stage-action-retry')) {
-        this.dispatchEvent(
-          new CustomEvent('ar:stage-retry', { bubbles: true, composed: true, detail: { stage } }),
-        );
+        emit(this, 'ar:stage-retry', { stage }, { bubbles: true, composed: true });
       } else if (target.classList.contains('stage-action-report')) {
-        this.dispatchEvent(
-          new CustomEvent('ar:stage-report', { bubbles: true, composed: true, detail: { stage } }),
-        );
+        emit(this, 'ar:stage-report', { stage }, { bubbles: true, composed: true });
       } else if (target.classList.contains('stage-action-reload')) {
         location.reload();
       }

--- a/src/components/ar-progress.ts
+++ b/src/components/ar-progress.ts
@@ -1,5 +1,6 @@
 import type { PipelineStage, StageStatus } from '../types/pipeline';
 import { t } from '../i18n';
+import { on } from '../lib/event-bus';
 
 interface StageInfo {
   stage: PipelineStage;
@@ -13,7 +14,7 @@ export class ArProgress extends HTMLElement {
   private stages: StageInfo[] = [];
   private startTimes = new Map<PipelineStage, number>();
   private detectedContentType: string | null = null;
-  private boundLocaleHandler: (() => void) | null = null;
+  private abortController: AbortController | null = null;
 
   constructor() {
     super();
@@ -22,19 +23,24 @@ export class ArProgress extends HTMLElement {
 
   connectedCallback(): void {
     this.render();
-    this.boundLocaleHandler = () => {
-      // Re-translate labels for active stages
-      this.stages.forEach((s) => {
-        if (s.stage === 'detect-background') s.label = t('progress.detectBg');
-        else if (s.stage === 'watermark-scan') s.label = t('progress.watermarkScan');
-        else if (s.stage === 'inpaint') s.label = t('progress.inpaint');
-        else if (s.stage === 'ml-segmentation') s.label = t('progress.bgRemovalML');
-      });
-      // Cancel button lives in the ar-app command bar now (#71);
-      // its locale update is handled there.
-      this.update();
-    };
-    document.addEventListener('nukebg:locale-changed', this.boundLocaleHandler);
+    this.abortController = new AbortController();
+    on(
+      document,
+      'nukebg:locale-changed',
+      () => {
+        // Re-translate labels for active stages
+        this.stages.forEach((s) => {
+          if (s.stage === 'detect-background') s.label = t('progress.detectBg');
+          else if (s.stage === 'watermark-scan') s.label = t('progress.watermarkScan');
+          else if (s.stage === 'inpaint') s.label = t('progress.inpaint');
+          else if (s.stage === 'ml-segmentation') s.label = t('progress.bgRemovalML');
+        });
+        // Cancel button lives in the ar-app command bar now (#71);
+        // its locale update is handled there.
+        this.update();
+      },
+      { signal: this.abortController.signal },
+    );
 
     // #78 — inline error action delegation. Buttons rendered per-stage
     // when status === 'error'; dispatch a composed CustomEvent so the
@@ -59,8 +65,8 @@ export class ArProgress extends HTMLElement {
   }
 
   disconnectedCallback(): void {
-    if (this.boundLocaleHandler)
-      document.removeEventListener('nukebg:locale-changed', this.boundLocaleHandler);
+    this.abortController?.abort();
+    this.abortController = null;
   }
 
   reset(): void {

--- a/src/components/ar-viewer.ts
+++ b/src/components/ar-viewer.ts
@@ -4,6 +4,7 @@
  * + replace background with custom color.
  */
 import { t } from '../i18n';
+import { on } from '../lib/event-bus';
 
 export class ArViewer extends HTMLElement {
   private container!: HTMLDivElement;
@@ -18,7 +19,7 @@ export class ArViewer extends HTMLElement {
   private boundMouseUp: (() => void) | null = null;
   private boundTouchMove: ((e: TouchEvent) => void) | null = null;
   private boundTouchEnd: (() => void) | null = null;
-  private boundLocaleHandler: (() => void) | null = null;
+  private abortController: AbortController | null = null;
 
   constructor() {
     super();
@@ -27,16 +28,21 @@ export class ArViewer extends HTMLElement {
 
   connectedCallback(): void {
     this.render();
-    this.boundLocaleHandler = () => {
-      const root = this.shadowRoot!;
-      const origLabel = root.querySelector('#lbl-original');
-      if (origLabel) origLabel.textContent = t('viewer.original');
-      const resultLabel = root.querySelector('#lbl-result');
-      if (resultLabel) resultLabel.textContent = t('viewer.result');
-      const bgLabel = root.querySelector('#viewer-bg-label');
-      if (bgLabel) bgLabel.textContent = t('viewer.bg');
-    };
-    document.addEventListener('nukebg:locale-changed', this.boundLocaleHandler);
+    this.abortController = new AbortController();
+    on(
+      document,
+      'nukebg:locale-changed',
+      () => {
+        const root = this.shadowRoot!;
+        const origLabel = root.querySelector('#lbl-original');
+        if (origLabel) origLabel.textContent = t('viewer.original');
+        const resultLabel = root.querySelector('#lbl-result');
+        if (resultLabel) resultLabel.textContent = t('viewer.result');
+        const bgLabel = root.querySelector('#viewer-bg-label');
+        if (bgLabel) bgLabel.textContent = t('viewer.bg');
+      },
+      { signal: this.abortController.signal },
+    );
   }
 
   disconnectedCallback(): void {
@@ -44,8 +50,8 @@ export class ArViewer extends HTMLElement {
     if (this.boundMouseUp) document.removeEventListener('mouseup', this.boundMouseUp);
     if (this.boundTouchMove) document.removeEventListener('touchmove', this.boundTouchMove);
     if (this.boundTouchEnd) document.removeEventListener('touchend', this.boundTouchEnd);
-    if (this.boundLocaleHandler)
-      document.removeEventListener('nukebg:locale-changed', this.boundLocaleHandler);
+    this.abortController?.abort();
+    this.abortController = null;
   }
 
   private render(): void {

--- a/src/i18n/index.ts
+++ b/src/i18n/index.ts
@@ -4,6 +4,8 @@
  * emite evento custom cuando cambia el locale.
  */
 
+import { emit } from '../lib/event-bus';
+
 type Translations = Record<string, Record<string, string>>;
 
 const translations: Translations = {
@@ -1551,9 +1553,7 @@ export function setLocale(locale: string): void {
   document.documentElement.dir = getDirection(locale);
 
   // Emit event so components re-render
-  document.dispatchEvent(new CustomEvent('nukebg:locale-changed', {
-    detail: { locale },
-  }));
+  emit(document, 'nukebg:locale-changed', { locale });
 }
 
 /** Gets the active locale */

--- a/src/lib/event-bus.ts
+++ b/src/lib/event-bus.ts
@@ -1,0 +1,106 @@
+/**
+ * Typed contract for every cross-component custom event in the app.
+ *
+ * Closes the audit-#98 finding about leaked document-level listeners
+ * (the `boundLocaleHandler` pattern across 8 components) by giving
+ * callers an `on()` helper that ties cleanup to an `AbortSignal`. Also
+ * removes the `(e as CustomEvent<...>).detail` casts at every consumer
+ * — the bus knows the payload shape from the event name alone.
+ *
+ * The map below is the **single source of truth** for cross-component
+ * events. Adding a new event = add a line here; everywhere else picks
+ * up the type automatically. Don't dispatch a `CustomEvent` with a key
+ * that isn't in this map — the helpers won't accept it.
+ *
+ * Spun out of #47 Phase 4, tracked under #217.
+ */
+
+/** Map every public custom-event name to its detail payload. Use
+ *  `undefined` for events with no payload — callers then pass
+ *  `undefined` explicitly so the event surface stays grep-able. */
+export interface NukeBgEventMap {
+  // ── Pipeline / image lifecycle ───────────────────────────────────
+  'ar:image-loaded': {
+    file: File;
+    imageData: ImageData;
+    originalImageData: ImageData;
+    originalWidth: number;
+    originalHeight: number;
+    wasDownsampled: boolean;
+  };
+  'ar:images-loaded': {
+    images: Array<{
+      file: File;
+      imageData: ImageData;
+      originalImageData: ImageData;
+      originalWidth: number;
+      originalHeight: number;
+      wasDownsampled: boolean;
+    }>;
+  };
+  'ar:cancel-processing': undefined;
+  'ar:nuke-success': undefined;
+  'ar:process-another': undefined;
+
+  // ── Progress / stage actions ─────────────────────────────────────
+  'ar:stage-retry': { stage: string };
+  'ar:stage-report': { stage: string };
+
+  // ── Editor handoff ───────────────────────────────────────────────
+  'ar:editor-cancel': undefined;
+  'ar:editor-done': { imageData: ImageData };
+  'ar:advanced-cancel': undefined;
+  'ar:advanced-done': { imageData: ImageData };
+
+  // ── Batch grid ───────────────────────────────────────────────────
+  'batch:item-click': { id: string; state: string };
+  'batch:download-zip': undefined;
+  'batch:cancel': undefined;
+
+  // ── App-wide signals ─────────────────────────────────────────────
+  'nukebg:locale-changed': { locale: string };
+  'nukebg:pwa-installable': undefined;
+  'nukebg:sw-update-available': undefined;
+}
+
+export type NukeBgEventName = keyof NukeBgEventMap;
+
+export interface EmitOptions {
+  /** Cross shadow-root + DOM tree boundaries. Default: false. */
+  bubbles?: boolean;
+  /** Allow the event to escape its shadow root. Default: false. */
+  composed?: boolean;
+}
+
+/** Dispatch a typed custom event. Compile-time checks the name AND the
+ *  detail shape against `NukeBgEventMap`. */
+export function emit<K extends NukeBgEventName>(
+  target: EventTarget,
+  name: K,
+  detail: NukeBgEventMap[K],
+  opts: EmitOptions = {},
+): void {
+  target.dispatchEvent(
+    new CustomEvent(name, {
+      detail,
+      bubbles: opts.bubbles ?? false,
+      composed: opts.composed ?? false,
+    }),
+  );
+}
+
+/** Subscribe to a typed custom event. Always pass an `AbortSignal` so
+ *  cleanup ties to the host's lifecycle — no manual `removeEventListener`
+ *  pattern, no leaked listeners on `disconnectedCallback` bugs. */
+export function on<K extends NukeBgEventName>(
+  target: EventTarget,
+  name: K,
+  handler: (detail: NukeBgEventMap[K], event: CustomEvent<NukeBgEventMap[K]>) => void,
+  opts: AddEventListenerOptions & { signal: AbortSignal },
+): void {
+  const wrapped = (e: Event): void => {
+    const ce = e as CustomEvent<NukeBgEventMap[K]>;
+    handler(ce.detail, ce);
+  };
+  target.addEventListener(name, wrapped, opts);
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -166,7 +166,7 @@ function createShortcutOverlay(): HTMLDivElement {
 function showConsoleLogo(): void {
   const logo = `
 %c    ☢ NUKEBG ☢
-    v2.10.1 | Terminal Edition
+    v2.10.2 | Terminal Edition
 
     Your images never leave this machine.
     Don't believe us? Read the source:

--- a/src/pipeline/constants.ts
+++ b/src/pipeline/constants.ts
@@ -59,9 +59,17 @@ export const SPARKLE_PARAMS = {
    *  neighbors. Real Gemini sparkle arms are narrow lines — perpendicular
    *  samples land in dark gap territory. */
   MAX_PERP_ARM_RATIO: 0.8,
-  /** Mask radius multiplier (applied to detected sparkle radius). Tight fit
-   *  minimises the area Telea has to reconstruct — less "flat patch" look. */
-  MASK_RADIUS_MULTIPLIER: 1.15,
+  /** Mask radius multiplier (applied to detected sparkle radius).
+   *
+   *  Bumped 1.15 → 1.5 (#223 follow-up) after the legacy color-deviation
+   *  watermarkDetect was retired — that detector contributed a wider halo
+   *  mask (up to 2.0× radius gated by sparkle palette). At 1.15× the new
+   *  combined mask was too tight: residual near-white halo pixels just
+   *  outside the shape were left untouched by Telea, then RMBG correctly
+   *  classified them as background — visible as transparent dots around
+   *  the inpainted sparkle. 1.5× covers the natural halo without the
+   *  "flat patch" look becoming distracting. */
+  MASK_RADIUS_MULTIPLIER: 1.5,
 } as const;
 
 export const DALLE_WATERMARK_PARAMS = {

--- a/src/pipeline/finalize.ts
+++ b/src/pipeline/finalize.ts
@@ -262,16 +262,75 @@ export function fillSubjectHoles(
  * Caveat: inappropriate for classes where legitimate subject lives in
  * multiple disconnected components (signatures with accent dots, icon sets).
  * Callers must gate by content type.
+ *
+ * Threshold policy: a blob survives if its size is ≥ max(2, largest *
+ * KEEP_RATIO). The earlier "keep only the single largest" rule was too
+ * aggressive — RMBG occasionally splits a real subject into two
+ * disconnected blobs (e.g. a car body separated by a sun-glare chrome
+ * stripe down the middle), and the smaller half got mis-killed as an
+ * "orphan". 1% of largest preserves real disconnected subject parts
+ * while still dropping the small false-positive specks the function
+ * was added to clean. The hard floor of 2 px is just a sanity gate
+ * for tiny canvases (test fixtures); on real-world inputs the relative
+ * threshold dominates.
  */
+const ORPHAN_KEEP_RATIO = 0.01; // ≥1% of the largest blob
+
 export function dropOrphanBlobs(img: ImageData): ImageData {
   const { data, width, height } = img;
   const n = width * height;
   const bin = new Uint8Array(n);
   for (let i = 0; i < n; i++) bin[i] = data[i * 4 + 3] > 0 ? 1 : 0;
-  keepLargestComponent(bin, width, height);
+
+  // Label connected components (8-connectivity, BFS) and record sizes.
+  const labels = new Int32Array(n);
+  const queue = new Int32Array(n);
+  const sizes: number[] = [0]; // id 0 = background
+  let nextId = 0;
+
+  for (let i = 0; i < n; i++) {
+    if (bin[i] === 0 || labels[i] !== 0) continue;
+    nextId++;
+    labels[i] = nextId;
+    let head = 0;
+    let tail = 0;
+    queue[tail++] = i;
+    let size = 0;
+    while (head < tail) {
+      const idx = queue[head++];
+      size++;
+      const x = idx % width;
+      const y = (idx - x) / width;
+      for (let dy = -1; dy <= 1; dy++) {
+        for (let dx = -1; dx <= 1; dx++) {
+          if (dx === 0 && dy === 0) continue;
+          const nx = x + dx;
+          const ny = y + dy;
+          if (nx < 0 || nx >= width || ny < 0 || ny >= height) continue;
+          const ni = ny * width + nx;
+          if (bin[ni] && labels[ni] === 0) {
+            labels[ni] = nextId;
+            queue[tail++] = ni;
+          }
+        }
+      }
+    }
+    sizes.push(size);
+  }
+
+  if (nextId < 2) return img; // 0 or 1 blob → nothing to drop
+
+  let maxSize = 0;
+  for (let id = 1; id <= nextId; id++) {
+    if (sizes[id] > maxSize) maxSize = sizes[id];
+  }
+  const threshold = Math.max(2, Math.floor(maxSize * ORPHAN_KEEP_RATIO));
+
   const out = new Uint8ClampedArray(data);
   for (let i = 0; i < n; i++) {
-    if (!bin[i]) out[i * 4 + 3] = 0;
+    if (bin[i] && sizes[labels[i]] < threshold) {
+      out[i * 4 + 3] = 0;
+    }
   }
   return new ImageData(out, width, height);
 }

--- a/src/pipeline/orchestrator.ts
+++ b/src/pipeline/orchestrator.ts
@@ -2,7 +2,6 @@ import type {
   PipelineStage,
   StageStatus,
   PipelineResult,
-  BgColorResult,
   WatermarkResult,
   ImageContentType,
 } from '../types/pipeline';
@@ -579,19 +578,14 @@ export class PipelineOrchestrator {
     let t = performance.now();
     this.emit('detect-background', 'running', 'Analyzing image...');
 
-    // Run bg detection and content classification in parallel
-    const [bgInfo, classifyResult] = await Promise.all([
-      this.cvCall<BgColorResult>('detect-bg-colors', {
-        pixels: new Uint8ClampedArray(imageData.data),
-        width,
-        height,
-      }),
-      this.cvCall<ClassifyImageResult>('classify-image', {
-        pixels: new Uint8ClampedArray(imageData.data),
-        width,
-        height,
-      }),
-    ]);
+    // bg-color detection retired alongside watermarkDetect (its only
+    // consumer) — see watermark-scan stage below for context. Classifier
+    // still runs.
+    const classifyResult = await this.cvCall<ClassifyImageResult>('classify-image', {
+      pixels: new Uint8ClampedArray(imageData.data),
+      width,
+      height,
+    });
 
     const contentType: ImageContentType = classifyResult.type;
     stageTiming['detect-background'] = performance.now() - t;
@@ -635,14 +629,14 @@ export class PipelineOrchestrator {
       t = performance.now();
       this.emit('watermark-scan', 'running', 'Checking for watermarks...');
 
-      const [wmGemini, wmDalle, wmSparkle] = await Promise.all([
-        this.cvCall<WatermarkResult>('watermark-detect', {
-          pixels: new Uint8ClampedArray(imageData.data),
-          width,
-          height,
-          colorA: bgInfo.colorA,
-          colorB: bgInfo.colorB,
-        }),
+      // Color-deviation watermarkDetect retired: it had no shape gate so it
+      // false-positived on real photos with bright clustered features in
+      // the bottom-right (motorbike chrome, skin highlights in portraits,
+      // etc.). The shape-based sparkleDetect handles Gemini sparkles
+      // robustly; watermarkDetectDalle handles the multicolor bar.
+      // Reference: motostest + selfie-clean-corner regression triage,
+      // 2026-04-28.
+      const [wmDalle, wmSparkle] = await Promise.all([
         this.cvCall<WatermarkResult>('watermark-detect-dalle', {
           pixels: new Uint8ClampedArray(imageData.data),
           width,
@@ -655,15 +649,14 @@ export class PipelineOrchestrator {
         }),
       ]);
 
-      const anyWatermark = wmGemini.detected || wmDalle.detected || wmSparkle.detected;
+      const anyWatermark = wmDalle.detected || wmSparkle.detected;
       const combinedMask = PipelineOrchestrator.combineMasks(
-        [wmGemini.mask, wmDalle.mask, wmSparkle.mask],
+        [wmDalle.mask, wmSparkle.mask],
         width * height,
       );
 
       if (anyWatermark && combinedMask) {
         const sources: string[] = [];
-        if (wmGemini.detected) sources.push('Gemini');
         if (wmDalle.detected) sources.push('DALL-E');
         if (wmSparkle.detected) sources.push('Gemini-shape');
         this.emit('watermark-scan', 'done', `Watermark detected [${sources.join(', ')}]`);

--- a/src/sw-register.ts
+++ b/src/sw-register.ts
@@ -1,3 +1,5 @@
+import { emit } from './lib/event-bus';
+
 /** Deferred install prompt captured from beforeinstallprompt */
 let deferredPrompt: BeforeInstallPromptEvent | null = null;
 
@@ -33,14 +35,14 @@ if ('serviceWorker' in navigator) {
 
           newWorker.addEventListener('statechange', () => {
             if (newWorker.state === 'installed' && navigator.serviceWorker.controller) {
-              document.dispatchEvent(new CustomEvent('nukebg:sw-update-available'));
+              emit(document, 'nukebg:sw-update-available', undefined);
             }
           });
         };
 
         // Check if there's already a waiting worker
         if (registration.waiting && navigator.serviceWorker.controller) {
-          document.dispatchEvent(new CustomEvent('nukebg:sw-update-available'));
+          emit(document, 'nukebg:sw-update-available', undefined);
         }
 
         registration.addEventListener('updatefound', onUpdateFound);
@@ -54,6 +56,6 @@ if ('serviceWorker' in navigator) {
   window.addEventListener('beforeinstallprompt', (e) => {
     e.preventDefault();
     deferredPrompt = e as BeforeInstallPromptEvent;
-    document.dispatchEvent(new CustomEvent('nukebg:pwa-installable'));
+    emit(document, 'nukebg:pwa-installable', undefined);
   });
 }

--- a/src/utils/image-io.ts
+++ b/src/utils/image-io.ts
@@ -175,7 +175,7 @@ export async function exportPng(imageData: ImageData): Promise<Blob> {
     });
   }
   return injectPngMetadata(rawBlob, {
-    Software: 'NukeBG v2.10.1',
+    Software: 'NukeBG v2.10.2',
     Source: 'https://nukebg.app',
   });
 }

--- a/tests/lib/event-bus.test.ts
+++ b/tests/lib/event-bus.test.ts
@@ -1,0 +1,133 @@
+import { describe, it, expect, vi } from 'vitest';
+import { emit, on } from '../../src/lib/event-bus';
+
+/**
+ * Behavioural tests for the typed event-bus helpers (#217).
+ *
+ * Type-level correctness is enforced by tsc via `npm run typecheck` —
+ * these tests verify the runtime shape: emit dispatches a CustomEvent
+ * with the right name/detail, on() unwraps the detail, and AbortSignal
+ * unsubscribes cleanly.
+ */
+
+describe('event-bus', () => {
+  describe('emit + on round-trip', () => {
+    it('delivers the detail payload to the handler', () => {
+      const target = new EventTarget();
+      const ac = new AbortController();
+      const handler = vi.fn();
+
+      on(target, 'batch:item-click', handler, { signal: ac.signal });
+      emit(target, 'batch:item-click', { id: 'x', state: 'pending' });
+
+      expect(handler).toHaveBeenCalledTimes(1);
+      expect(handler.mock.calls[0][0]).toEqual({ id: 'x', state: 'pending' });
+    });
+
+    it('passes the wrapping CustomEvent as second arg for callers that need bubbles/target', () => {
+      const target = new EventTarget();
+      const ac = new AbortController();
+      const handler = vi.fn();
+
+      on(target, 'batch:item-click', handler, { signal: ac.signal });
+      emit(target, 'batch:item-click', { id: 'x', state: 'pending' });
+
+      const ce = handler.mock.calls[0][1];
+      expect(ce.type).toBe('batch:item-click');
+      expect(ce.detail).toEqual({ id: 'x', state: 'pending' });
+    });
+
+    it('handles undefined-detail events (CustomEvent normalizes to null per spec)', () => {
+      const target = new EventTarget();
+      const ac = new AbortController();
+      const handler = vi.fn();
+
+      on(target, 'ar:cancel-processing', handler, { signal: ac.signal });
+      emit(target, 'ar:cancel-processing', undefined);
+
+      expect(handler).toHaveBeenCalledTimes(1);
+      // CustomEvent ctor coerces `detail: undefined` to null. Documenting
+      // the runtime contract so consumers know not to do strict-equal
+      // checks against undefined for void events.
+      expect(handler.mock.calls[0][0]).toBeNull();
+    });
+  });
+
+  describe('AbortSignal cleanup', () => {
+    it('stops delivering after the signal aborts', () => {
+      const target = new EventTarget();
+      const ac = new AbortController();
+      const handler = vi.fn();
+
+      on(target, 'nukebg:locale-changed', handler, { signal: ac.signal });
+      emit(target, 'nukebg:locale-changed', { locale: 'en' });
+      ac.abort();
+      emit(target, 'nukebg:locale-changed', { locale: 'es' });
+
+      expect(handler).toHaveBeenCalledTimes(1);
+      expect(handler.mock.calls[0][0].locale).toBe('en');
+    });
+
+    it('multiple listeners on the same target detach independently', () => {
+      const target = new EventTarget();
+      const ac1 = new AbortController();
+      const ac2 = new AbortController();
+      const h1 = vi.fn();
+      const h2 = vi.fn();
+
+      on(target, 'nukebg:locale-changed', h1, { signal: ac1.signal });
+      on(target, 'nukebg:locale-changed', h2, { signal: ac2.signal });
+
+      emit(target, 'nukebg:locale-changed', { locale: 'en' });
+      ac1.abort();
+      emit(target, 'nukebg:locale-changed', { locale: 'es' });
+
+      expect(h1).toHaveBeenCalledTimes(1);
+      expect(h2).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe('emit options', () => {
+    it('defaults bubbles and composed to false', () => {
+      const target = new EventTarget();
+      const ac = new AbortController();
+      let captured: CustomEvent | null = null;
+      on(
+        target,
+        'ar:nuke-success',
+        (_detail, ce) => {
+          captured = ce;
+        },
+        { signal: ac.signal },
+      );
+
+      emit(target, 'ar:nuke-success', undefined);
+      expect(captured).not.toBeNull();
+      expect(captured!.bubbles).toBe(false);
+      expect(captured!.composed).toBe(false);
+    });
+
+    it('forwards explicit bubbles + composed to the CustomEvent', () => {
+      const target = new EventTarget();
+      const ac = new AbortController();
+      let captured: CustomEvent | null = null;
+      on(
+        target,
+        'batch:item-click',
+        (_detail, ce) => {
+          captured = ce;
+        },
+        { signal: ac.signal },
+      );
+
+      emit(
+        target,
+        'batch:item-click',
+        { id: 'x', state: 'done' },
+        { bubbles: true, composed: true },
+      );
+      expect(captured!.bubbles).toBe(true);
+      expect(captured!.composed).toBe(true);
+    });
+  });
+});

--- a/tests/pipeline/finalize.test.ts
+++ b/tests/pipeline/finalize.test.ts
@@ -361,6 +361,62 @@ describe('dropOrphanBlobs', () => {
     dropOrphanBlobs(new ImageData(data, w, h));
     expect(Array.from(data)).toEqual(snapshot);
   });
+
+  it('preserves a substantial second blob (regression: coche right-side cropping)', () => {
+    // Reproduces the bug pattern: a real subject split by RMBG into two
+    // disconnected blobs. The smaller half must survive when it's a real
+    // chunk of the subject (not a tiny speck). Earlier the function
+    // dropped EVERY non-largest blob — even ones that were ~30% of main.
+    //
+    // 100x100 canvas. Left half body (50x100=5000 px) + right half body
+    // (40x100=4000 px) separated by a 10-px-wide α=0 stripe. Expected:
+    // both blobs survive (4000 ≥ max(2, 5000*0.01)=50).
+    const w = 100,
+      h = 100;
+    const data = new Uint8ClampedArray(w * h * 4);
+    for (let y = 0; y < h; y++) {
+      for (let x = 0; x < w; x++) {
+        const i = (y * w + x) * 4;
+        data[i] = 200;
+        data[i + 1] = 100;
+        data[i + 2] = 50;
+        // Body covers all rows; gap from x=45..54 is α=0.
+        data[i + 3] = x >= 45 && x <= 54 ? 0 : 255;
+      }
+    }
+
+    const out = dropOrphanBlobs(new ImageData(data, w, h));
+
+    // Left blob (largest) survives
+    expect(out.data[(50 * w + 10) * 4 + 3]).toBe(255);
+    // Right blob (smaller but substantial) ALSO survives — the regression
+    expect(out.data[(50 * w + 80) * 4 + 3]).toBe(255);
+  });
+
+  it('still drops tiny orphan specks under the relative threshold', () => {
+    // 100x100 canvas. Big body 50x50 (2500 px) + a 5-pixel speck. Speck
+    // size 5 < threshold max(2, 2500*0.01)=25 → dropped.
+    const w = 100,
+      h = 100;
+    const data = new Uint8ClampedArray(w * h * 4);
+    for (let y = 10; y < 60; y++) {
+      for (let x = 10; x < 60; x++) {
+        data[(y * w + x) * 4 + 3] = 255;
+      }
+    }
+    // 5-pixel horizontal speck at bottom-right corner.
+    for (let x = 90; x < 95; x++) {
+      data[(95 * w + x) * 4 + 3] = 255;
+    }
+
+    const out = dropOrphanBlobs(new ImageData(data, w, h));
+    // Body intact
+    expect(out.data[(30 * w + 30) * 4 + 3]).toBe(255);
+    // Speck dropped
+    for (let x = 90; x < 95; x++) {
+      expect(out.data[(95 * w + x) * 4 + 3]).toBe(0);
+    }
+  });
 });
 
 describe('fillSubjectHoles', () => {


### PR DESCRIPTION
Ships v2.10.2 to production.

## Highlights

- **Watermark false-positives killed** — motostest.jpeg + selfie-clean-corner.png stop tripping the legacy color-deviation detector. Shape-based sparkleDetect + DALL-E detector remain.
- **Coche right-side cropping fixed** — \`dropOrphanBlobs\` now uses a 1%-of-largest threshold instead of "single largest only". Real disconnected subject parts survive; tiny specks still die.
- **Sparkle inpaint halo restored** — the tight 1.15× mask after #223 left transparent dots around inpainted sparkles. Bumped to 1.5× to cover the natural halo.
- **e2e \`coche-capture\` no longer flakes** — renamed so it runs after smaller fixtures absorb cold-start ML warmup.
- **Typed event-bus** — every cross-component custom event now goes through \`src/lib/event-bus.ts\` with compile-time-checked names + payloads + AbortSignal-based cleanup. No more \`(e as CustomEvent<...>).detail\` casts; no more manual \`removeEventListener\` in disconnect.

## Validation gates

| Gate | Result |
|------|--------|
| \`npm run typecheck\` | ✅ green |
| \`npm test\` | ✅ **937/937** |
| \`npm run build\` | ✅ green |

## Risk

Pipeline behavior changes are tested with new regression-guards. The watermark change MAY surface new edge cases on real photos with actual Gemini sparkles where only the legacy detector fired (shape detector misses them). Acceptable trade — false-positive cure outweighs that risk.

## Roll-back

\`git revert\` the merge commit, OR \`git reset --hard\` to v2.10.1 commit on main (\`5c2efd9\`). Pipeline-only changes — fully symmetric.

## Known limitation deferred

Issue #226 — RMBG-1.4 mis-segments the lower portion of the front brake disc on motostest (and similar thin chrome features). Live ~1 month, doesn't block release; out-of-scope until a better permissive model is available.

## CHANGELOG

https://github.com/yocreoquesi/nukebg/blob/dev/CHANGELOG.md#2102--2026-04-28