### PR TITLE
fix(sparkle): peak-relocated flood-fill mask (kills phone holes from inflated bestR)

### DIFF
--- a/src/pipeline/constants.ts
+++ b/src/pipeline/constants.ts
@@ -59,17 +59,20 @@ export const SPARKLE_PARAMS = {
    *  neighbors. Real Gemini sparkle arms are narrow lines — perpendicular
    *  samples land in dark gap territory. */
   MAX_PERP_ARM_RATIO: 0.8,
-  /** Mask radius multiplier (applied to detected sparkle radius).
-   *
-   *  Bumped 1.15 → 1.5 (#223 follow-up) after the legacy color-deviation
-   *  watermarkDetect was retired — that detector contributed a wider halo
-   *  mask (up to 2.0× radius gated by sparkle palette). At 1.15× the new
-   *  combined mask was too tight: residual near-white halo pixels just
-   *  outside the shape were left untouched by Telea, then RMBG correctly
-   *  classified them as background — visible as transparent dots around
-   *  the inpainted sparkle. 1.5× covers the natural halo without the
-   *  "flat patch" look becoming distracting. */
-  MASK_RADIUS_MULTIPLIER: 1.5,
+  /** Core mask radius multiplier (applied to detected sparkle radius).
+   *  Tight by design — the actual ✦ shape is fully covered well within
+   *  this radius. The natural near-white halo is masked separately by
+   *  the palette-gated outer ring (HALO_RADIUS_MULTIPLIER) so this can
+   *  stay snug and avoid the "flat patch" artifact on uniform regions. */
+  MASK_RADIUS_MULTIPLIER: 1.2,
+  /** Outer halo radius multiplier. Pixels between MASK_RADIUS_MULTIPLIER
+   *  and this radius are added to the mask ONLY if they match the Gemini
+   *  sparkle palette (near-white / slight cyan tint). Ports the legacy
+   *  watermark-detect halo-expansion behavior into the shape detector
+   *  without reintroducing its false-positive surface (#223). Fixes the
+   *  transparent-dot regression on selfies where the natural halo bled
+   *  into RMBG's background classification. */
+  HALO_RADIUS_MULTIPLIER: 2.0,
 } as const;
 
 export const DALLE_WATERMARK_PARAMS = {

--- a/src/pipeline/constants.ts
+++ b/src/pipeline/constants.ts
@@ -59,20 +59,36 @@ export const SPARKLE_PARAMS = {
    *  neighbors. Real Gemini sparkle arms are narrow lines — perpendicular
    *  samples land in dark gap territory. */
   MAX_PERP_ARM_RATIO: 0.8,
-  /** Core mask radius multiplier (applied to detected sparkle radius).
-   *  Tight by design — the actual ✦ shape is fully covered well within
-   *  this radius. The natural near-white halo is masked separately by
-   *  the palette-gated outer ring (HALO_RADIUS_MULTIPLIER) so this can
-   *  stay snug and avoid the "flat patch" artifact on uniform regions. */
-  MASK_RADIUS_MULTIPLIER: 1.2,
-  /** Outer halo radius multiplier. Pixels between MASK_RADIUS_MULTIPLIER
-   *  and this radius are added to the mask ONLY if they match the Gemini
-   *  sparkle palette (near-white / slight cyan tint). Ports the legacy
-   *  watermark-detect halo-expansion behavior into the shape detector
-   *  without reintroducing its false-positive surface (#223). Fixes the
-   *  transparent-dot regression on selfies where the natural halo bled
-   *  into RMBG's background classification. */
+  /** Maximum mask spread from the (relocated) sparkle peak (multiplier of
+   *  `bestR`). Bounds the brightness-and-palette flood-fill so it can't
+   *  walk across the whole sky into adjacent subjects. */
   HALO_RADIUS_MULTIPLIER: 2.0,
+  /** Absolute pixel cap on mask radius, regardless of `bestR`. The detector
+   *  may pick the largest scale (55) when the sparkle's fixed-shape pattern
+   *  partially aligns with bright corner pixels, producing an inflated
+   *  bestR. This cap keeps the mask physically bounded to the typical
+   *  Gemini sparkle size, even when bestR over-estimates. */
+  HALO_RADIUS_ABS_CAP: 40,
+  /** Brightness floor for flood-fill expansion, expressed as a fraction of
+   *  the relocated peak pixel's luminance. A neighbor must satisfy
+   *  `lum(n) ≥ peakLum × this` to be added to the mask. */
+  HALO_BRIGHTNESS_RATIO: 0.65,
+  /** Minimum `max(R,G,B)` for a pixel to count as palette-match in the
+   *  flood-fill. The legacy 200 floor was too strict for dim/aliased ✦
+   *  glyphs in JPEG-compressed photos (peaks land around 180-195). 150
+   *  catches them while still excluding mid-luminance saturated regions
+   *  (skin, grass, bezels) via the saturation half of the gate. */
+  PALETTE_MIN_MAX: 150,
+  /** Tiny anti-aliasing seed radius around the (relocated) peak, ensuring
+   *  the very peak is masked even if its single-pixel sample dipped due
+   *  to sub-pixel placement of the ✦. */
+  SEED_RADIUS: 2,
+  /** Search radius (multiplier of `bestR`) used to relocate the mask center
+   *  from the detector's reported `(bestY, bestX)` to the brightest local
+   *  pixel. The detector's score landscape can place the center 30-40 px
+   *  off the actual peak when one cardinal arm lands on the sparkle and
+   *  the others hit nearby bright sky. */
+  PEAK_SEARCH_RADIUS_MULTIPLIER: 1.0,
 } as const;
 
 export const DALLE_WATERMARK_PARAMS = {

--- a/src/workers/cv/sparkle-detect.ts
+++ b/src/workers/cv/sparkle-detect.ts
@@ -2,14 +2,14 @@ import { SPARKLE_PARAMS } from '../../pipeline/constants';
 import type { WatermarkResult } from '../../types/pipeline';
 
 /** Returns true when the pixel matches the Gemini sparkle palette: a
- *  near-white or slightly cyan-tinted bright pixel. The original ✦ glyph
- *  is pure white (#FFFFFF) with a light blue halo (~#A0D8E0) that JPEG
- *  rounds into a tight high-luminance / low-saturation region. Used to
- *  gate halo expansion so we mask the natural halo without painting over
- *  unrelated bright neighbors (skin highlights, chrome, sun glare). */
+ *  bright low-saturation (or slight-cyan-tint) pixel. The `max` floor is
+ *  configurable (`SPARKLE_PARAMS.PALETTE_MIN_MAX`) so dim/aliased ✦ glyphs
+ *  on JPEG-compressed photos still match. Saturation cap rejects skin
+ *  tones, grass, and other colored objects so the flood-fill doesn't walk
+ *  out of the sparkle into the subject. */
 function isGeminiSparkleColor(r: number, g: number, b: number): boolean {
   const max = Math.max(r, g, b);
-  if (max < 200) return false;
+  if (max < SPARKLE_PARAMS.PALETTE_MIN_MAX) return false;
   const min = Math.min(r, g, b);
   const saturation = max - min;
   if (saturation <= 35) return true;
@@ -224,34 +224,89 @@ export function sparkleDetect(
     return { detected: false, mask: null };
   }
 
-  // Build mask: tight circular core + palette-gated halo ring.
-  // Core covers the ✦ shape; the halo ring catches near-white halo pixels
-  // (the soft glow Gemini renders around the glyph) so RMBG doesn't later
-  // classify them as background and leave transparent dots after inpaint.
-  const mask = new Uint8Array(width * height);
-  const coreR = Math.ceil(bestR * SPARKLE_PARAMS.MASK_RADIUS_MULTIPLIER);
-  const haloR = Math.ceil(bestR * SPARKLE_PARAMS.HALO_RADIUS_MULTIPLIER);
-  const coreR2 = coreR * coreR;
-  const haloR2 = haloR * haloR;
-  const y0 = Math.max(0, bestY - haloR);
-  const y1 = Math.min(height, bestY + haloR + 1);
-  const x0 = Math.max(0, bestX - haloR);
-  const x1 = Math.min(width, bestX + haloR + 1);
-  for (let y = y0; y < y1; y++) {
+  // Relocate the mask center from the detector's reported (bestY, bestX)
+  // to the brightest palette-matching pixel within `bestR`. The detector's
+  // 4-arm score landscape can place the center 30-40 px off the actual ✦
+  // peak when one cardinal hits the sparkle and the others land in nearby
+  // bright sky — building the mask around the true peak keeps it confined
+  // to the visible glyph instead of spreading toward whatever the detector
+  // accidentally sampled.
+  let peakY = bestY;
+  let peakX = bestX;
+  let peakLum = lum[bestY * width + bestX];
+  const searchR = Math.ceil(bestR * SPARKLE_PARAMS.PEAK_SEARCH_RADIUS_MULTIPLIER);
+  const sy0 = Math.max(0, bestY - searchR);
+  const sy1 = Math.min(height, bestY + searchR + 1);
+  const sx0 = Math.max(0, bestX - searchR);
+  const sx1 = Math.min(width, bestX + searchR + 1);
+  for (let y = sy0; y < sy1; y++) {
     const dy = y - bestY;
-    const dy2 = dy * dy;
-    const row = y * width;
-    for (let x = x0; x < x1; x++) {
+    for (let x = sx0; x < sx1; x++) {
       const dx = x - bestX;
-      const d2 = dx * dx + dy2;
-      if (d2 <= coreR2) {
-        mask[row + x] = 1;
-      } else if (d2 <= haloR2) {
-        const i = (row + x) * 4;
-        if (isGeminiSparkleColor(pixels[i], pixels[i + 1], pixels[i + 2])) {
-          mask[row + x] = 1;
-        }
+      if (dx * dx + dy * dy > searchR * searchR) continue;
+      const pi = (y * width + x) * 4;
+      if (!isGeminiSparkleColor(pixels[pi], pixels[pi + 1], pixels[pi + 2])) continue;
+      const l = lum[y * width + x];
+      if (l > peakLum) {
+        peakLum = l;
+        peakY = y;
+        peakX = x;
       }
+    }
+  }
+
+  // Build mask via brightness-and-palette flood-fill from the relocated
+  // peak. Spatial bound = min(haloR-multiplier × bestR, absolute cap) so
+  // an inflated bestR can't drag the mask into adjacent subjects.
+  const mask = new Uint8Array(width * height);
+  const haloR = Math.min(
+    Math.ceil(bestR * SPARKLE_PARAMS.HALO_RADIUS_MULTIPLIER),
+    SPARKLE_PARAMS.HALO_RADIUS_ABS_CAP,
+  );
+  const haloR2 = haloR * haloR;
+  const minLum = peakLum * SPARKLE_PARAMS.HALO_BRIGHTNESS_RATIO;
+
+  // Tiny seed disk around the relocated peak so anti-aliased peak pixels
+  // are always masked before the flood expands.
+  const queue: number[] = [];
+  const seedR = SPARKLE_PARAMS.SEED_RADIUS;
+  const seedR2 = seedR * seedR;
+  for (let dy = -seedR; dy <= seedR; dy++) {
+    for (let dx = -seedR; dx <= seedR; dx++) {
+      if (dx * dx + dy * dy > seedR2) continue;
+      const sy = peakY + dy;
+      const sx = peakX + dx;
+      if (sy < 0 || sy >= height || sx < 0 || sx >= width) continue;
+      const sIdx = sy * width + sx;
+      if (!mask[sIdx]) {
+        mask[sIdx] = 1;
+        queue.push(sIdx);
+      }
+    }
+  }
+
+  // 4-neighbor BFS — gates: within haloR distance from the relocated peak,
+  // luminance ≥ minLum, palette match (low-sat or slight cyan tint, dim
+  // floor PALETTE_MIN_MAX). Together these reject skin, dark bezels,
+  // grass, etc. while still walking through dim near-white halo pixels.
+  while (queue.length > 0) {
+    const idx = queue.pop()!;
+    const y = (idx / width) | 0;
+    const x = idx - y * width;
+    for (let nb = 0; nb < 4; nb++) {
+      const ny = y + (nb === 0 ? -1 : nb === 1 ? 1 : 0);
+      const nx = x + (nb === 2 ? -1 : nb === 3 ? 1 : 0);
+      if (ny < 0 || ny >= height || nx < 0 || nx >= width) continue;
+      const nIdx = ny * width + nx;
+      if (mask[nIdx]) continue;
+      const dly = ny - peakY;
+      const dlx = nx - peakX;
+      if (dly * dly + dlx * dlx > haloR2) continue;
+      if (lum[nIdx] < minLum) continue;
+      const pi = nIdx * 4;
+      if (!isGeminiSparkleColor(pixels[pi], pixels[pi + 1], pixels[pi + 2])) continue;
+      mask[nIdx] = 1;
+      queue.push(nIdx);
     }
   }
 

--- a/src/workers/cv/sparkle-detect.ts
+++ b/src/workers/cv/sparkle-detect.ts
@@ -1,6 +1,22 @@
 import { SPARKLE_PARAMS } from '../../pipeline/constants';
 import type { WatermarkResult } from '../../types/pipeline';
 
+/** Returns true when the pixel matches the Gemini sparkle palette: a
+ *  near-white or slightly cyan-tinted bright pixel. The original ✦ glyph
+ *  is pure white (#FFFFFF) with a light blue halo (~#A0D8E0) that JPEG
+ *  rounds into a tight high-luminance / low-saturation region. Used to
+ *  gate halo expansion so we mask the natural halo without painting over
+ *  unrelated bright neighbors (skin highlights, chrome, sun glare). */
+function isGeminiSparkleColor(r: number, g: number, b: number): boolean {
+  const max = Math.max(r, g, b);
+  if (max < 200) return false;
+  const min = Math.min(r, g, b);
+  const saturation = max - min;
+  if (saturation <= 35) return true;
+  if (b >= r && b >= g && r >= 180 && g >= 180) return true;
+  return false;
+}
+
 /**
  * Shape-based Gemini sparkle detector.
  *
@@ -208,22 +224,33 @@ export function sparkleDetect(
     return { detected: false, mask: null };
   }
 
-  // Build circular mask
+  // Build mask: tight circular core + palette-gated halo ring.
+  // Core covers the ✦ shape; the halo ring catches near-white halo pixels
+  // (the soft glow Gemini renders around the glyph) so RMBG doesn't later
+  // classify them as background and leave transparent dots after inpaint.
   const mask = new Uint8Array(width * height);
-  const maskR = Math.ceil(bestR * SPARKLE_PARAMS.MASK_RADIUS_MULTIPLIER);
-  const maskR2 = maskR * maskR;
-  const y0 = Math.max(0, bestY - maskR);
-  const y1 = Math.min(height, bestY + maskR + 1);
-  const x0 = Math.max(0, bestX - maskR);
-  const x1 = Math.min(width, bestX + maskR + 1);
+  const coreR = Math.ceil(bestR * SPARKLE_PARAMS.MASK_RADIUS_MULTIPLIER);
+  const haloR = Math.ceil(bestR * SPARKLE_PARAMS.HALO_RADIUS_MULTIPLIER);
+  const coreR2 = coreR * coreR;
+  const haloR2 = haloR * haloR;
+  const y0 = Math.max(0, bestY - haloR);
+  const y1 = Math.min(height, bestY + haloR + 1);
+  const x0 = Math.max(0, bestX - haloR);
+  const x1 = Math.min(width, bestX + haloR + 1);
   for (let y = y0; y < y1; y++) {
     const dy = y - bestY;
     const dy2 = dy * dy;
     const row = y * width;
     for (let x = x0; x < x1; x++) {
       const dx = x - bestX;
-      if (dx * dx + dy2 <= maskR2) {
+      const d2 = dx * dx + dy2;
+      if (d2 <= coreR2) {
         mask[row + x] = 1;
+      } else if (d2 <= haloR2) {
+        const i = (row + x) * 4;
+        if (isGeminiSparkleColor(pixels[i], pixels[i + 1], pixels[i + 2])) {
+          mask[row + x] = 1;
+        }
       }
     }
   }

--- a/tests/cv/sparkle-detect.test.ts
+++ b/tests/cv/sparkle-detect.test.ts
@@ -196,14 +196,18 @@ describe('sparkleDetect', () => {
     paintSparkle(pixels, w, cx, cy, radius, [240, 240, 240]);
     // Wide near-white annulus surrounding the shape — deliberately oversized
     // so it covers any haloR the detector ends up using.
-    paintHaloAnnulus(pixels, w, cx, cy, radius + 2, 50, [230, 230, 235]);
+    // Mid-bright near-white halo: bright enough for flood-fill brightness
+    // floor (lum ≈ 180 vs centerLum*0.65 ≈ 156), low enough that detector
+    // gates (G4 outer-ring contrast) still pass.
+    paintHaloAnnulus(pixels, w, cx, cy, radius, 50, [210, 210, 210]);
 
     const result = sparkleDetect(pixels, w, h);
     expect(result.detected).toBe(true);
 
     // A meaningful number of the near-white halo pixels MUST be masked —
-    // proves halo expansion picked them up via the palette gate.
-    const masked = countMaskedWithColor(result.mask!, pixels, [230, 230, 235]);
+    // proves the brightness+palette flood-fill walked into the halo
+    // through the connected near-white region.
+    const masked = countMaskedWithColor(result.mask!, pixels, [210, 210, 210]);
     expect(masked).toBeGreaterThan(20);
   });
 

--- a/tests/cv/sparkle-detect.test.ts
+++ b/tests/cv/sparkle-detect.test.ts
@@ -139,6 +139,95 @@ describe('sparkleDetect', () => {
     expect(count).toBeLessThan(w * h * 0.02);
   });
 
+  // Helper: paints a wide near-white halo annulus around a center, covering
+  // everything from just past the sparkle shape outward to a comfortable
+  // outer radius. Bigger than any bestR the detector might pick so the
+  // assertion is robust to the multi-scale search.
+  function paintHaloAnnulus(
+    pixels: Uint8ClampedArray,
+    w: number,
+    cx: number,
+    cy: number,
+    inner: number,
+    outer: number,
+    rgb: [number, number, number],
+  ): void {
+    for (let y = cy - outer; y <= cy + outer; y++) {
+      for (let x = cx - outer; x <= cx + outer; x++) {
+        const d2 = (x - cx) ** 2 + (y - cy) ** 2;
+        if (d2 >= inner * inner && d2 <= outer * outer) {
+          const i = (y * w + x) * 4;
+          pixels[i] = rgb[0];
+          pixels[i + 1] = rgb[1];
+          pixels[i + 2] = rgb[2];
+          pixels[i + 3] = 255;
+        }
+      }
+    }
+  }
+
+  // Counts how many masked pixels carry a specific RGB color. Decouples the
+  // assertion from whatever bestR/bestX the detector picked — we only care
+  // that pixels of the annulus color end up masked (palette match) or not
+  // (palette miss). RGB tolerance is exact since the test paints solid.
+  function countMaskedWithColor(
+    mask: Uint8Array,
+    pixels: Uint8ClampedArray,
+    rgb: [number, number, number],
+  ): number {
+    let count = 0;
+    for (let p = 0; p < mask.length; p++) {
+      if (!mask[p]) continue;
+      const i = p * 4;
+      if (pixels[i] === rgb[0] && pixels[i + 1] === rgb[1] && pixels[i + 2] === rgb[2]) {
+        count++;
+      }
+    }
+    return count;
+  }
+
+  it('extends mask into near-white halo around the sparkle (palette-gated)', () => {
+    const w = 500,
+      h = 500;
+    const cx = 430,
+      cy = 430,
+      radius = 20;
+    const pixels = solidImage(w, h, 60, 60, 60);
+    paintSparkle(pixels, w, cx, cy, radius, [240, 240, 240]);
+    // Wide near-white annulus surrounding the shape — deliberately oversized
+    // so it covers any haloR the detector ends up using.
+    paintHaloAnnulus(pixels, w, cx, cy, radius + 2, 50, [230, 230, 235]);
+
+    const result = sparkleDetect(pixels, w, h);
+    expect(result.detected).toBe(true);
+
+    // A meaningful number of the near-white halo pixels MUST be masked —
+    // proves halo expansion picked them up via the palette gate.
+    const masked = countMaskedWithColor(result.mask!, pixels, [230, 230, 235]);
+    expect(masked).toBeGreaterThan(20);
+  });
+
+  it('does NOT extend mask into non-palette neighbors (saturated red)', () => {
+    const w = 500,
+      h = 500;
+    const cx = 430,
+      cy = 430,
+      radius = 20;
+    const pixels = solidImage(w, h, 60, 60, 60);
+    paintSparkle(pixels, w, cx, cy, radius, [240, 240, 240]);
+    // Saturated red annulus — fails the palette gate, so halo expansion
+    // must NOT reach into it even though it's inside haloR.
+    paintHaloAnnulus(pixels, w, cx, cy, radius + 2, 50, [220, 30, 30]);
+
+    const result = sparkleDetect(pixels, w, h);
+    expect(result.detected).toBe(true);
+
+    // Zero red pixels should end up in the mask: the palette gate refuses
+    // the saturated red even though it lies inside the haloR ring.
+    const masked = countMaskedWithColor(result.mask!, pixels, [220, 30, 30]);
+    expect(masked).toBe(0);
+  });
+
   it('handles small images without crashing', () => {
     const w = 80,
       h = 80;


### PR DESCRIPTION
## Summary

Manual dev testing on the user's full-resolution selfie (4.33 MP, ✦ in bottom-right corner ~94 px below a held iPhone) showed a hard regression vs the deploy at \`984b578b.nukebg.pages.dev\`: 8587 transparent pixels in the phone + hand area where the reference is opaque.

This PR replaces the circular sparkle mask with a **peak-relocated brightness-and-palette flood-fill** that confines the mask to the actual ✦ glyph + its connected halo, never to a circular bbox that engulfs adjacent subjects.

## Why this happened

- \`sparkleDetect\` picked \`bestR=55\` (the largest candidate scale) at \`(2703, 1424)\` — 40 px ABOVE the actual ✦ peak (real peak at \`(2704, 1464)\`). Its 4-arm score landscape happened to align one cardinal with the real ✦ and the others with nearby bright sky.
- Resulting **circular** core mask was 132×132, engulfing the iPhone bezel + the man's hand.
- Telea inpainted those pixels with sky-tone (the surrounding context).
- RMBG correctly classified the now-sky-colored phone area as background → 8587-pixel hole.
- The \`984b578b\` deploy avoided this because either its mask landed differently OR its inpaint produced compatible foreground colors. Either way, the FIX is to stop building a circle around an off-center detection.

## Fix (three changes inside \`sparkle-detect.ts\` mask construction)

| # | Change | Effect |
|---|--------|--------|
| 1 | **Peak relocation**: search the brightest palette-matching pixel within \`bestR\` of the detector's center, anchor the mask there | Mask centers on the actual ✦ peak even when the detector's score landscape lands off-center |
| 2 | **Brightness-and-palette flood-fill**: 4-neighbor BFS from peak, gated by \`lum ≥ peakLum × HALO_BRIGHTNESS_RATIO\` AND palette match | Mask conforms to the visible glyph + connected halo, naturally stops at sparkle/skin boundary (skin is saturated → palette gate rejects) |
| 3 | **Absolute haloR cap** (\`HALO_RADIUS_ABS_CAP=40\`): bound spread to \`min(bestR × 2, 40)\` | Inflated \`bestR\` can't drag the mask into adjacent subjects even if the flood gates would let it |

Also lowered \`PALETTE_MIN_MAX\` (200 → 150) so dim/aliased ✦ glyphs on JPEG photos (peaks land around 180–195) are caught instead of leaving the visible shape unmasked.

The legacy color-deviation \`watermarkDetect\` retired in #223 stays retired — anchoring on a confirmed shape-detected sparkle keeps the false-positive surface (motostest, selfie-clean-corner) closed.

## Validation

| Gate | Result |
|------|--------|
| \`npm run typecheck\` | ✅ green |
| \`npm test\` | ✅ **939/939** (+2 vs main) |
| Manual e2e on user's selfie.png (4.33 MP) | Holes vs \`984b578b\` reference: **8587 → 0** |
| Phone + hand preservation | ✅ visually intact |
| Visible ✦ residual | Reduced from full-bright glyph to a faint inpaint smudge |

New unit tests cover halo accept (near-white annulus connected to the synthetic sparkle gets walked into) and palette reject (saturated red annulus is left alone). They had to use halo color \`(210,210,210)\` so the lowered \`PALETTE_MIN_MAX=150\` matches without contaminating the detector's outer-ring contrast gate (G4) that requires \`center − meanOuter ≥ 25\`.

## Files

| File | Change |
|------|--------|
| \`src/pipeline/constants.ts\` | New \`HALO_RADIUS_ABS_CAP\`, \`PALETTE_MIN_MAX\`, \`HALO_BRIGHTNESS_RATIO\`, \`SEED_RADIUS\`, \`PEAK_SEARCH_RADIUS_MULTIPLIER\`. Drop unused \`MASK_RADIUS_MULTIPLIER\`. |
| \`src/workers/cv/sparkle-detect.ts\` | Peak relocation + brightness/palette flood-fill replaces circular core+halo. \`isGeminiSparkleColor\` floor reads from \`PALETTE_MIN_MAX\`. |
| \`tests/cv/sparkle-detect.test.ts\` | +2 tests covering halo accept/reject under flood-fill semantics. |

## Known residual

The visible ✦ in the user's selfie still leaves a faint smudge after Telea fill — surrounding context is mixed sky-grey + skin-tan, so the fill doesn't perfectly match either. This is independent of the mask fix; it's an inpaint-quality concern (LaMa router decision for this particular case) and would need a separate change.