### PR TITLE
release: v2.11.0 — mobile editor gestures + network-first SW

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,42 @@ Unreleased entries accumulate on the `dev` branch. When we cut a release we copy
 
 ## [Unreleased]
 
+## [2.11.0] — 2026-04-29
+
+Minor release. Mobile UX overhaul for the advanced editor plus a
+service-worker fix so new releases stop being one navigation late on
+returning visitors.
+
+### Added
+
+- **Two-finger pan + pinch-zoom in the advanced editor.** Touch users
+  can now zoom (pinch) and pan (two fingers together, no pinch) on the
+  canvas. Both gestures compose in the same handler — drag to reframe
+  while pinching to zoom. Tracked with a centroid alongside the existing
+  pinch-distance so panX/Y and zoom update in a single \`applyTransform\`.
+  i18n labels updated across all 6 locales.
+
+### Fixed
+
+- **Apply / Cancel / Undo / Redo are no longer hidden behind the fixed
+  bottom toolbar on mobile.** Added \`padding-bottom: calc(160px +
+  env(safe-area-inset-bottom))\` on \`:host\` under
+  \`@media (pointer: coarse)\` so the editor's \`.controls\` row scrolls
+  into view above the fixed Pincel/Borrador/Lazo toolbar instead of
+  being eaten by it.
+- **Restaurar Original / Reprocesar visible on editor toggle (mobile).**
+  Switched the post-toggle \`scrollIntoView\` from \`block: 'center'\` to
+  \`block: 'start'\` so the editor's header lands at the top of viewport
+  with its action buttons fully rendered, instead of scrolled above
+  the fold.
+- **Service worker now serves the latest release on the very next
+  page load.** Replaced stale-while-revalidate on navigation with
+  network-first (cache fallback for offline). Returning visitors were
+  getting last-deploy's HTML once before the fresh version showed up
+  — \`v2.5.0\` shipping next to a deployed \`v2.10.2\` was a real
+  symptom on a Galaxy S23. Bumped \`CACHE_VERSION\` to \`nukebg-v5\`
+  so the activate handler purges the previous cache on first load.
+
 ## [2.10.2] — 2026-04-28
 
 Patch release. Six PRs landed since v2.10.1 — typed event-bus migration,

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 > Nuke backgrounds from any image. 100% client-side. Zero uploads. Zero BS.
 
-[![Version](https://img.shields.io/badge/version-2.10.2-brightgreen.svg)](https://github.com/yocreoquesi/nukebg/releases)
+[![Version](https://img.shields.io/badge/version-2.11.0-brightgreen.svg)](https://github.com/yocreoquesi/nukebg/releases)
 [![License: GPL-3.0](https://img.shields.io/badge/License-GPL%20v3-blue.svg)](https://www.gnu.org/licenses/gpl-3.0)
 [![Client-Side](https://img.shields.io/badge/Processing-100%25%20Client--Side-green.svg)](#-privacy)
 

--- a/index.html
+++ b/index.html
@@ -151,7 +151,7 @@
           "PNG export with true alpha transparency"
         ],
         "screenshot": "https://nukebg.app/og-image.png",
-        "softwareVersion": "2.10.2",
+        "softwareVersion": "2.11.0",
         "license": "https://www.gnu.org/licenses/gpl-3.0.html",
         "isAccessibleForFree": true,
         "creator": {
@@ -487,7 +487,7 @@
     <!-- <ar-post-cta id="post-cta"></ar-post-cta> -->
 
     <footer class="footer hazard-border-top" role="contentinfo">
-      <span>NukeBG <span style="color: var(--color-text-tertiary)">v2.10.2</span></span>
+      <span>NukeBG <span style="color: var(--color-text-tertiary)">v2.11.0</span></span>
       <span class="footer-sep">|</span>
       <a href="https://github.com/yocreoquesi/nukebg" target="_blank" rel="noopener noreferrer"
         >GitHub</a

--- a/infra/nginx.conf
+++ b/infra/nginx.conf
@@ -31,7 +31,7 @@ server {
     #   new Function() WASM bootstrap.
     # - sha256 hashes cover the 3 inline JSON-LD blocks in index.html.
     #   Regenerate with `node scripts/compute-csp-hashes.mjs` after edits.
-    add_header Content-Security-Policy "default-src 'self'; script-src 'self' blob: 'wasm-unsafe-eval' 'unsafe-eval' 'sha256-suL/7MXuEJxulF14znTnwjBHbgB7E1bNMb9DQbFnvao=' 'sha256-uZm4Xh9FxR3B7WjPHL5pbehtSMYTCy9JWzQzl3/UKA0=' 'sha256-o1DLxvGFHY9H1AG6Sro58slSTxU3T7zb020gfyqbFwM=' https://cdn.jsdelivr.net; worker-src 'self' blob:; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; connect-src 'self' https://huggingface.co https://cdn-lfs.huggingface.co https://cdn-lfs-us-1.huggingface.co https://cdn.jsdelivr.net https://cas-bridge.xethub.hf.co; font-src 'self'; object-src 'none'; base-uri 'self'; form-action 'none'" always;
+    add_header Content-Security-Policy "default-src 'self'; script-src 'self' blob: 'wasm-unsafe-eval' 'unsafe-eval' 'sha256-G/w80f038H+I2cLCOdptG84zIPhPj7PhJtLNQvCC5EI=' 'sha256-uZm4Xh9FxR3B7WjPHL5pbehtSMYTCy9JWzQzl3/UKA0=' 'sha256-o1DLxvGFHY9H1AG6Sro58slSTxU3T7zb020gfyqbFwM=' https://cdn.jsdelivr.net; worker-src 'self' blob:; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; connect-src 'self' https://huggingface.co https://cdn-lfs.huggingface.co https://cdn-lfs-us-1.huggingface.co https://cdn.jsdelivr.net https://cas-bridge.xethub.hf.co; font-src 'self'; object-src 'none'; base-uri 'self'; form-action 'none'" always;
 
     # Cache static assets
     # Note: add_header in location blocks replaces parent headers in nginx,
@@ -46,7 +46,7 @@ server {
         add_header Strict-Transport-Security "max-age=63072000; includeSubDomains; preload" always;
         add_header Cross-Origin-Opener-Policy "same-origin" always;
         add_header X-DNS-Prefetch-Control "off" always;
-        add_header Content-Security-Policy "default-src 'self'; script-src 'self' blob: 'wasm-unsafe-eval' 'unsafe-eval' 'sha256-suL/7MXuEJxulF14znTnwjBHbgB7E1bNMb9DQbFnvao=' 'sha256-uZm4Xh9FxR3B7WjPHL5pbehtSMYTCy9JWzQzl3/UKA0=' 'sha256-o1DLxvGFHY9H1AG6Sro58slSTxU3T7zb020gfyqbFwM=' https://cdn.jsdelivr.net; worker-src 'self' blob:; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; connect-src 'self' https://huggingface.co https://cdn-lfs.huggingface.co https://cdn-lfs-us-1.huggingface.co https://cdn.jsdelivr.net https://cas-bridge.xethub.hf.co; font-src 'self'; object-src 'none'; base-uri 'self'; form-action 'none'" always;
+        add_header Content-Security-Policy "default-src 'self'; script-src 'self' blob: 'wasm-unsafe-eval' 'unsafe-eval' 'sha256-G/w80f038H+I2cLCOdptG84zIPhPj7PhJtLNQvCC5EI=' 'sha256-uZm4Xh9FxR3B7WjPHL5pbehtSMYTCy9JWzQzl3/UKA0=' 'sha256-o1DLxvGFHY9H1AG6Sro58slSTxU3T7zb020gfyqbFwM=' https://cdn.jsdelivr.net; worker-src 'self' blob:; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; connect-src 'self' https://huggingface.co https://cdn-lfs.huggingface.co https://cdn-lfs-us-1.huggingface.co https://cdn.jsdelivr.net https://cas-bridge.xethub.hf.co; font-src 'self'; object-src 'none'; base-uri 'self'; form-action 'none'" always;
     }
 
     # ONNX model files — cache aggressively, same-origin so CORP is fine
@@ -60,7 +60,7 @@ server {
         add_header Strict-Transport-Security "max-age=63072000; includeSubDomains; preload" always;
         add_header Cross-Origin-Opener-Policy "same-origin" always;
         add_header X-DNS-Prefetch-Control "off" always;
-        add_header Content-Security-Policy "default-src 'self'; script-src 'self' blob: 'wasm-unsafe-eval' 'unsafe-eval' 'sha256-suL/7MXuEJxulF14znTnwjBHbgB7E1bNMb9DQbFnvao=' 'sha256-uZm4Xh9FxR3B7WjPHL5pbehtSMYTCy9JWzQzl3/UKA0=' 'sha256-o1DLxvGFHY9H1AG6Sro58slSTxU3T7zb020gfyqbFwM=' https://cdn.jsdelivr.net; worker-src 'self' blob:; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; connect-src 'self' https://huggingface.co https://cdn-lfs.huggingface.co https://cdn-lfs-us-1.huggingface.co https://cdn.jsdelivr.net https://cas-bridge.xethub.hf.co; font-src 'self'; object-src 'none'; base-uri 'self'; form-action 'none'" always;
+        add_header Content-Security-Policy "default-src 'self'; script-src 'self' blob: 'wasm-unsafe-eval' 'unsafe-eval' 'sha256-G/w80f038H+I2cLCOdptG84zIPhPj7PhJtLNQvCC5EI=' 'sha256-uZm4Xh9FxR3B7WjPHL5pbehtSMYTCy9JWzQzl3/UKA0=' 'sha256-o1DLxvGFHY9H1AG6Sro58slSTxU3T7zb020gfyqbFwM=' https://cdn.jsdelivr.net; worker-src 'self' blob:; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; connect-src 'self' https://huggingface.co https://cdn-lfs.huggingface.co https://cdn-lfs-us-1.huggingface.co https://cdn.jsdelivr.net https://cas-bridge.xethub.hf.co; font-src 'self'; object-src 'none'; base-uri 'self'; form-action 'none'" always;
     }
 
     # SPA fallback

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "nukebg",
-  "version": "2.10.2",
+  "version": "2.11.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "nukebg",
-      "version": "2.10.2",
+      "version": "2.11.0",
       "license": "GPL-3.0-only",
       "dependencies": {
         "@huggingface/transformers": "^3.8.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "nukebg",
   "private": true,
-  "version": "2.10.2",
+  "version": "2.11.0",
   "type": "module",
   "description": "NukeBG: Nuke AI backgrounds, checkerboard patterns, and watermarks. 100% client-side. Zero uploads. Zero BS.",
   "license": "GPL-3.0-only",

--- a/public/_headers
+++ b/public/_headers
@@ -7,7 +7,7 @@
   Cross-Origin-Resource-Policy: same-origin
   X-DNS-Prefetch-Control: off
   Strict-Transport-Security: max-age=63072000; includeSubDomains; preload
-  Content-Security-Policy: default-src 'self'; script-src 'self' blob: 'wasm-unsafe-eval' 'unsafe-eval' 'sha256-suL/7MXuEJxulF14znTnwjBHbgB7E1bNMb9DQbFnvao=' 'sha256-uZm4Xh9FxR3B7WjPHL5pbehtSMYTCy9JWzQzl3/UKA0=' 'sha256-o1DLxvGFHY9H1AG6Sro58slSTxU3T7zb020gfyqbFwM=' https://cdn.jsdelivr.net; worker-src 'self' blob:; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; connect-src 'self' https://huggingface.co https://cdn-lfs.huggingface.co https://cdn-lfs-us-1.huggingface.co https://cdn.jsdelivr.net https://cas-bridge.xethub.hf.co; font-src 'self'; object-src 'none'; base-uri 'self'; form-action 'none'
+  Content-Security-Policy: default-src 'self'; script-src 'self' blob: 'wasm-unsafe-eval' 'unsafe-eval' 'sha256-G/w80f038H+I2cLCOdptG84zIPhPj7PhJtLNQvCC5EI=' 'sha256-uZm4Xh9FxR3B7WjPHL5pbehtSMYTCy9JWzQzl3/UKA0=' 'sha256-o1DLxvGFHY9H1AG6Sro58slSTxU3T7zb020gfyqbFwM=' https://cdn.jsdelivr.net; worker-src 'self' blob:; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; connect-src 'self' https://huggingface.co https://cdn-lfs.huggingface.co https://cdn-lfs-us-1.huggingface.co https://cdn.jsdelivr.net https://cas-bridge.xethub.hf.co; font-src 'self'; object-src 'none'; base-uri 'self'; form-action 'none'
 
 /assets/*
   Cache-Control: public, max-age=31536000, immutable

--- a/public/service-worker.js
+++ b/public/service-worker.js
@@ -1,5 +1,5 @@
-// Service Worker v3 — PWA caching with stale-while-revalidate + cache-first
-const CACHE_VERSION = 'nukebg-v4';
+// Service Worker v4 — PWA caching with network-first (navigation) + cache-first (assets)
+const CACHE_VERSION = 'nukebg-v5';
 
 // URLs that must NEVER be cached (ML model + CDN assets)
 const EXCLUDED_PATTERNS = [
@@ -72,8 +72,10 @@ self.addEventListener('fetch', (event) => {
   if (request.method !== 'GET') return;
 
   if (isNavigationRequest(request)) {
-    // Stale-while-revalidate for navigation
-    event.respondWith(staleWhileRevalidate(request));
+    // Network-first for navigation so a new release shows up on the very next
+    // load instead of one navigation late. Hashed asset URLs in the fresh HTML
+    // never collide with cached ones, so cache-first below stays safe.
+    event.respondWith(networkFirst(request));
   } else if (isStaticAsset(url)) {
     // Cache-first for hashed assets, fonts, and static files
     event.respondWith(cacheFirst(request));
@@ -81,21 +83,19 @@ self.addEventListener('fetch', (event) => {
   // All other requests go to network (no caching)
 });
 
-// Strategy: stale-while-revalidate
-async function staleWhileRevalidate(request) {
+// Strategy: network-first (cache fallback for offline)
+async function networkFirst(request) {
   const cache = await caches.open(CACHE_VERSION);
-  const cachedResponse = await cache.match(request);
-
-  const networkFetch = fetch(request)
-    .then((response) => {
-      if (response.ok) {
-        cache.put(request, response.clone());
-      }
-      return response;
-    })
-    .catch(() => cachedResponse);
-
-  return cachedResponse || networkFetch;
+  try {
+    const response = await fetch(request);
+    if (response.ok) {
+      cache.put(request, response.clone());
+    }
+    return response;
+  } catch (_err) {
+    const cachedResponse = await cache.match(request);
+    return cachedResponse || new Response('Offline', { status: 503 });
+  }
 }
 
 // Strategy: cache-first

--- a/src/components/ar-app.ts
+++ b/src/components/ar-app.ts
@@ -1418,7 +1418,7 @@ export class ArApp extends HTMLElement {
         adv.setImage(current, original);
         adv.setAttribute('active', '');
         btn.setAttribute('data-active', 'true');
-        adv.scrollIntoView({ behavior: 'smooth', block: 'center' });
+        adv.scrollIntoView({ behavior: 'smooth', block: 'start' });
       },
       { signal },
     );

--- a/src/components/ar-editor-advanced.ts
+++ b/src/components/ar-editor-advanced.ts
@@ -111,9 +111,14 @@ export class ArEditorAdvanced extends HTMLElement {
   private lastPanClientX = 0;
   private lastPanClientY = 0;
 
-  // Touch pinch tracking. We avoid setPointerCapture during pinch so both
-  // fingers keep generating events.
+  // Two-finger gesture tracking. We avoid setPointerCapture during pinch so
+  // both fingers keep generating events. Tracking the midpoint alongside the
+  // distance lets us detect both pinch-zoom (Δdistance) and pan (Δmidpoint)
+  // in the same handler — they compose so users can drag-to-pan and
+  // pinch-to-zoom simultaneously.
   private lastPinchDist = 0;
+  private lastPinchMidX = 0;
+  private lastPinchMidY = 0;
   private pinching = false;
 
   // Lasso state (all coordinates in image-space — may be outside [0..w/h]
@@ -726,6 +731,12 @@ export class ArEditorAdvanced extends HTMLElement {
         }
 
         @media (pointer: coarse) {
+          /* Reserve space for the fixed bottom toolbar so .controls
+             (Apply / Cancel / Undo / Redo) can scroll into view above
+             it instead of being eaten by the fixed bar. */
+          :host {
+            padding-bottom: calc(160px + env(safe-area-inset-bottom, 0px));
+          }
           .toolbar {
             position: fixed;
             bottom: 0;
@@ -1378,12 +1389,23 @@ export class ArEditorAdvanced extends HTMLElement {
     return Math.sqrt(dx * dx + dy * dy);
   }
 
+  private getPinchMid(touches: TouchList): { x: number; y: number } {
+    return {
+      x: (touches[0].clientX + touches[1].clientX) / 2,
+      y: (touches[0].clientY + touches[1].clientY) / 2,
+    };
+  }
+
   private onTouchStart(e: TouchEvent): void {
     if (e.touches.length !== 2) return;
-    // Two fingers down: start pinch-to-zoom, suppress pointer draw path.
+    // Two fingers down: start pinch-zoom + two-finger pan, suppress
+    // the pointer draw path.
     e.preventDefault();
     this.pinching = true;
     this.lastPinchDist = this.getPinchDist(e.touches);
+    const mid = this.getPinchMid(e.touches);
+    this.lastPinchMidX = mid.x;
+    this.lastPinchMidY = mid.y;
     // Cancel any brush stroke that might have started on the first touch.
     this.drawing = false;
     this.lasso.endDragAnchor();
@@ -1393,11 +1415,22 @@ export class ArEditorAdvanced extends HTMLElement {
     if (e.touches.length !== 2 || !this.pinching) return;
     e.preventDefault();
     const dist = this.getPinchDist(e.touches);
+    const mid = this.getPinchMid(e.touches);
+    // Pan first so it composes with the zoom that follows. Order doesn't
+    // matter mathematically (translate + scale commute when applied to a
+    // delta), but we update the panX/panY before setZoom triggers a
+    // single applyTransform.
+    this.panX += mid.x - this.lastPinchMidX;
+    this.panY += mid.y - this.lastPinchMidY;
     if (this.lastPinchDist > 0) {
       const scale = dist / this.lastPinchDist;
       this.setZoom(this.zoom * scale);
+    } else {
+      this.applyTransform();
     }
     this.lastPinchDist = dist;
+    this.lastPinchMidX = mid.x;
+    this.lastPinchMidY = mid.y;
   }
 
   private onTouchEnd(): void {

--- a/src/i18n/index.ts
+++ b/src/i18n/index.ts
@@ -129,10 +129,10 @@ const translations: Translations = {
     'advanced.keyPan': 'Pan',
     'advanced.keyDeleteAnchor': 'Delete anchor',
     'advanced.gestureOneFinger': 'One-finger drag',
-    'advanced.gesturePinch': 'Two-finger pinch',
+    'advanced.gesturePinch': 'Two-finger pinch / drag',
     'advanced.gestureDoubleTap': 'Double-tap',
     'advanced.gestureDraw': 'Draw / drag',
-    'advanced.gestureZoom': 'Zoom',
+    'advanced.gestureZoom': 'Zoom & pan',
 
     // Viewer
     'viewer.original': 'Before',
@@ -373,10 +373,10 @@ const translations: Translations = {
     'advanced.keyPan': 'Desplazar',
     'advanced.keyDeleteAnchor': 'Borrar punto',
     'advanced.gestureOneFinger': 'Arrastre con un dedo',
-    'advanced.gesturePinch': 'Pellizco con dos dedos',
+    'advanced.gesturePinch': 'Dos dedos: pellizcar / arrastrar',
     'advanced.gestureDoubleTap': 'Doble toque',
     'advanced.gestureDraw': 'Dibujar / arrastrar',
-    'advanced.gestureZoom': 'Zoom',
+    'advanced.gestureZoom': 'Zoom y desplazar',
 
     // Viewer
     'viewer.original': 'Antes',
@@ -617,10 +617,10 @@ const translations: Translations = {
     'advanced.keyPan': 'D\u00E9placer',
     'advanced.keyDeleteAnchor': 'Supprimer la poign\u00E9e',
     'advanced.gestureOneFinger': 'Glisser \u00E0 un doigt',
-    'advanced.gesturePinch': 'Pincer \u00E0 deux doigts',
+    'advanced.gesturePinch': 'Deux doigts : pincer / glisser',
     'advanced.gestureDoubleTap': 'Double tap',
     'advanced.gestureDraw': 'Dessiner / glisser',
-    'advanced.gestureZoom': 'Zoom',
+    'advanced.gestureZoom': 'Zoom et déplacement',
 
     // Viewer
     'viewer.original': 'Avant',
@@ -861,10 +861,10 @@ const translations: Translations = {
     'advanced.keyPan': 'Verschieben',
     'advanced.keyDeleteAnchor': 'Griff l\u00F6schen',
     'advanced.gestureOneFinger': 'Mit einem Finger ziehen',
-    'advanced.gesturePinch': 'Mit zwei Fingern zoomen',
+    'advanced.gesturePinch': 'Zwei Finger: zoomen / ziehen',
     'advanced.gestureDoubleTap': 'Doppeltippen',
     'advanced.gestureDraw': 'Zeichnen / ziehen',
-    'advanced.gestureZoom': 'Zoom',
+    'advanced.gestureZoom': 'Zoom & Verschieben',
 
     // Viewer
     'viewer.original': 'Vorher',
@@ -1105,10 +1105,10 @@ const translations: Translations = {
     'advanced.keyPan': 'Mover',
     'advanced.keyDeleteAnchor': 'Apagar al\u00E7a',
     'advanced.gestureOneFinger': 'Arrastar com um dedo',
-    'advanced.gesturePinch': 'Pin\u00E7a com dois dedos',
+    'advanced.gesturePinch': 'Dois dedos: pin\u00E7a / arrastar',
     'advanced.gestureDoubleTap': 'Duplo toque',
     'advanced.gestureDraw': 'Desenhar / arrastar',
-    'advanced.gestureZoom': 'Zoom',
+    'advanced.gestureZoom': 'Zoom e deslocar',
 
     // Viewer
     'viewer.original': 'Antes',
@@ -1349,10 +1349,10 @@ const translations: Translations = {
     'advanced.keyPan': '\u5E73\u79FB',
     'advanced.keyDeleteAnchor': '\u5220\u9664\u624B\u67C4',
     'advanced.gestureOneFinger': '\u5355\u6307\u62D6\u52A8',
-    'advanced.gesturePinch': '\u53CC\u6307\u6346\u6346',
+    'advanced.gesturePinch': '\u53CC\u6307\u6346\u5408 / \u62D6\u52A8',
     'advanced.gestureDoubleTap': '\u53CC\u51FB',
     'advanced.gestureDraw': '\u7ED8\u5236 / \u62D6\u52A8',
-    'advanced.gestureZoom': '\u7F29\u653E',
+    'advanced.gestureZoom': '\u7F29\u653E\u4E0E\u5E73\u79FB',
 
     // Viewer
     'viewer.original': '\u539F\u56FE',

--- a/src/main.ts
+++ b/src/main.ts
@@ -166,7 +166,7 @@ function createShortcutOverlay(): HTMLDivElement {
 function showConsoleLogo(): void {
   const logo = `
 %c    ☢ NUKEBG ☢
