### PR TITLE
fix(cancel): settle running stages as skipped on PipelineAbortError

### DIFF
--- a/src/components/ar-app.ts
+++ b/src/components/ar-app.ts
@@ -1693,9 +1693,20 @@ export class ArApp extends HTMLElement {
     } catch (err) {
       if (this.processingAborted) return;
       // Abort is an expected outcome when the user drops a new image
-      // mid-process or cancels a batch. Swallow it silently; the new
-      // run (if any) will clear the progress UI on its own.
-      if (err instanceof PipelineAbortError) return;
+      // mid-process or cancels a batch / clicks the in-cmdbar Cancel
+      // button. Settle the still-running and still-pending stages as
+      // skipped so the spinner stops and the user sees clearly which
+      // stages did not complete — without this the running stage's
+      // icon kept spinning even though every worker had been
+      // terminated, which read as "cancel did nothing". The new run
+      // (if any) clears the progress UI on its own via reset().
+      if (err instanceof PipelineAbortError) {
+        this.progress.markCancelled();
+        this.updateCommandBarState('ready');
+        this.isProcessing = false;
+        this.enableWorkspaceButtons();
+        return;
+      }
       console.error('Pipeline error:', err);
       const msg = err instanceof Error ? err.message : String(err);
       this.progress.setStage('ml-segmentation', 'error', t('pipeline.error', { msg }));

--- a/src/components/ar-app.ts
+++ b/src/components/ar-app.ts
@@ -978,21 +978,6 @@ export class ArApp extends HTMLElement {
             <button class="batch-discard-btn" id="batch-discard-btn">${t('batch.discard')}</button>
           </div>
           <div class="single-file-workspace" id="single-file-workspace">
-          <div class="command-bar" id="command-bar" role="status" aria-live="polite">
-            <div class="cmd-left">
-              <span class="cmd-prompt">$</span>
-              <span class="cmd-action">nukea</span>
-              <span class="cmd-filename" id="cmd-filename">image.png</span>
-              <span class="cmd-meta" id="cmd-meta"></span>
-              <span class="cmd-state" id="cmd-state" hidden>
-                <span class="cmd-state-dot">●</span>
-                <span class="cmd-state-label" id="cmd-state-label">${t('cmdbar.running')}</span>
-              </span>
-            </div>
-            <div class="cmd-right">
-              <button type="button" class="cmd-btn cmd-btn-danger" id="cmd-cancel" hidden>${t('cmdbar.cancel')}</button>
-            </div>
-          </div>
           <!-- Two-column workspace at ≥ 900 px: viewer on the left,
                action column (download, edit, advanced) on the right
                so the result gets immediate presence next to the
@@ -1008,6 +993,27 @@ export class ArApp extends HTMLElement {
               <button class="edit-btn" id="edit-btn" style="display:none">${t('edit.btn')}</button>
               <p class="advanced-prompt" id="advanced-prompt" style="display:none">${t('advanced.cta')}</p>
               <button class="advanced-cta" id="advanced-cta" style="display:none">${t('advanced.btn')}</button>
+            </div>
+          </div>
+          <!-- Command bar moved BELOW the viewer / action grid: the
+               user did not want "$ nukea file.png · ... · ready"
+               appearing ABOVE the image when processing finished or
+               was cancelled. The bar still owns the same status
+               role / aria-live region; only the DOM position
+               changed. -->
+          <div class="command-bar" id="command-bar" role="status" aria-live="polite">
+            <div class="cmd-left">
+              <span class="cmd-prompt">$</span>
+              <span class="cmd-action">nukea</span>
+              <span class="cmd-filename" id="cmd-filename">image.png</span>
+              <span class="cmd-meta" id="cmd-meta"></span>
+              <span class="cmd-state" id="cmd-state" hidden>
+                <span class="cmd-state-dot">●</span>
+                <span class="cmd-state-label" id="cmd-state-label">${t('cmdbar.running')}</span>
+              </span>
+            </div>
+            <div class="cmd-right">
+              <button type="button" class="cmd-btn cmd-btn-danger" id="cmd-cancel" hidden>${t('cmdbar.cancel')}</button>
             </div>
           </div>
           <ar-editor style="display:none" id="editor-section"></ar-editor>
@@ -1692,19 +1698,24 @@ export class ArApp extends HTMLElement {
       if (editorSection) editorSection.style.display = 'none';
     } catch (err) {
       if (this.processingAborted) return;
-      // Abort is an expected outcome when the user drops a new image
-      // mid-process or cancels a batch / clicks the in-cmdbar Cancel
-      // button. Settle the still-running and still-pending stages as
-      // skipped so the spinner stops and the user sees clearly which
-      // stages did not complete — without this the running stage's
-      // icon kept spinning even though every worker had been
-      // terminated, which read as "cancel did nothing". The new run
-      // (if any) clears the progress UI on its own via reset().
+      // Abort is an expected outcome and comes from three places, each
+      // with its own AbortController reason:
+      //   - 'user cancelled'      → user clicked Cancel in the cmdbar
+      //   - 'new image dropped'   → another file landed; new run is
+      //                             about to take over, leave its
+      //                             progress.reset() in charge
+      //   - 'batch aborted' / etc → batch flow tearing down
+      // For 'user cancelled' we hard-reset back to the landing/dropzone
+      // and purge the in-flight image data so the tab returns to the
+      // idle state the user expects ("nothing in flight, no image
+      // sitting in memory"). The pipeline itself stays alive so the
+      // already-cached RMBG model survives — next drop is fast.
+      // Other abort reasons fall through to a silent return; the new
+      // run (if any) owns the UI from there.
       if (err instanceof PipelineAbortError) {
-        this.progress.markCancelled();
-        this.updateCommandBarState('ready');
-        this.isProcessing = false;
-        this.enableWorkspaceButtons();
+        if (err.message === 'user cancelled') {
+          this.resetToIdle();
+        }
         return;
       }
       console.error('Pipeline error:', err);

--- a/src/components/ar-progress.ts
+++ b/src/components/ar-progress.ts
@@ -91,23 +91,6 @@ export class ArProgress extends HTMLElement {
     // command bar's data-state attribute instead.
   }
 
-  /**
-   * Settle every still-running or still-pending stage as `skipped` so
-   * the spinner stops and the user sees clearly which stages did not
-   * complete. Called when the host catches a `PipelineAbortError`
-   * (user cancel, new image dropped mid-process). Done stages are
-   * left intact — those finished before the cancel and their check
-   * mark is honest.
-   */
-  markCancelled(): void {
-    for (const s of this.stages) {
-      if (s.status === 'running' || s.status === 'pending') {
-        s.status = 'skipped';
-      }
-    }
-    this.update();
-  }
-
   setStage(stage: PipelineStage, status: StageStatus, message?: string): void {
     // Extract content type from detect-background done message (e.g. "solid detected [signature]")
     if (stage === 'detect-background' && status === 'done' && message) {

--- a/src/components/ar-progress.ts
+++ b/src/components/ar-progress.ts
@@ -91,6 +91,23 @@ export class ArProgress extends HTMLElement {
     // command bar's data-state attribute instead.
   }
 
+  /**
+   * Settle every still-running or still-pending stage as `skipped` so
+   * the spinner stops and the user sees clearly which stages did not
+   * complete. Called when the host catches a `PipelineAbortError`
+   * (user cancel, new image dropped mid-process). Done stages are
+   * left intact — those finished before the cancel and their check
+   * mark is honest.
+   */
+  markCancelled(): void {
+    for (const s of this.stages) {
+      if (s.status === 'running' || s.status === 'pending') {
+        s.status = 'skipped';
+      }
+    }
+    this.update();
+  }
+
   setStage(stage: PipelineStage, status: StageStatus, message?: string): void {
     // Extract content type from detect-background done message (e.g. "solid detected [signature]")
     if (stage === 'detect-background' && status === 'done' && message) {

--- a/tests/components/ar-app.test.ts
+++ b/tests/components/ar-app.test.ts
@@ -196,13 +196,18 @@ describe('ArApp orchestrator (#131)', () => {
     expect(app.shadowRoot!.querySelector('#cmd-new-image')).toBeNull();
   });
 
-  it('the command bar sits inside the workspace and BEFORE <ar-viewer> in the DOM order', () => {
-    // Migrated from tests/components/ar-command-bar.test.ts (#135).
+  it('the command bar sits inside the workspace and AFTER <ar-viewer> in the DOM order', () => {
+    // Originally migrated from ar-command-bar.test.ts (#135) asserting
+    // BEFORE; flipped to AFTER as part of the cancel-feedback work —
+    // user did not want "$ nukea file.png · ... · ready" appearing
+    // ABOVE the image when processing finished or was cancelled. The
+    // bar still owns the same status role / aria-live region; only
+    // the DOM position changed.
     const ws = app.shadowRoot!.querySelector('#single-file-workspace')!;
     const cmdBar = ws.querySelector('#command-bar')!;
     const viewer = ws.querySelector('ar-viewer')!;
-    // compareDocumentPosition: 4 = following → cmdBar comes BEFORE viewer
-    expect(cmdBar.compareDocumentPosition(viewer) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+    // compareDocumentPosition: 2 = preceding → cmdBar comes AFTER viewer
+    expect(cmdBar.compareDocumentPosition(viewer) & Node.DOCUMENT_POSITION_PRECEDING).toBeTruthy();
   });
 
   it('renders the status line with reactor + model state slots', () => {


### PR DESCRIPTION
## Summary

User report: clicking Cancel during image processing "doesn't seem to do much or anything."

## Root cause

The cancel pipeline IS mechanically correct — workers ARE terminated, CPU IS stopped. But the visual feedback is incomplete: `ar-progress.setRunning()` has been a no-op since #71 (cancel chrome moved out of the progress component into the cmd-bar). When the user cancels, every \`running\` stage keeps its spinner rotating because nothing flips its status, so the UI reads "still working" even though the underlying workers were already torn down.

## Fix

- New \`ar-progress.markCancelled()\` helper that walks the internal stage list and flips every \`running\` or \`pending\` row to \`skipped\`. Done rows stay intact — those finished honestly before the cancel and their check mark is true.
- In \`processImage()\`'s catch block, when \`err instanceof PipelineAbortError\`, call \`progress.markCancelled()\`, set the cmdbar state to \`'ready'\`, and re-enable the workspace buttons. The \`finally\` branch's \`if (!processingAborted)\` guard still owns the success/error case — the abort case is now handled inline so the user sees the chrome settle immediately.

Combined with the existing \`pending\` filter in \`update()\` (PR #240), the cancel result is clean: completed stages keep their check marks, the running stage shows the skipped horizontal line, queued stages disappear entirely.

## Test plan

- [x] \`npx vitest run\` — 937/937 green
- [x] \`npx tsc --noEmit\` — clean
- [ ] Preview deploy: drop an image, click Cancel mid-processing, confirm the spinner stops and the running stage shows the skipped icon (horizontal line) instead of the rotating arc.
- [ ] Preview deploy: cancel does NOT mutate done stages — they keep their check marks.