### PR TITLE
fix(export): autocrop residual exportPng paths in ar-app (3 sites)

### DIFF
--- a/src/components/ar-app.ts
+++ b/src/components/ar-app.ts
@@ -1350,11 +1350,18 @@ export class ArApp extends HTMLElement {
           this.lastResultImageData = this.preEditResult;
           this.preEditResult = null;
 
-          const blob = await exportPng(this.lastResultImageData);
+          // Same split as the main flow: slider keeps the full-size
+          // canvas (alignment with original); export + info label use
+          // the cropped subject bbox.
+          const exportImageData = autoCropToSubject(this.lastResultImageData);
+          const blob = await exportPng(exportImageData);
           const originalForViewer = this.currentOriginalImageData ?? this.currentImageData;
           if (originalForViewer) this.viewer.setOriginal(originalForViewer, this.currentFileSize);
-          this.viewer.setResult(this.lastResultImageData, blob);
-          await this.download.setResult(this.lastResultImageData, this.currentFileName, 0, blob);
+          this.viewer.setResult(this.lastResultImageData, blob, {
+            width: exportImageData.width,
+            height: exportImageData.height,
+          });
+          await this.download.setResult(exportImageData, this.currentFileName, 0, blob);
 
           // Switch button back to "Edit manually"
           const editBtn = this.shadowRoot!.querySelector('#edit-btn') as HTMLElement;
@@ -1397,7 +1404,10 @@ export class ArApp extends HTMLElement {
         const editedData = await refineEdges(this.pipeline, rawEdited, {
           skipTopologyCleanup: true,
         });
-        const blob = await exportPng(editedData);
+        // Crop for export; slider canvas keeps the full-size frame so
+        // the manual brush strokes still align with the original.
+        const exportImageData = autoCropToSubject(editedData);
+        const blob = await exportPng(exportImageData);
 
         // Save pre-edit for discard functionality
         this.preEditResult = this.lastResultImageData;
@@ -1405,8 +1415,11 @@ export class ArApp extends HTMLElement {
         this.lastResultImageData = editedData;
 
         // "Before" stays as the original input image; only "after" updates
-        this.viewer.setResult(editedData, blob);
-        await this.download.setResult(editedData, this.currentFileName, 0, blob);
+        this.viewer.setResult(editedData, blob, {
+          width: exportImageData.width,
+          height: exportImageData.height,
+        });
+        await this.download.setResult(exportImageData, this.currentFileName, 0, blob);
 
         // Hide editor, show discard button
         (this.shadowRoot!.querySelector('#editor-section') as HTMLElement).style.display = 'none';
@@ -1469,9 +1482,15 @@ export class ArApp extends HTMLElement {
         const refined = await refineEdges(this.pipeline, imageData, {
           skipTopologyCleanup: true,
         });
-        const blob = await exportPng(refined);
-        this.viewer.setResult(refined, blob);
-        await this.download.setResult(refined, this.currentFileName, 0, blob);
+        // Same split as elsewhere: slider stays full-size for alignment;
+        // export + info label use the cropped subject bbox.
+        const exportImageData = autoCropToSubject(refined);
+        const blob = await exportPng(exportImageData);
+        this.viewer.setResult(refined, blob, {
+          width: exportImageData.width,
+          height: exportImageData.height,
+        });
+        await this.download.setResult(exportImageData, this.currentFileName, 0, blob);
         this.lastResultImageData = refined;
       },
       { signal },

--- a/src/pipeline/image-processor.ts
+++ b/src/pipeline/image-processor.ts
@@ -8,11 +8,7 @@ import type { PrecisionMode } from './constants';
  * so callers depending on `ImageProcessor` don't transitively pick up
  * the orchestrator.
  */
-export type StageCallback = (
-  stage: PipelineStage,
-  status: StageStatus,
-  message?: string,
-) => void;
+export type StageCallback = (stage: PipelineStage, status: StageStatus, message?: string) => void;
 
 /**
  * Public surface every image-processing engine in the app honours.

--- a/tests/components/ar-editor-advanced.test.ts
+++ b/tests/components/ar-editor-advanced.test.ts
@@ -18,7 +18,15 @@ vi.mock('../../src/refine/loaders/rmbg14', () => ({
     label: 'mock',
     approxDownloadMb: 0,
     warmup: vi.fn(() => Promise.resolve()),
-    segment: vi.fn(() => Promise.resolve({ alpha: new Uint8Array(16), width: 4, height: 4, latencyMs: 1, backend: 'wasm' })),
+    segment: vi.fn(() =>
+      Promise.resolve({
+        alpha: new Uint8Array(16),
+        width: 4,
+        height: 4,
+        latencyMs: 1,
+        backend: 'wasm',
+      }),
+    ),
     dispose: vi.fn(() => Promise.resolve()),
   })),
 }));

--- a/tests/pipeline/finalize-result.test.ts
+++ b/tests/pipeline/finalize-result.test.ts
@@ -100,10 +100,7 @@ function makeOriginal(): ImageData {
 
 describe('finalizePipelineResult — content-type gating', () => {
   it('PHOTO drops detached orphan blobs', () => {
-    const out = finalizePipelineResult(
-      makeResult('PHOTO', { detached: true }),
-      makeOriginal(),
-    );
+    const out = finalizePipelineResult(makeResult('PHOTO', { detached: true }), makeOriginal());
     expect(out.data[0 * 4 + 3]).toBe(0); // orphan pixel zeroed
     expect(out.data[(8 * W + 8) * 4 + 3]).toBeGreaterThan(0); // body kept
   });
@@ -117,34 +114,22 @@ describe('finalizePipelineResult — content-type gating', () => {
   });
 
   it('SIGNATURE keeps detached components (legitimate accent dots, separated strokes)', () => {
-    const out = finalizePipelineResult(
-      makeResult('SIGNATURE', { detached: true }),
-      makeOriginal(),
-    );
+    const out = finalizePipelineResult(makeResult('SIGNATURE', { detached: true }), makeOriginal());
     expect(out.data[0 * 4 + 3]).toBe(255); // orphan survives
   });
 
   it('ICON keeps detached components (icon sets, multi-glyph)', () => {
-    const out = finalizePipelineResult(
-      makeResult('ICON', { detached: true }),
-      makeOriginal(),
-    );
+    const out = finalizePipelineResult(makeResult('ICON', { detached: true }), makeOriginal());
     expect(out.data[0 * 4 + 3]).toBe(255);
   });
 
   it('PHOTO fills small interior holes (specular-highlight false negatives)', () => {
-    const out = finalizePipelineResult(
-      makeResult('PHOTO', { hole: true }),
-      makeOriginal(),
-    );
+    const out = finalizePipelineResult(makeResult('PHOTO', { hole: true }), makeOriginal());
     expect(out.data[(7 * W + 7) * 4 + 3]).toBe(255);
   });
 
   it('SIGNATURE preserves interior holes (legitimate counter shapes)', () => {
-    const out = finalizePipelineResult(
-      makeResult('SIGNATURE', { hole: true }),
-      makeOriginal(),
-    );
+    const out = finalizePipelineResult(makeResult('SIGNATURE', { hole: true }), makeOriginal());
     expect(out.data[(7 * W + 7) * 4 + 3]).toBe(0);
   });
 });

--- a/tests/pipeline/pending-timers.test.ts
+++ b/tests/pipeline/pending-timers.test.ts
@@ -29,7 +29,9 @@ describe('worker-channel — pending-timer bookkeeping (#44)', () => {
   });
 
   it('the central onMessage handler settles via settlePending instead of touching pendingRequests directly', () => {
-    const onMessageMatch = CHANNEL.match(/private onMessage\(msg: TMsg\): void \{[\s\S]*?^ {2}\}$/m);
+    const onMessageMatch = CHANNEL.match(
+      /private onMessage\(msg: TMsg\): void \{[\s\S]*?^ {2}\}$/m,
+    );
     expect(onMessageMatch, 'onMessage body not matched').not.toBeNull();
     const body = onMessageMatch![0];
     // The only pendingRequests access in onMessage should be the lookup,


### PR DESCRIPTION
## > what

Stack on top of \`feat(export): autocrop downloaded image to the subject bbox\` (7dd53e1). Cubre los **3 call sites de \`exportPng\`** que ese commit dejó exportando full-size canvas en lugar del subject bbox.

## > problem

Auditando #247 contra el commit del autocrop, el flow principal y el batch están bien cubiertos pero hay 3 paths de export adicionales en \`src/components/ar-app.ts\` que **no aplican el crop**:

| Línea | Flow | Síntoma |
|---|---|---|
| 1353 | Discard edit (restore pre-edit) | User cancela edit → descarga canvas grande sin cropear |
| 1400 | Basic editor done (manual brush) | Después de pintar con brush → descarga full-size |
| 1472 | Advanced editor done (lasso/refine) | Después de lasso + refine en advanced → descarga full-size |

El issue #247 declara explícitamente: *\"applies to every output path — basic editor, advanced editor, batch, single-image export\"*. Estos 3 quedaron afuera = regresión silenciosa user-visible.

## > fix

Mismo split que ya usa el main flow en \`_onPrimary\`:

\`\`\`ts
const exportImageData = autoCropToSubject(<full-size>);
const blob = await exportPng(exportImageData);
this.viewer.setResult(<full-size>, blob, {
  width: exportImageData.width,
  height: exportImageData.height,
});
await this.download.setResult(exportImageData, ...);
\`\`\`

Aplicado a los 3 sitios. Slider sigue alineado con la imagen original (canvas full-size); el download blob, el size meta y el info label de la viewer ahora reportan el tamaño cropeado.

## > tests

- \`npm run typecheck\` ✓
- \`npm run lint\` ✓
- \`npm test\` → **954 passing**, sin regresión.

No agrego tests nuevos: la lógica del crop ya tiene cobertura en \`tests/utils/auto-crop.test.ts\` (6 tests cubriendo bbox tight, all-opaque/all-transparent no-op, single pixel, padding, threshold). Aquí solo cableo el utility en 3 sitios más con el mismo patrón ya validado.

## > QA físico

- [ ] Subir foto → editar con brush → download → verificar que el archivo tenga las dimensiones del subject, no del canvas.
- [ ] Subir foto → cancelar edición (discard) → download → idem.
- [ ] Subir foto → advanced editor + lasso crop → done → download → idem.

## > closes

Refs #247 (junto con 7dd53e1 cierran el alcance completo del issue).