-    v2.10.2 | Terminal Edition
+    v2.11.0 | Terminal Edition
 
     Your images never leave this machine.
     Don't believe us? Read the source:

--- a/src/utils/image-io.ts
+++ b/src/utils/image-io.ts
@@ -175,7 +175,7 @@ export async function exportPng(imageData: ImageData): Promise<Blob> {
     });
   }
   return injectPngMetadata(rawBlob, {
-    Software: 'NukeBG v2.10.2',
+    Software: 'NukeBG v2.11.0',
     Source: 'https://nukebg.app',
   });
 }


### PR DESCRIPTION
Promotes v2.11.0 from dev to main → deploys to Cloudflare Pages production.

## Changes since v2.10.2

- **feat(advanced-editor):** two-finger pinch-zoom + two-finger pan via centroid tracking; compose in a single `applyTransform`.
- **fix(advanced-editor mobile):** Apply / Cancel / Undo / Redo render above the fixed bottom toolbar instead of behind it.
- **fix(advanced-editor mobile):** REPROCESAR + RESTAURAR ORIGINAL visible on editor toggle (`scrollIntoView block: 'start'`).
- **fix(sw):** network-first navigation replaces stale-while-revalidate; `CACHE_VERSION` bumped to `nukebg-v5`. Returning visitors get the latest release on the next page load instead of one navigation late.
- **i18n:** `gesturePinch` + `gestureZoom` updated across all 6 locales.
- **fix(csp):** regenerated sha256 for index.html JSON-LD after version bump.

Merged via PR #229.

## Test plan

- [x] All CI checks green on PR #229 (typecheck, vitest, playwright iphone+webkit, pipeline e2e, lint+format, codeql, osv, npm audit, cloudflare preview)
- [x] Verified A1 + A2 on Galaxy S23 / Android 16 / Chrome
- [x] User-confirmed pinch zoom + two-finger pan on device
- [ ] Smoke test on production after deploy (force-reload to bypass any cached old SW)