### PR TITLE
fix(sparkle): shape-polygon mask covers on-skin glyph half (#239)

### DIFF
--- a/src/components/ar-progress.ts
+++ b/src/components/ar-progress.ts
@@ -164,10 +164,6 @@ export class ArProgress extends HTMLElement {
           font-size: 14px;
           line-height: 1;
         }
-        .stage.pending .stage-icon {
-          border: 1.5px solid var(--color-surface-border, #1a3a1a);
-          border-radius: 0;
-        }
         .stage.running .stage-icon {
           color: var(--color-accent-primary, #00ff41);
           animation: spin 2s linear infinite;
@@ -193,30 +189,8 @@ export class ArProgress extends HTMLElement {
           font-size: var(--text-xs, 0.75rem);
           color: var(--color-text-tertiary, #00b34a);
         }
-        .progress-bar {
-          width: 100%;
-          height: 3px;
-          background: var(--color-bg-secondary, #0d0d0d);
-          border-radius: 0;
-          margin-top: 4px;
-          overflow: hidden;
-        }
-        .progress-fill {
-          height: 100%;
-          background: var(--color-accent-primary, #00ff41);
-          border-radius: 0;
-          box-shadow: 0 0 4px rgba(var(--color-accent-rgb, 0, 255, 65), 0.4);
-          transition: width 0.3s ease;
-        }
         @keyframes spin {
           to { transform: rotate(360deg); }
-        }
-        .progress-fill.parsing {
-          animation: pulse 1.5s ease-in-out infinite;
-        }
-        @keyframes pulse {
-          0%, 100% { opacity: 1; }
-          50% { opacity: 0.5; }
         }
         /* === Mobile (max-width: 480px) === */
         @media (max-width: 480px) {
@@ -251,7 +225,6 @@ export class ArProgress extends HTMLElement {
 
         @media (prefers-reduced-motion: reduce) {
           .stage.running .stage-icon { animation: none !important; }
-          .progress-fill.parsing { animation: none !important; }
         }
 
         /* Inline error-stage actions (#78). Mirrors the error modal
@@ -314,9 +287,13 @@ export class ArProgress extends HTMLElement {
     const container = this.shadowRoot!.querySelector('.stages');
     if (!container) return;
 
-    // Filter out stages that shouldn't be shown
+    // Render only stages that have started or settled. Pending stages
+    // (initial state from reset()) are queued internally but not shown
+    // — surfacing them with an empty bordered icon mid-pipeline confused
+    // users into thinking the next stage was already running. Skipped
+    // inpaint is also hidden (no watermark to remove → no row needed).
     const visibleStages = this.stages.filter((s) => {
-      // Hide inpaint if skipped (no watermark)
+      if (s.status === 'pending') return false;
       if (s.stage === 'inpaint' && s.status === 'skipped') return false;
       return true;
     });
@@ -327,31 +304,6 @@ export class ArProgress extends HTMLElement {
         const timeStr = s.timeMs !== undefined ? `${(s.timeMs / 1000).toFixed(1)}s` : '';
         const safeMessage = s.message ? this.escapeHtml(s.message) : '';
         const msgStr = safeMessage ? `<span class="stage-message">${safeMessage}</span>` : '';
-
-        // Extract percentage from message like "Loading AI model... 45%"
-        const pctMatch = safeMessage.match(/(\d+)%/);
-        let progressBar = '';
-        if (s.status === 'running' && pctMatch) {
-          const pct = parseInt(pctMatch[1]);
-          // At 85% the model is being initialized (WASM compilation) - show pulsing bar
-          const isParsing = pct >= 80 && pct < 100;
-          const barClass = isParsing ? 'progress-fill parsing' : 'progress-fill';
-          const label = isParsing ? t('progress.initAI') : safeMessage;
-          progressBar = `<div class="progress-bar"><div class="${barClass}" style="width: ${pct}%"></div></div>`;
-          // Override message during parsing phase
-          if (isParsing) {
-            const msgEl = `<span class="stage-message">${label}</span>`;
-            return `
-            <div class="stage ${this.escapeHtml(s.status)}">
-              <span class="stage-icon">${icon}</span>
-              <span class="stage-label">${this.escapeHtml(s.label)}</span>
-              ${msgEl}
-              <span class="stage-time">${timeStr}</span>
-            </div>
-            ${progressBar}
-          `;
-          }
-        }
 
         // #78 — when a stage errors, render retry / report / reload
         // actions inline so the user can recover without hunting the
@@ -372,7 +324,6 @@ export class ArProgress extends HTMLElement {
           ${msgStr}
           <span class="stage-time">${timeStr}</span>
         </div>
-        ${progressBar}
         ${errorActions}
       `;
       })

--- a/src/pipeline/constants.ts
+++ b/src/pipeline/constants.ts
@@ -89,8 +89,27 @@ export const SPARKLE_PARAMS = {
    *  from the detector's reported `(bestY, bestX)` to the brightest local
    *  pixel. The detector's score landscape can place the center 30-40 px
    *  off the actual peak when one cardinal arm lands on the sparkle and
-   *  the others hit nearby bright sky. */
-  PEAK_SEARCH_RADIUS_MULTIPLIER: 1.0,
+   *  the others hit nearby bright sky. Effective search radius is
+   *  `max(bestR × this, PEAK_SEARCH_RADIUS_MIN)` — the absolute floor
+   *  guards against small `bestR` (e.g. 14) where a 1× multiplier
+   *  doesn't reach the actual peak. */
+  PEAK_SEARCH_RADIUS_MULTIPLIER: 2.0,
+  /** Absolute pixel floor for peak-relocation search radius, regardless
+   *  of `bestR`. With `bestR=14` and a 1× multiplier the previous
+   *  search box was only 14 px wide — when the detector's centre
+   *  landed at a glyph tip, that wasn't enough to reach the real
+   *  centre and the polygon got anchored at the tip. 50 px guarantees
+   *  the actual ✦ centre is in scope at all sane glyph sizes. */
+  PEAK_SEARCH_RADIUS_MIN: 50,
+  /** Brightness ratio (vs. relocated peak luminance) used by the 1D
+   *  cardinal probe that measures the actual glyph extent. Walking
+   *  outward from the peak along N/S/E/W, a pixel "still belongs to
+   *  the glyph" while `lum >= peakLum × this`. The MAX of the four
+   *  measured extents becomes the polygon's arm length, so the mask
+   *  adapts to the rendered glyph regardless of which `bestR` the
+   *  detector picked. 0.5 catches dim arm tips on JPEG-compressed
+   *  inputs without bleeding into background highlights. */
+  EXTENT_PROBE_BRIGHTNESS_RATIO: 0.5,
 } as const;
 
 export const DALLE_WATERMARK_PARAMS = {

--- a/src/pipeline/constants.ts
+++ b/src/pipeline/constants.ts
@@ -59,33 +59,9 @@ export const SPARKLE_PARAMS = {
    *  neighbors. Real Gemini sparkle arms are narrow lines — perpendicular
    *  samples land in dark gap territory. */
   MAX_PERP_ARM_RATIO: 0.8,
-  /** Minimum `max(R,G,B)` for a pixel to count as a Gemini-sparkle
-   *  palette match. The legacy 200 floor was too strict for dim/aliased
-   *  ✦ glyphs in JPEG-compressed photos (peaks land around 180-195).
-   *  150 catches them while still excluding mid-luminance saturated
-   *  regions (skin, grass, bezels) via the saturation half of the
-   *  gate in `isGeminiSparkleColor`. */
-  PALETTE_MIN_MAX: 150,
-  /** Search radius (multiplier of `bestR`) used to relocate the mask
-   *  centre from the detector's score-landscape `(bestY, bestX)` to
-   *  the brightest palette-matching pixel — the visual centre of the
-   *  rendered glyph. Effective radius = max(bestR × this, MIN). */
-  PEAK_SEARCH_RADIUS_MULTIPLIER: 2.0,
-  /** Absolute floor for peak-relocation search radius. Guards against
-   *  small `bestR` (10-14) producing a search box too tight to reach
-   *  the real peak from a 30-50 px score-landscape offset. */
-  PEAK_SEARCH_RADIUS_MIN: 80,
-  /** Anti-aliasing buffer (pixels) added to `bestR` for the final mask
-   *  radius. The detector's `bestR` is its best-fit scale for the ✦
-   *  pattern, which closely matches the rendered glyph's outer extent.
-   *  A small buffer catches dim anti-aliased halo pixels at the tips. */
-  MASK_BUFFER_PX: 5,
-  /** Absolute pixel cap on the final mask radius, regardless of
-   *  `bestR`. Defends against pathological cases where the detector
-   *  picks the largest scale on a partial-match. 80 covers typical
-   *  Gemini ✦ rendering at 4-5 MP without engulfing adjacent subjects
-   *  beyond the glyph footprint. */
-  MASK_RADIUS_ABS_CAP: 80,
+  /** Mask radius multiplier (applied to detected sparkle radius). Tight fit
+   *  minimises the area Telea has to reconstruct — less "flat patch" look. */
+  MASK_RADIUS_MULTIPLIER: 1.15,
 } as const;
 
 export const DALLE_WATERMARK_PARAMS = {

--- a/src/pipeline/constants.ts
+++ b/src/pipeline/constants.ts
@@ -66,38 +66,26 @@ export const SPARKLE_PARAMS = {
    *  regions (skin, grass, bezels) via the saturation half of the
    *  gate in `isGeminiSparkleColor`. */
   PALETTE_MIN_MAX: 150,
-  /** Cluster scan window radius (multiplier of `bestR`) centered on the
-   *  shape detector's `(bestY, bestX)`. Generous enough to capture the
-   *  entire rendered glyph plus halo, focused enough to keep distant
-   *  bright clusters (e.g. clothing highlights, sun-lit foliage) out
-   *  of the centroid. Replaces the legacy whole-corner sweep, which
-   *  was contaminated on photos with bright content in the bottom-right
-   *  beyond the sparkle itself. */
-  CLUSTER_SCAN_RADIUS_MULTIPLIER: 3,
-  /** Absolute floor for the cluster scan radius (pixels). Guards against
-   *  small `bestR` (10-14) producing a window too tight to capture
-   *  anti-aliased halo pixels. */
-  CLUSTER_SCAN_RADIUS_MIN: 80,
-  /** Minimum number of palette-matching pixels required to build a
-   *  cluster mask after the shape detector triggers. Defends against
-   *  pathological cases where shape detect passes but the cluster is
-   *  too sparse to derive a stable centroid (e.g. JPEG noise). Falls
-   *  through to no-mask when below. */
-  CLUSTER_MIN_PALETTE_PIXELS: 20,
-  /** Buffer (px) added to the cluster bbox half-extent before the
-   *  MASK_RADIUS_MULTIPLIER scaling, to catch dim anti-aliasing pixels
-   *  that didn't pass the palette gate. Port of the legacy `+ 10`. */
-  CLUSTER_BBOX_BUFFER_PX: 10,
-  /** Multiplier on cluster radius for the solid mask core. Port of
-   *  legacy `WATERMARK_PARAMS.MASK_RADIUS_MULTIPLIER=1.3` — the value
-   *  that produced the clean 984b578b removal. */
-  MASK_RADIUS_MULTIPLIER: 1.3,
-  /** Absolute pixel cap on the final mask radius, regardless of cluster
-   *  spread. Defends against pathological clusters (e.g. detector
-   *  passes on a glyph adjacent to a bright reflection that drags the
-   *  bbox). 80 covers typical Gemini ✦ rendering at 4-5 MP without
-   *  engulfing adjacent subjects. */
-  CLUSTER_MAX_RADIUS_ABS_CAP: 80,
+  /** Search radius (multiplier of `bestR`) used to relocate the mask
+   *  centre from the detector's score-landscape `(bestY, bestX)` to
+   *  the brightest palette-matching pixel — the visual centre of the
+   *  rendered glyph. Effective radius = max(bestR × this, MIN). */
+  PEAK_SEARCH_RADIUS_MULTIPLIER: 2.0,
+  /** Absolute floor for peak-relocation search radius. Guards against
+   *  small `bestR` (10-14) producing a search box too tight to reach
+   *  the real peak from a 30-50 px score-landscape offset. */
+  PEAK_SEARCH_RADIUS_MIN: 80,
+  /** Anti-aliasing buffer (pixels) added to `bestR` for the final mask
+   *  radius. The detector's `bestR` is its best-fit scale for the ✦
+   *  pattern, which closely matches the rendered glyph's outer extent.
+   *  A small buffer catches dim anti-aliased halo pixels at the tips. */
+  MASK_BUFFER_PX: 5,
+  /** Absolute pixel cap on the final mask radius, regardless of
+   *  `bestR`. Defends against pathological cases where the detector
+   *  picks the largest scale on a partial-match. 80 covers typical
+   *  Gemini ✦ rendering at 4-5 MP without engulfing adjacent subjects
+   *  beyond the glyph footprint. */
+  MASK_RADIUS_ABS_CAP: 80,
 } as const;
 
 export const DALLE_WATERMARK_PARAMS = {

--- a/src/pipeline/constants.ts
+++ b/src/pipeline/constants.ts
@@ -59,30 +59,32 @@ export const SPARKLE_PARAMS = {
    *  neighbors. Real Gemini sparkle arms are narrow lines — perpendicular
    *  samples land in dark gap territory. */
   MAX_PERP_ARM_RATIO: 0.8,
-  /** Maximum mask spread from the (relocated) sparkle peak (multiplier of
-   *  `bestR`). Bounds the brightness-and-palette flood-fill so it can't
-   *  walk across the whole sky into adjacent subjects. */
-  HALO_RADIUS_MULTIPLIER: 2.0,
-  /** Absolute pixel cap on mask radius, regardless of `bestR`. The detector
+  /** Cardinal-arm length of the rasterized ✦ mask, expressed as a fraction
+   *  of `bestR`. The detector's arm-sample lives at `bestR * 0.6`; we
+   *  extend slightly past it to catch tip anti-aliasing. Length is also
+   *  hard-bounded by `HALO_RADIUS_ABS_CAP`. */
+  ARM_LENGTH_MULTIPLIER: 0.7,
+  /** Central disk radius of the rasterized ✦ mask, fraction of `bestR`. */
+  CORE_RADIUS_MULTIPLIER: 0.25,
+  /** Half-width of an arm at its base (next to the central disk), fraction
+   *  of `bestR`. Arms taper linearly from this thickness to 1 px at the
+   *  tip — matches the rendered Gemini glyph and keeps the footprint
+   *  small (~150-300 px total at typical bestR). */
+  ARM_BASE_THICKNESS_MULTIPLIER: 0.2,
+  /** Absolute pixel cap on arm length, regardless of `bestR`. The detector
    *  may pick the largest scale (55) when the sparkle's fixed-shape pattern
    *  partially aligns with bright corner pixels, producing an inflated
    *  bestR. This cap keeps the mask physically bounded to the typical
    *  Gemini sparkle size, even when bestR over-estimates. */
   HALO_RADIUS_ABS_CAP: 40,
-  /** Brightness floor for flood-fill expansion, expressed as a fraction of
-   *  the relocated peak pixel's luminance. A neighbor must satisfy
-   *  `lum(n) ≥ peakLum × this` to be added to the mask. */
-  HALO_BRIGHTNESS_RATIO: 0.65,
-  /** Minimum `max(R,G,B)` for a pixel to count as palette-match in the
-   *  flood-fill. The legacy 200 floor was too strict for dim/aliased ✦
-   *  glyphs in JPEG-compressed photos (peaks land around 180-195). 150
-   *  catches them while still excluding mid-luminance saturated regions
-   *  (skin, grass, bezels) via the saturation half of the gate. */
+  /** Minimum `max(R,G,B)` for a pixel to count as palette-match. Used by
+   *  peak relocation to anchor the mask on the actual ✦ centre rather
+   *  than the detector's off-by-N score-landscape coordinate. The legacy
+   *  200 floor was too strict for dim/aliased ✦ glyphs in JPEG-compressed
+   *  photos (peaks land around 180-195). 150 catches them while still
+   *  excluding mid-luminance saturated regions (skin, grass, bezels)
+   *  via the saturation half of the gate. */
   PALETTE_MIN_MAX: 150,
-  /** Tiny anti-aliasing seed radius around the (relocated) peak, ensuring
-   *  the very peak is masked even if its single-pixel sample dipped due
-   *  to sub-pixel placement of the ✦. */
-  SEED_RADIUS: 2,
   /** Search radius (multiplier of `bestR`) used to relocate the mask center
    *  from the detector's reported `(bestY, bestX)` to the brightest local
    *  pixel. The detector's score landscape can place the center 30-40 px

--- a/src/pipeline/constants.ts
+++ b/src/pipeline/constants.ts
@@ -59,57 +59,45 @@ export const SPARKLE_PARAMS = {
    *  neighbors. Real Gemini sparkle arms are narrow lines — perpendicular
    *  samples land in dark gap territory. */
   MAX_PERP_ARM_RATIO: 0.8,
-  /** Cardinal-arm length of the rasterized ✦ mask, expressed as a fraction
-   *  of `bestR`. The detector's arm-sample lives at `bestR * 0.6`; we
-   *  extend slightly past it to catch tip anti-aliasing. Length is also
-   *  hard-bounded by `HALO_RADIUS_ABS_CAP`. */
-  ARM_LENGTH_MULTIPLIER: 0.7,
-  /** Central disk radius of the rasterized ✦ mask, fraction of `bestR`. */
-  CORE_RADIUS_MULTIPLIER: 0.25,
-  /** Half-width of an arm at its base (next to the central disk), fraction
-   *  of `bestR`. Arms taper linearly from this thickness to 1 px at the
-   *  tip — matches the rendered Gemini glyph and keeps the footprint
-   *  small (~150-300 px total at typical bestR). */
-  ARM_BASE_THICKNESS_MULTIPLIER: 0.2,
-  /** Absolute pixel cap on arm length, regardless of `bestR`. The detector
-   *  may pick the largest scale (55) when the sparkle's fixed-shape pattern
-   *  partially aligns with bright corner pixels, producing an inflated
-   *  bestR. This cap keeps the mask physically bounded to the typical
-   *  Gemini sparkle size, even when bestR over-estimates. */
-  HALO_RADIUS_ABS_CAP: 40,
-  /** Minimum `max(R,G,B)` for a pixel to count as palette-match. Used by
-   *  peak relocation to anchor the mask on the actual ✦ centre rather
-   *  than the detector's off-by-N score-landscape coordinate. The legacy
-   *  200 floor was too strict for dim/aliased ✦ glyphs in JPEG-compressed
-   *  photos (peaks land around 180-195). 150 catches them while still
-   *  excluding mid-luminance saturated regions (skin, grass, bezels)
-   *  via the saturation half of the gate. */
+  /** Minimum `max(R,G,B)` for a pixel to count as a Gemini-sparkle
+   *  palette match. The legacy 200 floor was too strict for dim/aliased
+   *  ✦ glyphs in JPEG-compressed photos (peaks land around 180-195).
+   *  150 catches them while still excluding mid-luminance saturated
+   *  regions (skin, grass, bezels) via the saturation half of the
+   *  gate in `isGeminiSparkleColor`. */
   PALETTE_MIN_MAX: 150,
-  /** Search radius (multiplier of `bestR`) used to relocate the mask center
-   *  from the detector's reported `(bestY, bestX)` to the brightest local
-   *  pixel. The detector's score landscape can place the center 30-40 px
-   *  off the actual peak when one cardinal arm lands on the sparkle and
-   *  the others hit nearby bright sky. Effective search radius is
-   *  `max(bestR × this, PEAK_SEARCH_RADIUS_MIN)` — the absolute floor
-   *  guards against small `bestR` (e.g. 14) where a 1× multiplier
-   *  doesn't reach the actual peak. */
-  PEAK_SEARCH_RADIUS_MULTIPLIER: 2.0,
-  /** Absolute pixel floor for peak-relocation search radius, regardless
-   *  of `bestR`. With `bestR=14` and a 1× multiplier the previous
-   *  search box was only 14 px wide — when the detector's centre
-   *  landed at a glyph tip, that wasn't enough to reach the real
-   *  centre and the polygon got anchored at the tip. 50 px guarantees
-   *  the actual ✦ centre is in scope at all sane glyph sizes. */
-  PEAK_SEARCH_RADIUS_MIN: 50,
-  /** Brightness ratio (vs. relocated peak luminance) used by the 1D
-   *  cardinal probe that measures the actual glyph extent. Walking
-   *  outward from the peak along N/S/E/W, a pixel "still belongs to
-   *  the glyph" while `lum >= peakLum × this`. The MAX of the four
-   *  measured extents becomes the polygon's arm length, so the mask
-   *  adapts to the rendered glyph regardless of which `bestR` the
-   *  detector picked. 0.5 catches dim arm tips on JPEG-compressed
-   *  inputs without bleeding into background highlights. */
-  EXTENT_PROBE_BRIGHTNESS_RATIO: 0.5,
+  /** Cluster scan window radius (multiplier of `bestR`) centered on the
+   *  shape detector's `(bestY, bestX)`. Generous enough to capture the
+   *  entire rendered glyph plus halo, focused enough to keep distant
+   *  bright clusters (e.g. clothing highlights, sun-lit foliage) out
+   *  of the centroid. Replaces the legacy whole-corner sweep, which
+   *  was contaminated on photos with bright content in the bottom-right
+   *  beyond the sparkle itself. */
+  CLUSTER_SCAN_RADIUS_MULTIPLIER: 3,
+  /** Absolute floor for the cluster scan radius (pixels). Guards against
+   *  small `bestR` (10-14) producing a window too tight to capture
+   *  anti-aliased halo pixels. */
+  CLUSTER_SCAN_RADIUS_MIN: 80,
+  /** Minimum number of palette-matching pixels required to build a
+   *  cluster mask after the shape detector triggers. Defends against
+   *  pathological cases where shape detect passes but the cluster is
+   *  too sparse to derive a stable centroid (e.g. JPEG noise). Falls
+   *  through to no-mask when below. */
+  CLUSTER_MIN_PALETTE_PIXELS: 20,
+  /** Buffer (px) added to the cluster bbox half-extent before the
+   *  MASK_RADIUS_MULTIPLIER scaling, to catch dim anti-aliasing pixels
+   *  that didn't pass the palette gate. Port of the legacy `+ 10`. */
+  CLUSTER_BBOX_BUFFER_PX: 10,
+  /** Multiplier on cluster radius for the solid mask core. Port of
+   *  legacy `WATERMARK_PARAMS.MASK_RADIUS_MULTIPLIER=1.3` — the value
+   *  that produced the clean 984b578b removal. */
+  MASK_RADIUS_MULTIPLIER: 1.3,
+  /** Absolute pixel cap on the final mask radius, regardless of cluster
+   *  spread. Defends against pathological clusters (e.g. detector
+   *  passes on a glyph adjacent to a bright reflection that drags the
+   *  bbox). 80 covers typical Gemini ✦ rendering at 4-5 MP without
+   *  engulfing adjacent subjects. */
+  CLUSTER_MAX_RADIUS_ABS_CAP: 80,
 } as const;
 
 export const DALLE_WATERMARK_PARAMS = {

--- a/src/pipeline/orchestrator.ts
+++ b/src/pipeline/orchestrator.ts
@@ -655,15 +655,31 @@ export class PipelineOrchestrator {
         }),
       ]);
 
-      const anyWatermark = wmGemini.detected || wmDalle.detected || wmSparkle.detected;
+      // The legacy color-deviation `watermarkDetect` produces a high-quality
+      // cluster-centroid mask but has NO shape gate, so it false-positives on
+      // real photos with bright clustered features in the bottom-right
+      // (motorbike chrome, skin highlights, etc. — see issue triage that
+      // motivated the original PR #223 retirement). The shape-based
+      // `sparkleDetect` adds 6 strict gates (4-arm symmetry, narrow-arm
+      // isolation, center peak vs outer ring, etc.) that reliably reject
+      // those false-positives but its own mask is just a simple circle at
+      // the score-landscape best-fit point.
+      //
+      // Combine their strengths: only trust the legacy mask when the shape
+      // detector ALSO confirms a real Gemini ✦. Together they kill the false
+      // positives without sacrificing the cluster-centroid mask quality that
+      // produced the clean 984b578b deploy on user's selfie.
+      const geminiConfirmed = wmGemini.detected && wmSparkle.detected;
+      const geminiMaskGated = geminiConfirmed ? wmGemini.mask : null;
+      const anyWatermark = geminiConfirmed || wmDalle.detected || wmSparkle.detected;
       const combinedMask = PipelineOrchestrator.combineMasks(
-        [wmGemini.mask, wmDalle.mask, wmSparkle.mask],
+        [geminiMaskGated, wmDalle.mask, wmSparkle.mask],
         width * height,
       );
 
       if (anyWatermark && combinedMask) {
         const sources: string[] = [];
-        if (wmGemini.detected) sources.push('Gemini');
+        if (geminiConfirmed) sources.push('Gemini');
         if (wmDalle.detected) sources.push('DALL-E');
         if (wmSparkle.detected) sources.push('Gemini-shape');
         this.emit('watermark-scan', 'done', `Watermark detected [${sources.join(', ')}]`);

--- a/src/pipeline/orchestrator.ts
+++ b/src/pipeline/orchestrator.ts
@@ -2,6 +2,7 @@ import type {
   PipelineStage,
   StageStatus,
   PipelineResult,
+  BgColorResult,
   WatermarkResult,
   ImageContentType,
 } from '../types/pipeline';
@@ -578,14 +579,19 @@ export class PipelineOrchestrator {
     let t = performance.now();
     this.emit('detect-background', 'running', 'Analyzing image...');
 
-    // bg-color detection retired alongside watermarkDetect (its only
-    // consumer) — see watermark-scan stage below for context. Classifier
-    // still runs.
-    const classifyResult = await this.cvCall<ClassifyImageResult>('classify-image', {
-      pixels: new Uint8ClampedArray(imageData.data),
-      width,
-      height,
-    });
+    // Run bg detection and content classification in parallel
+    const [bgInfo, classifyResult] = await Promise.all([
+      this.cvCall<BgColorResult>('detect-bg-colors', {
+        pixels: new Uint8ClampedArray(imageData.data),
+        width,
+        height,
+      }),
+      this.cvCall<ClassifyImageResult>('classify-image', {
+        pixels: new Uint8ClampedArray(imageData.data),
+        width,
+        height,
+      }),
+    ]);
 
     const contentType: ImageContentType = classifyResult.type;
     stageTiming['detect-background'] = performance.now() - t;
@@ -629,14 +635,14 @@ export class PipelineOrchestrator {
       t = performance.now();
       this.emit('watermark-scan', 'running', 'Checking for watermarks...');
 
-      // Color-deviation watermarkDetect retired: it had no shape gate so it
-      // false-positived on real photos with bright clustered features in
-      // the bottom-right (motorbike chrome, skin highlights in portraits,
-      // etc.). The shape-based sparkleDetect handles Gemini sparkles
-      // robustly; watermarkDetectDalle handles the multicolor bar.
-      // Reference: motostest + selfie-clean-corner regression triage,
-      // 2026-04-28.
-      const [wmDalle, wmSparkle] = await Promise.all([
+      const [wmGemini, wmDalle, wmSparkle] = await Promise.all([
+        this.cvCall<WatermarkResult>('watermark-detect', {
+          pixels: new Uint8ClampedArray(imageData.data),
+          width,
+          height,
+          colorA: bgInfo.colorA,
+          colorB: bgInfo.colorB,
+        }),
         this.cvCall<WatermarkResult>('watermark-detect-dalle', {
           pixels: new Uint8ClampedArray(imageData.data),
           width,
@@ -649,14 +655,15 @@ export class PipelineOrchestrator {
         }),
       ]);
 
-      const anyWatermark = wmDalle.detected || wmSparkle.detected;
+      const anyWatermark = wmGemini.detected || wmDalle.detected || wmSparkle.detected;
       const combinedMask = PipelineOrchestrator.combineMasks(
-        [wmDalle.mask, wmSparkle.mask],
+        [wmGemini.mask, wmDalle.mask, wmSparkle.mask],
         width * height,
       );
 
       if (anyWatermark && combinedMask) {
         const sources: string[] = [];
+        if (wmGemini.detected) sources.push('Gemini');
         if (wmDalle.detected) sources.push('DALL-E');
         if (wmSparkle.detected) sources.push('Gemini-shape');
         this.emit('watermark-scan', 'done', `Watermark detected [${sources.join(', ')}]`);

--- a/src/workers/cv/sparkle-detect.ts
+++ b/src/workers/cv/sparkle-detect.ts
@@ -224,100 +224,84 @@ export function sparkleDetect(
     return { detected: false, mask: null };
   }
 
-  // Build the mask via palette-cluster centroid + bbox-derived radius.
-  // Port of the proven legacy `watermarkDetect` mask-building from the
-  // 984b578b deploy: scan the bottom-right corner, collect every
-  // palette-matching pixel, anchor a circular mask on their centroid
-  // with radius derived from their bounding box.
+  // Relocate the mask centre from the detector's score-landscape
+  // `(bestY, bestX)` to the brightest palette-matching pixel within
+  // a generous search box. The detector's 4-arm score peak can sit
+  // 30-50 px off the visual centroid of the rendered glyph (one arm
+  // hits the sparkle, others land on bright sky → score peaks
+  // off-glyph). Brightest palette pixel IS the visual centre.
   //
-  // Why this is the right strategy after shape detection passes:
-  //   - Shape detector's `(bestY, bestX)` comes from the score landscape
-  //     of the 4-arm pattern — it can be 30-50 px off the visual centroid
-  //     of the rendered glyph (the on-axis cardinal arm + bright sky
-  //     interference can produce a high score off the real peak).
-  //   - The cluster centroid IS, by construction, the visual centroid of
-  //     the bright palette pixels. The bbox tells us how far the glyph
-  //     extends, regardless of which `bestR` the detector picked.
-  //   - The CORE of the mask (`radius * MASK_RADIUS_MULTIPLIER`) is solid
-  //     and unconditional — covers the entire glyph, including the
-  //     anti-aliased on-skin half whose pixels don't pass the palette
-  //     gate themselves. This is what makes the legacy approach work
-  //     where the shape-polygon failed.
-  //
-  // False-positive risk that originally retired the legacy detector
-  // (motorcycle chrome, skin highlights) is neutralized here because
-  // the 4-arm shape gates G1-G6 above already qualified the input as
-  // a real Gemini ✦ before this code runs.
-  // Scan a generous window around the shape detector's `(bestY, bestX)`
-  // — NOT the whole corner. The shape gates G1-G6 already qualified
-  // the input as a real Gemini ✦, so we only need to focus on pixels
-  // near it. A whole-corner sweep is contaminated by unrelated bright
-  // clusters (clothing highlights, sun-lit foliage) which drag the
-  // centroid 80-100 px off the true sparkle.
-  const scanR = Math.max(
-    bestR * SPARKLE_PARAMS.CLUSTER_SCAN_RADIUS_MULTIPLIER,
-    SPARKLE_PARAMS.CLUSTER_SCAN_RADIUS_MIN,
+  // Why we drop the cluster-centroid + bbox approach we had in
+  // v=cluster-1: the centroid of palette pixels in a window centred
+  // on `bestY/bestX` collapsed back to `bestY/bestX` (symmetric
+  // window + roughly symmetric pixels), giving us nothing the
+  // detector didn't already have. The bbox absorbed scattered
+  // skin-specular highlights and inflated to ~95×95 → mask centred
+  // on the wrong point AND 50% bigger than the real glyph. Anchoring
+  // on the relocated peak with a `bestR`-derived radius gives a
+  // tight, correctly-placed mask without requiring any extra heuristics.
+  let peakY = bestY;
+  let peakX = bestX;
+  let peakLum = lum[bestY * width + bestX];
+  const searchR = Math.max(
+    Math.ceil(bestR * SPARKLE_PARAMS.PEAK_SEARCH_RADIUS_MULTIPLIER),
+    SPARKLE_PARAMS.PEAK_SEARCH_RADIUS_MIN,
   );
-  const scanY0 = Math.max(0, bestY - scanR);
-  const scanY1 = Math.min(height, bestY + scanR + 1);
-  const scanX0 = Math.max(0, bestX - scanR);
-  const scanX1 = Math.min(width, bestX + scanR + 1);
-  let sumY = 0;
-  let sumX = 0;
-  let cMinY = Infinity;
-  let cMaxY = -Infinity;
-  let cMinX = Infinity;
-  let cMaxX = -Infinity;
-  let clusterCount = 0;
-  for (let y = scanY0; y < scanY1; y++) {
-    const row = y * width;
-    for (let x = scanX0; x < scanX1; x++) {
-      const pi = (row + x) * 4;
+  const sy0 = Math.max(0, bestY - searchR);
+  const sy1 = Math.min(height, bestY + searchR + 1);
+  const sx0 = Math.max(0, bestX - searchR);
+  const sx1 = Math.min(width, bestX + searchR + 1);
+  for (let y = sy0; y < sy1; y++) {
+    const dy = y - bestY;
+    for (let x = sx0; x < sx1; x++) {
+      const dx = x - bestX;
+      if (dx * dx + dy * dy > searchR * searchR) continue;
+      const pi = (y * width + x) * 4;
       if (!isGeminiSparkleColor(pixels[pi], pixels[pi + 1], pixels[pi + 2])) continue;
-      sumY += y;
-      sumX += x;
-      if (y < cMinY) cMinY = y;
-      if (y > cMaxY) cMaxY = y;
-      if (x < cMinX) cMinX = x;
-      if (x > cMaxX) cMaxX = x;
-      clusterCount++;
+      const l = lum[y * width + x];
+      if (l > peakLum) {
+        peakLum = l;
+        peakY = y;
+        peakX = x;
+      }
     }
   }
 
+  // Build the mask as a tight circle around the relocated peak. Radius
+  // = `bestR + MASK_BUFFER_PX`, capped by `MASK_RADIUS_ABS_CAP`.
+  //
+  // `bestR` is the detector's best-fit scale, derived from the 4-arm
+  // pattern that matched at this point — it directly corresponds to
+  // the glyph's outer extent. Adding ~5 px catches anti-aliased halo
+  // pixels at the arm tips. The cap defends against the edge case
+  // where the detector picks the largest scale on a partial match.
+  //
+  // We deliberately do NOT extend the mask to cover the on-skin half
+  // of the glyph beyond the relocated peak ± bestR. The on-skin tail
+  // is anti-aliased into skin tone (palette gate would refuse it
+  // anyway) and reaches into the subject — engulfing it forces LaMa
+  // to fill subject pixels with sky-tone, which RMBG then strips,
+  // producing transparency holes between fingers. This mirrors the
+  // 984b578b behaviour: the visible on-bg portion is fully removed,
+  // any anti-aliased on-skin remnant is left alone (acceptable
+  // tradeoff over a transparency hole on the subject).
   const mask = new Uint8Array(width * height);
-  if (clusterCount < SPARKLE_PARAMS.CLUSTER_MIN_PALETTE_PIXELS) {
-    // Shape-detect passed but the palette cluster is degenerate. Refuse
-    // to build a mask rather than guess — the inpaint stage will see
-    // an empty mask and skip cleanly.
-    // eslint-disable-next-line no-console
-    console.warn(
-      `[NukeBG sparkle v=cluster-1] bestR=${bestR} det=(${bestY},${bestX}) ` +
-        `cluster=${clusterCount} (below MIN_PALETTE_PIXELS) — no mask built`,
-    );
-    return { detected: true, mask, centerX: bestX, centerY: bestY, radius: bestR };
-  }
-
-  const cyAbs = Math.round(sumY / clusterCount);
-  const cxAbs = Math.round(sumX / clusterCount);
-  const bboxHalfExtent = Math.floor(Math.max(cMaxY - cMinY, cMaxX - cMinX) / 2);
-  const rawRadius = bboxHalfExtent + SPARKLE_PARAMS.CLUSTER_BBOX_BUFFER_PX;
   const maskRadius = Math.min(
-    Math.round(rawRadius * SPARKLE_PARAMS.MASK_RADIUS_MULTIPLIER),
-    SPARKLE_PARAMS.CLUSTER_MAX_RADIUS_ABS_CAP,
+    bestR + SPARKLE_PARAMS.MASK_BUFFER_PX,
+    SPARKLE_PARAMS.MASK_RADIUS_ABS_CAP,
   );
   const maskRadius2 = maskRadius * maskRadius;
-
-  const y0 = Math.max(0, cyAbs - maskRadius);
-  const y1 = Math.min(height - 1, cyAbs + maskRadius);
-  const x0 = Math.max(0, cxAbs - maskRadius);
-  const x1 = Math.min(width - 1, cxAbs + maskRadius);
+  const y0 = Math.max(0, peakY - maskRadius);
+  const y1 = Math.min(height - 1, peakY + maskRadius);
+  const x0 = Math.max(0, peakX - maskRadius);
+  const x1 = Math.min(width - 1, peakX + maskRadius);
   let maskCount = 0;
   for (let y = y0; y <= y1; y++) {
-    const dy = y - cyAbs;
+    const dy = y - peakY;
     const dy2 = dy * dy;
     const row = y * width;
     for (let x = x0; x <= x1; x++) {
-      const dx = x - cxAbs;
+      const dx = x - peakX;
       if (dx * dx + dy2 <= maskRadius2) {
         mask[row + x] = 1;
         maskCount++;
@@ -325,22 +309,26 @@ export function sparkleDetect(
     }
   }
 
-  // Diagnostic log — palette-cluster strategy. Tagged `v=cluster-1` so
-  // a stale Service Worker bundle is identifiable by the missing prefix.
-  // Logged unconditionally (visible in preview/production builds) while
-  // we stabilize this on real photos. One line per image, no PII.
+  // Diagnostic log — peak-anchored circular mask. Tagged `v=peak-1`
+  // so a stale Service Worker bundle is identifiable by the missing
+  // prefix. Logged unconditionally (visible in preview/production
+  // builds) while we stabilize on real photos. One line per image,
+  // no PII. peakDelta surfaces how far peak relocation moved the
+  // centre from the detector's reported point.
+  const peakDeltaY = peakY - bestY;
+  const peakDeltaX = peakX - bestX;
   // eslint-disable-next-line no-console
   console.warn(
-    `[NukeBG sparkle v=cluster-1] bestR=${bestR} det=(${bestY},${bestX}) ` +
-      `centroid=(${cyAbs},${cxAbs}) cluster=${clusterCount} ` +
-      `bbox=${cMaxY - cMinY}x${cMaxX - cMinX} maskRadius=${maskRadius} maskPx=${maskCount}`,
+    `[NukeBG sparkle v=peak-1] bestR=${bestR} det=(${bestY},${bestX}) ` +
+      `peak=(${peakY},${peakX}) peakDelta=(${peakDeltaY},${peakDeltaX}) ` +
+      `peakLum=${peakLum.toFixed(0)} maskRadius=${maskRadius} maskPx=${maskCount}`,
   );
 
   return {
     detected: true,
     mask,
-    centerX: cxAbs,
-    centerY: cyAbs,
+    centerX: peakX,
+    centerY: peakY,
     radius: maskRadius,
   };
 }

--- a/src/workers/cv/sparkle-detect.ts
+++ b/src/workers/cv/sparkle-detect.ts
@@ -224,134 +224,123 @@ export function sparkleDetect(
     return { detected: false, mask: null };
   }
 
-  // Relocate the mask center from the detector's reported (bestY, bestX)
-  // to the brightest palette-matching pixel within the search box. The
-  // detector's 4-arm score landscape can place the center 30-40 px off
-  // the actual ✦ peak when one cardinal hits the sparkle and the others
-  // land in nearby bright sky. Effective radius = max(bestR × mult, MIN)
-  // so even a small bestR (14) reaches far enough to find the real peak.
-  let peakY = bestY;
-  let peakX = bestX;
-  let peakLum = lum[bestY * width + bestX];
-  const searchR = Math.max(
-    Math.ceil(bestR * SPARKLE_PARAMS.PEAK_SEARCH_RADIUS_MULTIPLIER),
-    SPARKLE_PARAMS.PEAK_SEARCH_RADIUS_MIN,
+  // Build the mask via palette-cluster centroid + bbox-derived radius.
+  // Port of the proven legacy `watermarkDetect` mask-building from the
+  // 984b578b deploy: scan the bottom-right corner, collect every
+  // palette-matching pixel, anchor a circular mask on their centroid
+  // with radius derived from their bounding box.
+  //
+  // Why this is the right strategy after shape detection passes:
+  //   - Shape detector's `(bestY, bestX)` comes from the score landscape
+  //     of the 4-arm pattern — it can be 30-50 px off the visual centroid
+  //     of the rendered glyph (the on-axis cardinal arm + bright sky
+  //     interference can produce a high score off the real peak).
+  //   - The cluster centroid IS, by construction, the visual centroid of
+  //     the bright palette pixels. The bbox tells us how far the glyph
+  //     extends, regardless of which `bestR` the detector picked.
+  //   - The CORE of the mask (`radius * MASK_RADIUS_MULTIPLIER`) is solid
+  //     and unconditional — covers the entire glyph, including the
+  //     anti-aliased on-skin half whose pixels don't pass the palette
+  //     gate themselves. This is what makes the legacy approach work
+  //     where the shape-polygon failed.
+  //
+  // False-positive risk that originally retired the legacy detector
+  // (motorcycle chrome, skin highlights) is neutralized here because
+  // the 4-arm shape gates G1-G6 above already qualified the input as
+  // a real Gemini ✦ before this code runs.
+  // Scan a generous window around the shape detector's `(bestY, bestX)`
+  // — NOT the whole corner. The shape gates G1-G6 already qualified
+  // the input as a real Gemini ✦, so we only need to focus on pixels
+  // near it. A whole-corner sweep is contaminated by unrelated bright
+  // clusters (clothing highlights, sun-lit foliage) which drag the
+  // centroid 80-100 px off the true sparkle.
+  const scanR = Math.max(
+    bestR * SPARKLE_PARAMS.CLUSTER_SCAN_RADIUS_MULTIPLIER,
+    SPARKLE_PARAMS.CLUSTER_SCAN_RADIUS_MIN,
   );
-  const sy0 = Math.max(0, bestY - searchR);
-  const sy1 = Math.min(height, bestY + searchR + 1);
-  const sx0 = Math.max(0, bestX - searchR);
-  const sx1 = Math.min(width, bestX + searchR + 1);
-  for (let y = sy0; y < sy1; y++) {
-    const dy = y - bestY;
-    for (let x = sx0; x < sx1; x++) {
-      const dx = x - bestX;
-      if (dx * dx + dy * dy > searchR * searchR) continue;
-      const pi = (y * width + x) * 4;
+  const scanY0 = Math.max(0, bestY - scanR);
+  const scanY1 = Math.min(height, bestY + scanR + 1);
+  const scanX0 = Math.max(0, bestX - scanR);
+  const scanX1 = Math.min(width, bestX + scanR + 1);
+  let sumY = 0;
+  let sumX = 0;
+  let cMinY = Infinity;
+  let cMaxY = -Infinity;
+  let cMinX = Infinity;
+  let cMaxX = -Infinity;
+  let clusterCount = 0;
+  for (let y = scanY0; y < scanY1; y++) {
+    const row = y * width;
+    for (let x = scanX0; x < scanX1; x++) {
+      const pi = (row + x) * 4;
       if (!isGeminiSparkleColor(pixels[pi], pixels[pi + 1], pixels[pi + 2])) continue;
-      const l = lum[y * width + x];
-      if (l > peakLum) {
-        peakLum = l;
-        peakY = y;
-        peakX = x;
+      sumY += y;
+      sumX += x;
+      if (y < cMinY) cMinY = y;
+      if (y > cMaxY) cMaxY = y;
+      if (x < cMinX) cMinX = x;
+      if (x > cMaxX) cMaxX = x;
+      clusterCount++;
+    }
+  }
+
+  const mask = new Uint8Array(width * height);
+  if (clusterCount < SPARKLE_PARAMS.CLUSTER_MIN_PALETTE_PIXELS) {
+    // Shape-detect passed but the palette cluster is degenerate. Refuse
+    // to build a mask rather than guess — the inpaint stage will see
+    // an empty mask and skip cleanly.
+    // eslint-disable-next-line no-console
+    console.warn(
+      `[NukeBG sparkle v=cluster-1] bestR=${bestR} det=(${bestY},${bestX}) ` +
+        `cluster=${clusterCount} (below MIN_PALETTE_PIXELS) — no mask built`,
+    );
+    return { detected: true, mask, centerX: bestX, centerY: bestY, radius: bestR };
+  }
+
+  const cyAbs = Math.round(sumY / clusterCount);
+  const cxAbs = Math.round(sumX / clusterCount);
+  const bboxHalfExtent = Math.floor(Math.max(cMaxY - cMinY, cMaxX - cMinX) / 2);
+  const rawRadius = bboxHalfExtent + SPARKLE_PARAMS.CLUSTER_BBOX_BUFFER_PX;
+  const maskRadius = Math.min(
+    Math.round(rawRadius * SPARKLE_PARAMS.MASK_RADIUS_MULTIPLIER),
+    SPARKLE_PARAMS.CLUSTER_MAX_RADIUS_ABS_CAP,
+  );
+  const maskRadius2 = maskRadius * maskRadius;
+
+  const y0 = Math.max(0, cyAbs - maskRadius);
+  const y1 = Math.min(height - 1, cyAbs + maskRadius);
+  const x0 = Math.max(0, cxAbs - maskRadius);
+  const x1 = Math.min(width - 1, cxAbs + maskRadius);
+  let maskCount = 0;
+  for (let y = y0; y <= y1; y++) {
+    const dy = y - cyAbs;
+    const dy2 = dy * dy;
+    const row = y * width;
+    for (let x = x0; x <= x1; x++) {
+      const dx = x - cxAbs;
+      if (dx * dx + dy2 <= maskRadius2) {
+        mask[row + x] = 1;
+        maskCount++;
       }
     }
   }
 
-  // Probe the actual glyph extent in the 4 cardinal directions. Walking
-  // outward from the relocated peak, count consecutive pixels with
-  // `lum >= peakLum × ratio`. The MAX of the four extents becomes the
-  // polygon arm length — so the mask adapts to the rendered glyph
-  // regardless of which `bestR` the detector picked. Taking the MAX
-  // (not the average) is intentional: an asymmetric glyph (half on
-  // bright sky, half on darker skin) shortens the on-skin probe but
-  // not the on-sky one; using the max ensures both arms are covered.
-  const minExtentLum = peakLum * SPARKLE_PARAMS.EXTENT_PROBE_BRIGHTNESS_RATIO;
-  const probeCap = SPARKLE_PARAMS.HALO_RADIUS_ABS_CAP;
-  const probe = (dy: number, dx: number): number => {
-    for (let i = 1; i <= probeCap; i++) {
-      const y = peakY + dy * i;
-      const x = peakX + dx * i;
-      if (y < 0 || y >= height || x < 0 || x >= width) return i - 1;
-      if (lum[y * width + x] < minExtentLum) return i - 1;
-    }
-    return probeCap;
-  };
-  const extN = probe(-1, 0);
-  const extS = probe(1, 0);
-  const extW = probe(0, -1);
-  const extE = probe(0, 1);
-  const probedExtent = Math.max(extN, extS, extE, extW);
-
-  // Build mask by rasterizing the ✦ glyph footprint at the relocated peak.
-  // Shape-based instead of brightness/palette flood-fill so the mask
-  // covers the entire visible glyph regardless of what's underneath —
-  // critical when the sparkle straddles a subject boundary (e.g. half on
-  // sky / half on the user's hand). The inpaint downstream (LaMa or
-  // PatchMatch via lama-router) reconstructs the masked pixels with
-  // content-aware fill; if the mask doesn't cover the on-skin half, no
-  // inpaint quality can rescue it.
-  //
-  // armLen = max(probedExtent, ARM_LENGTH_MULTIPLIER × bestR), bounded by
-  // HALO_RADIUS_ABS_CAP. The bestR-derived floor guards against degenerate
-  // probes (peak in a dim region); the absolute cap stops an over-bright
-  // sky probe from stretching into adjacent subjects.
-  const mask = new Uint8Array(width * height);
-  const armLen = Math.min(
-    Math.max(probedExtent, Math.round(bestR * SPARKLE_PARAMS.ARM_LENGTH_MULTIPLIER)),
-    SPARKLE_PARAMS.HALO_RADIUS_ABS_CAP,
-  );
-  const coreR = Math.max(2, Math.round(bestR * SPARKLE_PARAMS.CORE_RADIUS_MULTIPLIER));
-  const coreR2 = coreR * coreR;
-  const baseThickness = Math.max(
-    1,
-    Math.round(bestR * SPARKLE_PARAMS.ARM_BASE_THICKNESS_MULTIPLIER),
-  );
-
-  const y0 = Math.max(0, peakY - armLen);
-  const y1 = Math.min(height - 1, peakY + armLen);
-  const x0 = Math.max(0, peakX - armLen);
-  const x1 = Math.min(width - 1, peakX + armLen);
-  for (let y = y0; y <= y1; y++) {
-    const dy = y - peakY;
-    const ay = Math.abs(dy);
-    const row = y * width;
-    for (let x = x0; x <= x1; x++) {
-      const dx = x - peakX;
-      const ax = Math.abs(dx);
-      // L∞ distance from centre — drives the linear arm taper.
-      const dist = ax > ay ? ax : ay;
-      if (dist > armLen) continue;
-      // Tapering thickness: full at base, 1 px at tip.
-      const thickness = Math.max(1, Math.round(baseThickness * (1 - dist / armLen)));
-      const inHArm = ay <= thickness; // horizontal arm
-      const inVArm = ax <= thickness; // vertical arm
-      const inCore = dx * dx + dy * dy <= coreR2;
-      if (inHArm || inVArm || inCore) mask[row + x] = 1;
-    }
-  }
-
-  // Diagnostic log — surfaces detector vs. relocated peak vs. probed
-  // extents so a mis-anchored polygon can be identified from a single
-  // console line. Logged unconditionally (including production preview
-  // builds) while we stabilize the mask strategy on real photos. Tagged
-  // with `v=shape-2` so a stale Service Worker bundle is identifiable
-  // by the absence of this prefix. The log is one line per processed
-  // image and carries no PII.
-  let maskCount = 0;
-  for (let i = 0; i < mask.length; i++) if (mask[i]) maskCount++;
+  // Diagnostic log — palette-cluster strategy. Tagged `v=cluster-1` so
+  // a stale Service Worker bundle is identifiable by the missing prefix.
+  // Logged unconditionally (visible in preview/production builds) while
+  // we stabilize this on real photos. One line per image, no PII.
   // eslint-disable-next-line no-console
   console.warn(
-    `[NukeBG sparkle v=shape-2] bestR=${bestR} det=(${bestY},${bestX}) ` +
-      `peak=(${peakY},${peakX}) peakLum=${peakLum.toFixed(0)} ` +
-      `extents=N${extN}/S${extS}/E${extE}/W${extW} armLen=${armLen} ` +
-      `maskPx=${maskCount}`,
+    `[NukeBG sparkle v=cluster-1] bestR=${bestR} det=(${bestY},${bestX}) ` +
+      `centroid=(${cyAbs},${cxAbs}) cluster=${clusterCount} ` +
+      `bbox=${cMaxY - cMinY}x${cMaxX - cMinX} maskRadius=${maskRadius} maskPx=${maskCount}`,
   );
 
   return {
     detected: true,
     mask,
-    centerX: bestX,
-    centerY: bestY,
-    radius: bestR,
+    centerX: cxAbs,
+    centerY: cyAbs,
+    radius: maskRadius,
   };
 }

--- a/src/workers/cv/sparkle-detect.ts
+++ b/src/workers/cv/sparkle-detect.ts
@@ -255,58 +255,53 @@ export function sparkleDetect(
     }
   }
 
-  // Build mask via brightness-and-palette flood-fill from the relocated
-  // peak. Spatial bound = min(haloR-multiplier × bestR, absolute cap) so
-  // an inflated bestR can't drag the mask into adjacent subjects.
+  // Build mask by rasterizing the ✦ glyph footprint at the relocated peak.
+  // Shape-based instead of brightness/palette flood-fill so the mask
+  // covers the entire visible glyph regardless of what's underneath —
+  // critical when the sparkle straddles a subject boundary (e.g. half on
+  // sky / half on the user's hand). The inpaint downstream (LaMa or
+  // PatchMatch via lama-router) reconstructs the masked pixels with
+  // content-aware fill; if the mask doesn't cover the on-skin half, no
+  // inpaint quality can rescue it.
+  //
+  // Geometry mirrors the rendered Gemini glyph and the test fixture's
+  // `paintSparkle`: 4 cardinal arms tapering from a base half-width
+  // (CORE_RADIUS_MULTIPLIER × bestR scaled) to 1 px at the tip, plus a
+  // central disk. Arm length is bounded by both ARM_LENGTH_MULTIPLIER ×
+  // bestR and the absolute cap HALO_RADIUS_ABS_CAP — so an over-estimated
+  // bestR cannot drag the mask into adjacent subjects.
   const mask = new Uint8Array(width * height);
-  const haloR = Math.min(
-    Math.ceil(bestR * SPARKLE_PARAMS.HALO_RADIUS_MULTIPLIER),
+  const armLen = Math.min(
+    Math.round(bestR * SPARKLE_PARAMS.ARM_LENGTH_MULTIPLIER),
     SPARKLE_PARAMS.HALO_RADIUS_ABS_CAP,
   );
-  const haloR2 = haloR * haloR;
-  const minLum = peakLum * SPARKLE_PARAMS.HALO_BRIGHTNESS_RATIO;
+  const coreR = Math.max(2, Math.round(bestR * SPARKLE_PARAMS.CORE_RADIUS_MULTIPLIER));
+  const coreR2 = coreR * coreR;
+  const baseThickness = Math.max(
+    1,
+    Math.round(bestR * SPARKLE_PARAMS.ARM_BASE_THICKNESS_MULTIPLIER),
+  );
 
-  // Tiny seed disk around the relocated peak so anti-aliased peak pixels
-  // are always masked before the flood expands.
-  const queue: number[] = [];
-  const seedR = SPARKLE_PARAMS.SEED_RADIUS;
-  const seedR2 = seedR * seedR;
-  for (let dy = -seedR; dy <= seedR; dy++) {
-    for (let dx = -seedR; dx <= seedR; dx++) {
-      if (dx * dx + dy * dy > seedR2) continue;
-      const sy = peakY + dy;
-      const sx = peakX + dx;
-      if (sy < 0 || sy >= height || sx < 0 || sx >= width) continue;
-      const sIdx = sy * width + sx;
-      if (!mask[sIdx]) {
-        mask[sIdx] = 1;
-        queue.push(sIdx);
-      }
-    }
-  }
-
-  // 4-neighbor BFS — gates: within haloR distance from the relocated peak,
-  // luminance ≥ minLum, palette match (low-sat or slight cyan tint, dim
-  // floor PALETTE_MIN_MAX). Together these reject skin, dark bezels,
-  // grass, etc. while still walking through dim near-white halo pixels.
-  while (queue.length > 0) {
-    const idx = queue.pop()!;
-    const y = (idx / width) | 0;
-    const x = idx - y * width;
-    for (let nb = 0; nb < 4; nb++) {
-      const ny = y + (nb === 0 ? -1 : nb === 1 ? 1 : 0);
-      const nx = x + (nb === 2 ? -1 : nb === 3 ? 1 : 0);
-      if (ny < 0 || ny >= height || nx < 0 || nx >= width) continue;
-      const nIdx = ny * width + nx;
-      if (mask[nIdx]) continue;
-      const dly = ny - peakY;
-      const dlx = nx - peakX;
-      if (dly * dly + dlx * dlx > haloR2) continue;
-      if (lum[nIdx] < minLum) continue;
-      const pi = nIdx * 4;
-      if (!isGeminiSparkleColor(pixels[pi], pixels[pi + 1], pixels[pi + 2])) continue;
-      mask[nIdx] = 1;
-      queue.push(nIdx);
+  const y0 = Math.max(0, peakY - armLen);
+  const y1 = Math.min(height - 1, peakY + armLen);
+  const x0 = Math.max(0, peakX - armLen);
+  const x1 = Math.min(width - 1, peakX + armLen);
+  for (let y = y0; y <= y1; y++) {
+    const dy = y - peakY;
+    const ay = Math.abs(dy);
+    const row = y * width;
+    for (let x = x0; x <= x1; x++) {
+      const dx = x - peakX;
+      const ax = Math.abs(dx);
+      // L∞ distance from centre — drives the linear arm taper.
+      const dist = ax > ay ? ax : ay;
+      if (dist > armLen) continue;
+      // Tapering thickness: full at base, 1 px at tip.
+      const thickness = Math.max(1, Math.round(baseThickness * (1 - dist / armLen)));
+      const inHArm = ay <= thickness; // horizontal arm
+      const inVArm = ax <= thickness; // vertical arm
+      const inCore = dx * dx + dy * dy <= coreR2;
+      if (inHArm || inVArm || inCore) mask[row + x] = 1;
     }
   }
 

--- a/src/workers/cv/sparkle-detect.ts
+++ b/src/workers/cv/sparkle-detect.ts
@@ -332,16 +332,20 @@ export function sparkleDetect(
 
   // Diagnostic log — surfaces detector vs. relocated peak vs. probed
   // extents so a mis-anchored polygon can be identified from a single
-  // console line in dev. Quiet in production builds (Vite defines
-  // `import.meta.env.DEV` based on mode).
-  if (typeof import.meta.env !== 'undefined' && import.meta.env.DEV) {
-    // eslint-disable-next-line no-console
-    console.log(
-      `[NukeBG sparkle] bestR=${bestR} det=(${bestY},${bestX}) ` +
-        `peak=(${peakY},${peakX}) peakLum=${peakLum.toFixed(0)} ` +
-        `extents=N${extN}/S${extS}/E${extE}/W${extW} armLen=${armLen}`,
-    );
-  }
+  // console line. Logged unconditionally (including production preview
+  // builds) while we stabilize the mask strategy on real photos. Tagged
+  // with `v=shape-2` so a stale Service Worker bundle is identifiable
+  // by the absence of this prefix. The log is one line per processed
+  // image and carries no PII.
+  let maskCount = 0;
+  for (let i = 0; i < mask.length; i++) if (mask[i]) maskCount++;
+  // eslint-disable-next-line no-console
+  console.warn(
+    `[NukeBG sparkle v=shape-2] bestR=${bestR} det=(${bestY},${bestX}) ` +
+      `peak=(${peakY},${peakX}) peakLum=${peakLum.toFixed(0)} ` +
+      `extents=N${extN}/S${extS}/E${extE}/W${extW} armLen=${armLen} ` +
+      `maskPx=${maskCount}`,
+  );
 
   return {
     detected: true,

--- a/src/workers/cv/sparkle-detect.ts
+++ b/src/workers/cv/sparkle-detect.ts
@@ -1,22 +1,6 @@
 import { SPARKLE_PARAMS } from '../../pipeline/constants';
 import type { WatermarkResult } from '../../types/pipeline';
 
-/** Returns true when the pixel matches the Gemini sparkle palette: a
- *  bright low-saturation (or slight-cyan-tint) pixel. The `max` floor is
- *  configurable (`SPARKLE_PARAMS.PALETTE_MIN_MAX`) so dim/aliased ✦ glyphs
- *  on JPEG-compressed photos still match. Saturation cap rejects skin
- *  tones, grass, and other colored objects so the flood-fill doesn't walk
- *  out of the sparkle into the subject. */
-function isGeminiSparkleColor(r: number, g: number, b: number): boolean {
-  const max = Math.max(r, g, b);
-  if (max < SPARKLE_PARAMS.PALETTE_MIN_MAX) return false;
-  const min = Math.min(r, g, b);
-  const saturation = max - min;
-  if (saturation <= 35) return true;
-  if (b >= r && b >= g && r >= 180 && g >= 180) return true;
-  return false;
-}
-
 /**
  * Shape-based Gemini sparkle detector.
  *
@@ -224,111 +208,31 @@ export function sparkleDetect(
     return { detected: false, mask: null };
   }
 
-  // Relocate the mask centre from the detector's score-landscape
-  // `(bestY, bestX)` to the brightest palette-matching pixel within
-  // a generous search box. The detector's 4-arm score peak can sit
-  // 30-50 px off the visual centroid of the rendered glyph (one arm
-  // hits the sparkle, others land on bright sky → score peaks
-  // off-glyph). Brightest palette pixel IS the visual centre.
-  //
-  // Why we drop the cluster-centroid + bbox approach we had in
-  // v=cluster-1: the centroid of palette pixels in a window centred
-  // on `bestY/bestX` collapsed back to `bestY/bestX` (symmetric
-  // window + roughly symmetric pixels), giving us nothing the
-  // detector didn't already have. The bbox absorbed scattered
-  // skin-specular highlights and inflated to ~95×95 → mask centred
-  // on the wrong point AND 50% bigger than the real glyph. Anchoring
-  // on the relocated peak with a `bestR`-derived radius gives a
-  // tight, correctly-placed mask without requiring any extra heuristics.
-  let peakY = bestY;
-  let peakX = bestX;
-  let peakLum = lum[bestY * width + bestX];
-  const searchR = Math.max(
-    Math.ceil(bestR * SPARKLE_PARAMS.PEAK_SEARCH_RADIUS_MULTIPLIER),
-    SPARKLE_PARAMS.PEAK_SEARCH_RADIUS_MIN,
-  );
-  const sy0 = Math.max(0, bestY - searchR);
-  const sy1 = Math.min(height, bestY + searchR + 1);
-  const sx0 = Math.max(0, bestX - searchR);
-  const sx1 = Math.min(width, bestX + searchR + 1);
-  for (let y = sy0; y < sy1; y++) {
-    const dy = y - bestY;
-    for (let x = sx0; x < sx1; x++) {
-      const dx = x - bestX;
-      if (dx * dx + dy * dy > searchR * searchR) continue;
-      const pi = (y * width + x) * 4;
-      if (!isGeminiSparkleColor(pixels[pi], pixels[pi + 1], pixels[pi + 2])) continue;
-      const l = lum[y * width + x];
-      if (l > peakLum) {
-        peakLum = l;
-        peakY = y;
-        peakX = x;
-      }
-    }
-  }
-
-  // Build the mask as a tight circle around the relocated peak. Radius
-  // = `bestR + MASK_BUFFER_PX`, capped by `MASK_RADIUS_ABS_CAP`.
-  //
-  // `bestR` is the detector's best-fit scale, derived from the 4-arm
-  // pattern that matched at this point — it directly corresponds to
-  // the glyph's outer extent. Adding ~5 px catches anti-aliased halo
-  // pixels at the arm tips. The cap defends against the edge case
-  // where the detector picks the largest scale on a partial match.
-  //
-  // We deliberately do NOT extend the mask to cover the on-skin half
-  // of the glyph beyond the relocated peak ± bestR. The on-skin tail
-  // is anti-aliased into skin tone (palette gate would refuse it
-  // anyway) and reaches into the subject — engulfing it forces LaMa
-  // to fill subject pixels with sky-tone, which RMBG then strips,
-  // producing transparency holes between fingers. This mirrors the
-  // 984b578b behaviour: the visible on-bg portion is fully removed,
-  // any anti-aliased on-skin remnant is left alone (acceptable
-  // tradeoff over a transparency hole on the subject).
+  // Build circular mask
   const mask = new Uint8Array(width * height);
-  const maskRadius = Math.min(
-    bestR + SPARKLE_PARAMS.MASK_BUFFER_PX,
-    SPARKLE_PARAMS.MASK_RADIUS_ABS_CAP,
-  );
-  const maskRadius2 = maskRadius * maskRadius;
-  const y0 = Math.max(0, peakY - maskRadius);
-  const y1 = Math.min(height - 1, peakY + maskRadius);
-  const x0 = Math.max(0, peakX - maskRadius);
-  const x1 = Math.min(width - 1, peakX + maskRadius);
-  let maskCount = 0;
-  for (let y = y0; y <= y1; y++) {
-    const dy = y - peakY;
+  const maskR = Math.ceil(bestR * SPARKLE_PARAMS.MASK_RADIUS_MULTIPLIER);
+  const maskR2 = maskR * maskR;
+  const y0 = Math.max(0, bestY - maskR);
+  const y1 = Math.min(height, bestY + maskR + 1);
+  const x0 = Math.max(0, bestX - maskR);
+  const x1 = Math.min(width, bestX + maskR + 1);
+  for (let y = y0; y < y1; y++) {
+    const dy = y - bestY;
     const dy2 = dy * dy;
     const row = y * width;
-    for (let x = x0; x <= x1; x++) {
-      const dx = x - peakX;
-      if (dx * dx + dy2 <= maskRadius2) {
+    for (let x = x0; x < x1; x++) {
+      const dx = x - bestX;
+      if (dx * dx + dy2 <= maskR2) {
         mask[row + x] = 1;
-        maskCount++;
       }
     }
   }
-
-  // Diagnostic log — peak-anchored circular mask. Tagged `v=peak-1`
-  // so a stale Service Worker bundle is identifiable by the missing
-  // prefix. Logged unconditionally (visible in preview/production
-  // builds) while we stabilize on real photos. One line per image,
-  // no PII. peakDelta surfaces how far peak relocation moved the
-  // centre from the detector's reported point.
-  const peakDeltaY = peakY - bestY;
-  const peakDeltaX = peakX - bestX;
-  // eslint-disable-next-line no-console
-  console.warn(
-    `[NukeBG sparkle v=peak-1] bestR=${bestR} det=(${bestY},${bestX}) ` +
-      `peak=(${peakY},${peakX}) peakDelta=(${peakDeltaY},${peakDeltaX}) ` +
-      `peakLum=${peakLum.toFixed(0)} maskRadius=${maskRadius} maskPx=${maskCount}`,
-  );
 
   return {
     detected: true,
     mask,
-    centerX: peakX,
-    centerY: peakY,
-    radius: maskRadius,
+    centerX: bestX,
+    centerY: bestY,
+    radius: bestR,
   };
 }

--- a/src/workers/cv/sparkle-detect.ts
+++ b/src/workers/cv/sparkle-detect.ts
@@ -225,16 +225,18 @@ export function sparkleDetect(
   }
 
   // Relocate the mask center from the detector's reported (bestY, bestX)
-  // to the brightest palette-matching pixel within `bestR`. The detector's
-  // 4-arm score landscape can place the center 30-40 px off the actual ✦
-  // peak when one cardinal hits the sparkle and the others land in nearby
-  // bright sky — building the mask around the true peak keeps it confined
-  // to the visible glyph instead of spreading toward whatever the detector
-  // accidentally sampled.
+  // to the brightest palette-matching pixel within the search box. The
+  // detector's 4-arm score landscape can place the center 30-40 px off
+  // the actual ✦ peak when one cardinal hits the sparkle and the others
+  // land in nearby bright sky. Effective radius = max(bestR × mult, MIN)
+  // so even a small bestR (14) reaches far enough to find the real peak.
   let peakY = bestY;
   let peakX = bestX;
   let peakLum = lum[bestY * width + bestX];
-  const searchR = Math.ceil(bestR * SPARKLE_PARAMS.PEAK_SEARCH_RADIUS_MULTIPLIER);
+  const searchR = Math.max(
+    Math.ceil(bestR * SPARKLE_PARAMS.PEAK_SEARCH_RADIUS_MULTIPLIER),
+    SPARKLE_PARAMS.PEAK_SEARCH_RADIUS_MIN,
+  );
   const sy0 = Math.max(0, bestY - searchR);
   const sy1 = Math.min(height, bestY + searchR + 1);
   const sx0 = Math.max(0, bestX - searchR);
@@ -255,6 +257,31 @@ export function sparkleDetect(
     }
   }
 
+  // Probe the actual glyph extent in the 4 cardinal directions. Walking
+  // outward from the relocated peak, count consecutive pixels with
+  // `lum >= peakLum × ratio`. The MAX of the four extents becomes the
+  // polygon arm length — so the mask adapts to the rendered glyph
+  // regardless of which `bestR` the detector picked. Taking the MAX
+  // (not the average) is intentional: an asymmetric glyph (half on
+  // bright sky, half on darker skin) shortens the on-skin probe but
+  // not the on-sky one; using the max ensures both arms are covered.
+  const minExtentLum = peakLum * SPARKLE_PARAMS.EXTENT_PROBE_BRIGHTNESS_RATIO;
+  const probeCap = SPARKLE_PARAMS.HALO_RADIUS_ABS_CAP;
+  const probe = (dy: number, dx: number): number => {
+    for (let i = 1; i <= probeCap; i++) {
+      const y = peakY + dy * i;
+      const x = peakX + dx * i;
+      if (y < 0 || y >= height || x < 0 || x >= width) return i - 1;
+      if (lum[y * width + x] < minExtentLum) return i - 1;
+    }
+    return probeCap;
+  };
+  const extN = probe(-1, 0);
+  const extS = probe(1, 0);
+  const extW = probe(0, -1);
+  const extE = probe(0, 1);
+  const probedExtent = Math.max(extN, extS, extE, extW);
+
   // Build mask by rasterizing the ✦ glyph footprint at the relocated peak.
   // Shape-based instead of brightness/palette flood-fill so the mask
   // covers the entire visible glyph regardless of what's underneath —
@@ -264,15 +291,13 @@ export function sparkleDetect(
   // content-aware fill; if the mask doesn't cover the on-skin half, no
   // inpaint quality can rescue it.
   //
-  // Geometry mirrors the rendered Gemini glyph and the test fixture's
-  // `paintSparkle`: 4 cardinal arms tapering from a base half-width
-  // (CORE_RADIUS_MULTIPLIER × bestR scaled) to 1 px at the tip, plus a
-  // central disk. Arm length is bounded by both ARM_LENGTH_MULTIPLIER ×
-  // bestR and the absolute cap HALO_RADIUS_ABS_CAP — so an over-estimated
-  // bestR cannot drag the mask into adjacent subjects.
+  // armLen = max(probedExtent, ARM_LENGTH_MULTIPLIER × bestR), bounded by
+  // HALO_RADIUS_ABS_CAP. The bestR-derived floor guards against degenerate
+  // probes (peak in a dim region); the absolute cap stops an over-bright
+  // sky probe from stretching into adjacent subjects.
   const mask = new Uint8Array(width * height);
   const armLen = Math.min(
-    Math.round(bestR * SPARKLE_PARAMS.ARM_LENGTH_MULTIPLIER),
+    Math.max(probedExtent, Math.round(bestR * SPARKLE_PARAMS.ARM_LENGTH_MULTIPLIER)),
     SPARKLE_PARAMS.HALO_RADIUS_ABS_CAP,
   );
   const coreR = Math.max(2, Math.round(bestR * SPARKLE_PARAMS.CORE_RADIUS_MULTIPLIER));
@@ -303,6 +328,19 @@ export function sparkleDetect(
       const inCore = dx * dx + dy * dy <= coreR2;
       if (inHArm || inVArm || inCore) mask[row + x] = 1;
     }
+  }
+
+  // Diagnostic log — surfaces detector vs. relocated peak vs. probed
+  // extents so a mis-anchored polygon can be identified from a single
+  // console line in dev. Quiet in production builds (Vite defines
+  // `import.meta.env.DEV` based on mode).
+  if (typeof import.meta.env !== 'undefined' && import.meta.env.DEV) {
+    // eslint-disable-next-line no-console
+    console.log(
+      `[NukeBG sparkle] bestR=${bestR} det=(${bestY},${bestX}) ` +
+        `peak=(${peakY},${peakX}) peakLum=${peakLum.toFixed(0)} ` +
+        `extents=N${extN}/S${extS}/E${extE}/W${extW} armLen=${armLen}`,
+    );
   }
 
   return {

--- a/tests/components/ar-progress.test.ts
+++ b/tests/components/ar-progress.test.ts
@@ -45,14 +45,15 @@ describe('ar-progress — replay after reset', () => {
     document.body.innerHTML = '';
   });
 
-  it('after reset() alone, every icon slot is empty (this is the bug we fix)', () => {
+  it('after reset() alone, no stages are rendered (pending stages are hidden)', () => {
     const el = mount();
     el.reset();
     const stages = stageEls(el);
-    expect(stages.length).toBeGreaterThan(0);
-    for (const s of stages) {
-      expect(iconHtml(s)).toBe('');
-    }
+    // Pending stages are filtered out of the render entirely; the
+    // log row stays empty until pipeline emits its first running event.
+    // This replaces the previous regression test that asserted empty
+    // icon slots — that surface was confusing users mid-pipeline.
+    expect(stages.length).toBe(0);
   });
 
   it('replays a full success history — every visible stage has a done icon', () => {

--- a/tests/cv/sparkle-detect.test.ts
+++ b/tests/cv/sparkle-detect.test.ts
@@ -67,13 +67,18 @@ describe('sparkleDetect', () => {
 
     expect(result.detected).toBe(true);
     expect(result.mask).not.toBeNull();
-    // Sparkle sits in the bottom-right quadrant of the downscaled selfie
-    expect(result.centerX).toBeGreaterThan(width * 0.75);
-    expect(result.centerY).toBeGreaterThan(height * 0.7);
-    // Radius should be within the relative band (1.5%-5.5% of min dim)
-    const minDim = Math.min(width, height);
-    expect(result.radius).toBeGreaterThanOrEqual(Math.floor(minDim * 0.015));
-    expect(result.radius).toBeLessThanOrEqual(Math.ceil(minDim * 0.055));
+    // Sparkle sits in the bottom-right quadrant of the downscaled selfie.
+    // (centerX/Y now report the cluster centroid, which is the visual
+    // centre of the rendered glyph rather than the detector's
+    // score-landscape best-fit point.)
+    expect(result.centerX).toBeGreaterThan(width * 0.5);
+    expect(result.centerY).toBeGreaterThan(height * 0.5);
+    // Mask radius derives from the palette cluster bbox, capped by
+    // CLUSTER_MAX_RADIUS_ABS_CAP=80. Just sanity-check it's positive
+    // and within the cap — the precise value depends on the fixture's
+    // bright-pixel layout.
+    expect(result.radius).toBeGreaterThan(0);
+    expect(result.radius).toBeLessThanOrEqual(80);
   });
 
   it('does not detect a sparkle in a clean photo region (no watermark)', async () => {

--- a/tests/cv/sparkle-detect.test.ts
+++ b/tests/cv/sparkle-detect.test.ts
@@ -67,18 +67,13 @@ describe('sparkleDetect', () => {
 
     expect(result.detected).toBe(true);
     expect(result.mask).not.toBeNull();
-    // Sparkle sits in the bottom-right quadrant of the downscaled selfie.
-    // (centerX/Y now report the cluster centroid, which is the visual
-    // centre of the rendered glyph rather than the detector's
-    // score-landscape best-fit point.)
-    expect(result.centerX).toBeGreaterThan(width * 0.5);
-    expect(result.centerY).toBeGreaterThan(height * 0.5);
-    // Mask radius derives from the palette cluster bbox, capped by
-    // CLUSTER_MAX_RADIUS_ABS_CAP=80. Just sanity-check it's positive
-    // and within the cap — the precise value depends on the fixture's
-    // bright-pixel layout.
-    expect(result.radius).toBeGreaterThan(0);
-    expect(result.radius).toBeLessThanOrEqual(80);
+    // Sparkle sits in the bottom-right quadrant of the downscaled selfie
+    expect(result.centerX).toBeGreaterThan(width * 0.75);
+    expect(result.centerY).toBeGreaterThan(height * 0.7);
+    // Radius should be within the relative band (1.5%-5.5% of min dim)
+    const minDim = Math.min(width, height);
+    expect(result.radius).toBeGreaterThanOrEqual(Math.floor(minDim * 0.015));
+    expect(result.radius).toBeLessThanOrEqual(Math.ceil(minDim * 0.055));
   });
 
   it('does not detect a sparkle in a clean photo region (no watermark)', async () => {
@@ -142,52 +137,6 @@ describe('sparkleDetect', () => {
     expect(count).toBeGreaterThan(0);
     // Mask should not cover more than 2% of the image
     expect(count).toBeLessThan(w * h * 0.02);
-  });
-
-  it('mask is shape-based: covers the glyph footprint regardless of underlying pixel color', () => {
-    // Regression for the on-skin half-glyph case: when a sparkle straddles
-    // a subject boundary (e.g. half on dark sky, half on a hand), the
-    // legacy flood-fill mask only caught the bright/palette-matching half
-    // and left the on-skin half visible. The shape rasterizer must cover
-    // the full glyph footprint regardless of what's underneath, so the
-    // downstream LaMa/PatchMatch inpaint can reconstruct it.
-    const w = 500,
-      h = 500;
-    const cx = 430,
-      cy = 430,
-      radius = 20;
-    const pixels = solidImage(w, h, 60, 60, 60);
-    paintSparkle(pixels, w, cx, cy, radius, [240, 240, 240]);
-
-    // Overpaint a 3×3 block on the east arm with a saturated skin-tone —
-    // fails the sparkle palette but lies inside the glyph footprint. A
-    // flood-fill mask refuses these pixels (they break the palette gate);
-    // a shape mask covers them. Keep the patch tight enough that detector
-    // gates (cardinal/perp sample positions) are unaffected.
-    const px = cx + 6,
-      py = cy;
-    for (let y = py - 1; y <= py + 1; y++) {
-      for (let x = px - 1; x <= px + 1; x++) {
-        const i = (y * w + x) * 4;
-        pixels[i] = 200;
-        pixels[i + 1] = 130;
-        pixels[i + 2] = 110;
-        pixels[i + 3] = 255;
-      }
-    }
-
-    const result = sparkleDetect(pixels, w, h);
-    expect(result.detected).toBe(true);
-
-    let overpaintMasked = 0;
-    for (let y = py - 1; y <= py + 1; y++) {
-      for (let x = px - 1; x <= px + 1; x++) {
-        if (result.mask![y * w + x]) overpaintMasked++;
-      }
-    }
-    // All 9 non-palette pixels inside the east-arm footprint must be in
-    // the mask — proves the rasterizer ignores per-pixel colour.
-    expect(overpaintMasked).toBe(9);
   });
 
   it('handles small images without crashing', () => {

--- a/tests/cv/sparkle-detect.test.ts
+++ b/tests/cv/sparkle-detect.test.ts
@@ -139,54 +139,13 @@ describe('sparkleDetect', () => {
     expect(count).toBeLessThan(w * h * 0.02);
   });
 
-  // Helper: paints a wide near-white halo annulus around a center, covering
-  // everything from just past the sparkle shape outward to a comfortable
-  // outer radius. Bigger than any bestR the detector might pick so the
-  // assertion is robust to the multi-scale search.
-  function paintHaloAnnulus(
-    pixels: Uint8ClampedArray,
-    w: number,
-    cx: number,
-    cy: number,
-    inner: number,
-    outer: number,
-    rgb: [number, number, number],
-  ): void {
-    for (let y = cy - outer; y <= cy + outer; y++) {
-      for (let x = cx - outer; x <= cx + outer; x++) {
-        const d2 = (x - cx) ** 2 + (y - cy) ** 2;
-        if (d2 >= inner * inner && d2 <= outer * outer) {
-          const i = (y * w + x) * 4;
-          pixels[i] = rgb[0];
-          pixels[i + 1] = rgb[1];
-          pixels[i + 2] = rgb[2];
-          pixels[i + 3] = 255;
-        }
-      }
-    }
-  }
-
-  // Counts how many masked pixels carry a specific RGB color. Decouples the
-  // assertion from whatever bestR/bestX the detector picked — we only care
-  // that pixels of the annulus color end up masked (palette match) or not
-  // (palette miss). RGB tolerance is exact since the test paints solid.
-  function countMaskedWithColor(
-    mask: Uint8Array,
-    pixels: Uint8ClampedArray,
-    rgb: [number, number, number],
-  ): number {
-    let count = 0;
-    for (let p = 0; p < mask.length; p++) {
-      if (!mask[p]) continue;
-      const i = p * 4;
-      if (pixels[i] === rgb[0] && pixels[i + 1] === rgb[1] && pixels[i + 2] === rgb[2]) {
-        count++;
-      }
-    }
-    return count;
-  }
-
-  it('extends mask into near-white halo around the sparkle (palette-gated)', () => {
+  it('mask is shape-based: covers the glyph footprint regardless of underlying pixel color', () => {
+    // Regression for the on-skin half-glyph case: when a sparkle straddles
+    // a subject boundary (e.g. half on dark sky, half on a hand), the
+    // legacy flood-fill mask only caught the bright/palette-matching half
+    // and left the on-skin half visible. The shape rasterizer must cover
+    // the full glyph footprint regardless of what's underneath, so the
+    // downstream LaMa/PatchMatch inpaint can reconstruct it.
     const w = 500,
       h = 500;
     const cx = 430,
@@ -194,42 +153,36 @@ describe('sparkleDetect', () => {
       radius = 20;
     const pixels = solidImage(w, h, 60, 60, 60);
     paintSparkle(pixels, w, cx, cy, radius, [240, 240, 240]);
-    // Wide near-white annulus surrounding the shape — deliberately oversized
-    // so it covers any haloR the detector ends up using.
-    // Mid-bright near-white halo: bright enough for flood-fill brightness
-    // floor (lum ≈ 180 vs centerLum*0.65 ≈ 156), low enough that detector
-    // gates (G4 outer-ring contrast) still pass.
-    paintHaloAnnulus(pixels, w, cx, cy, radius, 50, [210, 210, 210]);
+
+    // Overpaint a 3×3 block on the east arm with a saturated skin-tone —
+    // fails the sparkle palette but lies inside the glyph footprint. A
+    // flood-fill mask refuses these pixels (they break the palette gate);
+    // a shape mask covers them. Keep the patch tight enough that detector
+    // gates (cardinal/perp sample positions) are unaffected.
+    const px = cx + 6,
+      py = cy;
+    for (let y = py - 1; y <= py + 1; y++) {
+      for (let x = px - 1; x <= px + 1; x++) {
+        const i = (y * w + x) * 4;
+        pixels[i] = 200;
+        pixels[i + 1] = 130;
+        pixels[i + 2] = 110;
+        pixels[i + 3] = 255;
+      }
+    }
 
     const result = sparkleDetect(pixels, w, h);
     expect(result.detected).toBe(true);
 
-    // A meaningful number of the near-white halo pixels MUST be masked —
-    // proves the brightness+palette flood-fill walked into the halo
-    // through the connected near-white region.
-    const masked = countMaskedWithColor(result.mask!, pixels, [210, 210, 210]);
-    expect(masked).toBeGreaterThan(20);
-  });
-
-  it('does NOT extend mask into non-palette neighbors (saturated red)', () => {
-    const w = 500,
-      h = 500;
-    const cx = 430,
-      cy = 430,
-      radius = 20;
-    const pixels = solidImage(w, h, 60, 60, 60);
-    paintSparkle(pixels, w, cx, cy, radius, [240, 240, 240]);
-    // Saturated red annulus — fails the palette gate, so halo expansion
-    // must NOT reach into it even though it's inside haloR.
-    paintHaloAnnulus(pixels, w, cx, cy, radius + 2, 50, [220, 30, 30]);
-
-    const result = sparkleDetect(pixels, w, h);
-    expect(result.detected).toBe(true);
-
-    // Zero red pixels should end up in the mask: the palette gate refuses
-    // the saturated red even though it lies inside the haloR ring.
-    const masked = countMaskedWithColor(result.mask!, pixels, [220, 30, 30]);
-    expect(masked).toBe(0);
+    let overpaintMasked = 0;
+    for (let y = py - 1; y <= py + 1; y++) {
+      for (let x = px - 1; x <= px + 1; x++) {
+        if (result.mask![y * w + x]) overpaintMasked++;
+      }
+    }
+    // All 9 non-palette pixels inside the east-arm footprint must be in
+    // the mask — proves the rasterizer ignores per-pixel colour.
+    expect(overpaintMasked).toBe(9);
   });
 
   it('handles small images without crashing', () => {


### PR DESCRIPTION
## Summary

Restores the watermark/sparkle removal pipeline to the proven 984b578b deploy (the user's confirmed-ideal baseline) AND adds two surgical fixes on top:

1. **Gate the legacy `watermarkDetect` with the shape detector** — kills false positives on real photos with bright clusters in the bottom-right (motorbike chrome, skin highlights) without sacrificing the cluster-centroid mask quality on real Gemini ✦ glyphs.
2. **Hide queued pipeline stages from the progress UI + drop the per-stage progress bar** — stops surfacing "Eliminando fondo [ML]" before that stage runs and removes a 3px bar that duplicated info already in the textual message.

## Why a rollback

The branch started as a shape-polygon mask iteration to fix #239 (sparkle remnant on the on-skin half of the glyph). After several iterations — peak-relocated polygon, adaptive arm-length probe, palette-cluster centroid — every variant either left parts of the glyph visible or engulfed the subject and produced RMBG transparency holes between the user's fingers.

User pinned the spec on https://984b578b.nukebg.pages.dev: "ese resultado era el ideal." That deploy ran the legacy color-deviation `watermarkDetect` (retired in PR #223) alongside `sparkleDetect`, with their masks unioned. PR #225 and #238 were band-aids over the post-#223 hole and never matched the legacy quality. Rolling back the four sparkle-pipeline files to commit `196d4d2` (parent of #223) restores the exact code path that produced the clean removal.

## Why bringing the legacy back is now safe

PR #223 had a real motivator: `watermarkDetect` has no shape gate, so any tight bright cluster in the bottom-right fires it (motostest false positive, etc.). This PR addresses that without retiring the detector — it gates the legacy mask behind shape-detector confirmation:

```ts
const geminiConfirmed = wmGemini.detected && wmSparkle.detected;
const geminiMaskGated = geminiConfirmed ? wmGemini.mask : null;
```

`sparkleDetect` already has 6 strict gates (4-arm symmetry, narrow-arm isolation, center peak vs outer ring, etc.) that reliably reject motostest, motorcycles-clean, fiat-clean, trump-clean fixtures — verified by existing unit tests. Together: cluster-centroid mask quality from legacy + false-positive immunity from shape.

## Changes

- `src/pipeline/orchestrator.ts` — restore three-detector union (legacy + dalle + sparkle-shape) with the new `geminiConfirmed` gate.
- `src/pipeline/constants.ts` — restore `SPARKLE_PARAMS` to its pre-#223 form (drop `MASK_RADIUS_MULTIPLIER=1.5`, all the polygon/probe params from my iterations).
- `src/workers/cv/sparkle-detect.ts` — back to the simple-circle mask at `bestR × MASK_RADIUS_MULTIPLIER`.
- `tests/cv/sparkle-detect.test.ts` — restored assertions matching the simple-circle mask.
- `src/components/ar-progress.ts` — filter `pending` rows out of the render; drop `.progress-bar` / `.progress-fill` / `@keyframes pulse` / `isParsing` branch.
- `tests/components/ar-progress.test.ts` — updated the regression that asserted the bug behaviour ("empty icon slots after reset") to assert the fix ("no rows rendered after reset").

## Test plan

- [x] `npx vitest run` — 937/937 green
- [x] `npx tsc --noEmit` — clean
- [x] CI green
- [ ] Preview deploy: user confirms selfie removal still matches `984b578b`
- [ ] Preview deploy: user confirms motostest no longer flags a watermark
- [ ] Preview deploy: user confirms `Eliminando fondo [ML]` only appears when RMBG actually starts, no progress bar visible