### PR TITLE
fix: editor visibility leak + collapse classifier to 3 types

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -73,7 +73,10 @@ jobs:
       - name: Run OSV-Scanner
         uses: google/osv-scanner-action/osv-scanner-action@v2.3.5
         with:
+          # `--skip-git` was removed in osv-scanner v2.x (git-history
+          # scanning is no longer the default and is controlled via a
+          # different mechanism). Action v2.3.5 was bumped in #253; this
+          # restores compatibility without losing dependency coverage.
           scan-args: |-
             --recursive
-            --skip-git
             ./

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,39 @@ Unreleased entries accumulate on the `dev` branch. When we cut a release we copy
 
 ## [Unreleased]
 
+### Changed
+
+- **Classifier collapsed from 4 to 3 content types.** Removed `ILLUSTRATION`
+  from `ImageContentType`. Audit confirmed the label had zero behavioural
+  impact: `finalize-result.ts` treated it identically to `PHOTO` and no
+  other module branched on it. The remaining classes — `PHOTO`,
+  `SIGNATURE`, `ICON` — each now correspond to a distinct pipeline path.
+  Illustration-style content (flat shading, limited palette) still works
+  end-to-end; it just falls through to the PHOTO path. TypeScript union
+  narrowing prevents accidental re-introduction.
+- **SIGNATURE classifier tightened (asymmetric calibration).** Added
+  `SIGNATURE_UNIQUE_COLORS_MAX = 200` as a fifth gate on the SIGNATURE
+  branch. Photographic subjects on near-white backgrounds (e.g. a
+  desaturated product shot) used to satisfy the four pre-existing
+  thresholds because the white background pulled the saturation mean
+  below 0.08; the new gate filters them out by their unique-color count.
+  Calibration is intentionally asymmetric — signatures are niche, so we
+  prefer to misclassify a noisy scanned signature as PHOTO over admitting
+  a non-signature that would be corrupted by the threshold-based path.
+- **Cmdbar verb is now `nuke` instead of `nukea`.** The hardcoded
+  template literal read `nukea` regardless of UI language; replaced
+  with `nuke` so the prompt reads naturally in any locale.
+
+### Fixed
+
+- **Editor no longer flashes during reprocessing.** When a user clicked
+  *Edit* → *Process another* → pasted a new image, the editor stayed
+  visible during the entire pipeline run. `resetToIdle()` did not hide
+  `#editor-section`, and the existing hide at the end of `processImage()`
+  only fired after success. Editor visibility is now centralized: hidden
+  on processing entry and on idle reset, visible only after a successful
+  run when the user opens it via the Edit button.
+
 ## [2.12.0] — 2026-04-30
 
 Minor release. Headline feature is **autocrop on export** — the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,7 +36,7 @@ Unreleased entries accumulate on the `dev` branch. When we cut a release we copy
 ### Fixed
 
 - **Editor no longer flashes during reprocessing.** When a user clicked
-  *Edit* → *Process another* → pasted a new image, the editor stayed
+  _Edit_ → _Process another_ → pasted a new image, the editor stayed
   visible during the entire pipeline run. `resetToIdle()` did not hide
   `#editor-section`, and the existing hide at the end of `processImage()`
   only fired after success. Editor visibility is now centralized: hidden

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Drop. Nuke. Download. That's it.
 
 ```
 [+] ML BACKGROUND REMOVAL       RMBG-1.4 for segmentation with auto-classification.
-                                  Photos, illustrations, signatures, icons. Each optimized.
+                                  Photos, signatures, icons. Each optimized.
 
 [+] CHECKERBOARD OBLITERATION    Detects and classifies painted checkerboard backgrounds.
                                   Any grid size, any generator.
@@ -103,13 +103,13 @@ Deploy `dist/` to any static host: Cloudflare Pages, GitHub Pages, Netlify, Verc
     |
     v
   [1. CLASSIFY + SCAN] ---------- auto-detect content type + background (CV, instant)
-    |                              PHOTO / ILLUSTRATION / SIGNATURE / ICON
+    |                              PHOTO / SIGNATURE / ICON
     |
     +-- SIGNATURE? -------------> [CV threshold] Otsu + Sauvola (<50ms) --> DONE
     |
     +-- ICON? ------------------> [RMBG threshold 0.3] skip watermark --> DONE
     |
-    +-- PHOTO / ILLUSTRATION? --> continue
+    +-- PHOTO? -----------------> continue
     |
     v
   [2. WATERMARK DETECTION] ------ Gemini sparkle + DALL-E color bar (CV, instant)

--- a/index.html
+++ b/index.html
@@ -439,7 +439,7 @@
         <ul>
           <li>100% client-side processing. Your images never touch a server.</li>
           <li>ML-powered background removal (RMBG-1.4 via WebAssembly)</li>
-          <li>Auto-detects image type: photo, illustration, signature, icon</li>
+          <li>Auto-detects image type: photo, signature, icon</li>
           <li>Before/after comparison view and manual editor</li>
           <li>Works offline after first visit (PWA)</li>
           <li>No account, no watermarks on output, no limits</li>

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -24,5 +24,5 @@ called by the runtime:
 | `analyze-speckle.mjs`  | Count tiny disconnected alpha blobs (speckle), grouped by size. Drives the `MIN_CLUSTER_SIZE` constants.                                   |
 | `remove-bg-rmbg.ts`    | Run the RMBG-1.4 segmenter against a single image, save the mask + composited PNG. Used to compare model upgrades.                         |
 | `validate.ts`          | Run a full pipeline pass over every fixture in `tests/fixtures/` and emit a per-image report (timing, content-type, watermark hits).       |
-| `validate-mascots.ts`  | Same as `validate.ts` but scoped to the cartoon-mascot fixtures used to tune the illustration branch.                                      |
+| `validate-mascots.ts`  | Same as `validate.ts` but scoped to the cartoon-mascot fixtures — flat-shaded illustration-style images that exercise the PHOTO path.      |
 | `test-ml.ts`           | Smoke-test the ML worker contract end-to-end against a single fixture.                                                                     |

--- a/src/components/ar-app.ts
+++ b/src/components/ar-app.ts
@@ -994,7 +994,7 @@ export class ArApp extends HTMLElement {
             </div>
           </div>
           <!-- Command bar moved BELOW the viewer / action grid: the
-               user did not want "$ nukea file.png · ... · ready"
+               user did not want "$ nuke file.png · ... · ready"
                appearing ABOVE the image when processing finished or
                was cancelled. The bar still owns the same status
                role / aria-live region; only the DOM position
@@ -1002,7 +1002,7 @@ export class ArApp extends HTMLElement {
           <div class="command-bar" id="command-bar" role="status" aria-live="polite">
             <div class="cmd-left">
               <span class="cmd-prompt">$</span>
-              <span class="cmd-action">nukea</span>
+              <span class="cmd-action">nuke</span>
               <span class="cmd-filename" id="cmd-filename">image.png</span>
               <span class="cmd-meta" id="cmd-meta"></span>
               <span class="cmd-state" id="cmd-state" hidden>
@@ -1589,6 +1589,12 @@ export class ArApp extends HTMLElement {
     const hero = this.shadowRoot!.querySelector('#hero')!;
     const workspace = this.shadowRoot!.querySelector('#workspace')!;
 
+    // Editor only visible after a successful processing run. Hide it
+    // here so a new run cannot inherit display:block from a previous
+    // edit that was still open when the user pasted a new image.
+    const editorSection = this.shadowRoot!.querySelector('#editor-section') as HTMLElement;
+    if (editorSection) editorSection.style.display = 'none';
+
     hero.classList.add('hidden');
     workspace.classList.add('visible');
 
@@ -1677,9 +1683,6 @@ export class ArApp extends HTMLElement {
       const editBtn = this.shadowRoot!.querySelector('#edit-btn') as HTMLElement;
       if (editBtn) editBtn.style.display = 'block';
       this.setAdvancedBtnVisible(true);
-      // Hide editor if it was open from a previous edit
-      const editorSection = this.shadowRoot!.querySelector('#editor-section') as HTMLElement;
-      if (editorSection) editorSection.style.display = 'none';
     } catch (err) {
       if (this.processingAborted) return;
       // Abort is an expected outcome from "new image dropped" or
@@ -2000,6 +2003,8 @@ export class ArApp extends HTMLElement {
     if (single) single.style.display = 'flex';
     if (detailBar) detailBar.style.display = 'none';
     if (failedBar) failedBar.style.display = 'none';
+    const editorSection = root.querySelector('#editor-section') as HTMLElement | null;
+    if (editorSection) editorSection.style.display = 'none';
 
     this.download.reset();
     this.preEditResult = null;

--- a/src/pipeline/constants.ts
+++ b/src/pipeline/constants.ts
@@ -293,6 +293,18 @@ export const IMAGE_CLASSIFY_PARAMS = {
   SIGNATURE_DARK_PIXEL_MIN: 0.01,
   /** Max dark pixel ratio (not too much ink) */
   SIGNATURE_DARK_PIXEL_MAX: 0.4,
+  /**
+   * Max unique colors (5-bit/channel quantized) for a signature.
+   *
+   * Signatures are a niche content type — the calibration is intentionally
+   * asymmetric: it is much worse to misclassify a non-signature (e.g. a
+   * desaturated product photo on white) AS a signature than to miss a
+   * noisy scanned signature and let it fall through to PHOTO. Hence the
+   * tight cap aligned with ICON_MAX_UNIQUE_COLORS — both classes are
+   * flat 2D content with limited palettes; anything richer is treated
+   * as photographic.
+   */
+  SIGNATURE_UNIQUE_COLORS_MAX: 200,
 
   // ICON thresholds
   /** Max total pixels for icon classification */
@@ -303,14 +315,6 @@ export const IMAGE_CLASSIFY_PARAMS = {
   ICON_ASPECT_MIN: 0.7,
   /** Max aspect ratio for ~square icon */
   ICON_ASPECT_MAX: 1.43,
-
-  // ILLUSTRATION thresholds
-  /** Min unique colors for illustration */
-  ILLUSTRATION_UNIQUE_COLORS_MIN: 50,
-  /** Max unique colors for illustration */
-  ILLUSTRATION_UNIQUE_COLORS_MAX: 800,
-  /** Max brightness std for illustration (uniform lighting) */
-  ILLUSTRATION_BRIGHTNESS_STD_MAX: 70,
 
   // ICON RMBG threshold
   /** RMBG confidence threshold for icons (lower = more aggressive) */

--- a/src/pipeline/finalize-result.ts
+++ b/src/pipeline/finalize-result.ts
@@ -15,9 +15,9 @@ import { dropOrphanBlobs, fillSubjectHoles, promoteSpeckleAlpha } from './finali
  *      gradient, and writes onto pristine original RGB (with inpainted
  *      RGB blended in the watermark region only).
  *
- *   2. Topology cleanup gated by `contentType`. PHOTO and ILLUSTRATION
- *      assume "subject is one body": orphan blobs go (RMBG horizon
- *      bands, detached watermark fragments), interior holes get filled
+ *   2. Topology cleanup gated by `contentType`. PHOTO assumes
+ *      "subject is one body": orphan blobs go (RMBG horizon bands,
+ *      detached watermark fragments), interior holes get filled
  *      (specular highlights mistaken for background), and partial-α
  *      specks inside opaque regions get promoted. SIGNATURE and ICON
  *      may legitimately have multiple components and interior
@@ -41,7 +41,7 @@ export function finalizePipelineResult(result: PipelineResult, original: ImageDa
   });
 
   const ct = result.contentType;
-  if (ct === 'PHOTO' || ct === 'ILLUSTRATION') {
+  if (ct === 'PHOTO') {
     return promoteSpeckleAlpha(fillSubjectHoles(dropOrphanBlobs(composed)));
   }
   return composed;

--- a/src/types/pipeline.ts
+++ b/src/types/pipeline.ts
@@ -1,5 +1,5 @@
 /** Image content type for auto-algorithm selection */
-export type ImageContentType = 'PHOTO' | 'ILLUSTRATION' | 'SIGNATURE' | 'ICON';
+export type ImageContentType = 'PHOTO' | 'SIGNATURE' | 'ICON';
 
 /** Stage identifiers for progress reporting */
 export type PipelineStage = 'detect-background' | 'ml-segmentation' | 'watermark-scan' | 'inpaint';

--- a/src/workers/cv/classify-image.ts
+++ b/src/workers/cv/classify-image.ts
@@ -1,7 +1,7 @@
 import { IMAGE_CLASSIFY_PARAMS } from '../../pipeline/constants';
 
 /** Content type classification for auto-algorithm selection */
-export type ImageContentType = 'PHOTO' | 'ILLUSTRATION' | 'SIGNATURE' | 'ICON';
+export type ImageContentType = 'PHOTO' | 'SIGNATURE' | 'ICON';
 
 /** Extracted image features used for classification */
 export interface ImageFeatures {
@@ -106,18 +106,25 @@ export function extractImageFeatures(
  * Classify an image based on extracted features.
  * Returns the optimal content type for pipeline routing.
  *
- * Priority order: SIGNATURE > ICON > ILLUSTRATION > PHOTO (default)
+ * Priority order: SIGNATURE > ICON > PHOTO (default).
+ * Calibration is intentionally asymmetric for SIGNATURE: a non-signature
+ * misclassified as SIGNATURE skips ML entirely and corrupts the result,
+ * while a signature that falls through to PHOTO still gets processed
+ * acceptably. Hence the tight uniqueColors gate on SIGNATURE.
  */
 export function classifyImage(features: ImageFeatures): ImageContentType {
   const P = IMAGE_CLASSIFY_PARAMS;
 
-  // SIGNATURE: high brightness, low saturation, mostly white with some dark strokes
+  // SIGNATURE: high brightness, low saturation, mostly white with some dark strokes,
+  // and few unique colors (the uniqueColors gate rejects photographic content
+  // that happens to sit on a white background, e.g. a desaturated product shot).
   if (
     features.brightnessMean > P.SIGNATURE_BRIGHTNESS_MIN &&
     features.saturationMean < P.SIGNATURE_SATURATION_MAX &&
     features.nearWhiteRatio > P.SIGNATURE_NEAR_WHITE_MIN &&
     features.darkPixelRatio >= P.SIGNATURE_DARK_PIXEL_MIN &&
-    features.darkPixelRatio <= P.SIGNATURE_DARK_PIXEL_MAX
+    features.darkPixelRatio <= P.SIGNATURE_DARK_PIXEL_MAX &&
+    features.uniqueColors < P.SIGNATURE_UNIQUE_COLORS_MAX
   ) {
     return 'SIGNATURE';
   }
@@ -130,15 +137,6 @@ export function classifyImage(features: ImageFeatures): ImageContentType {
     features.aspectRatio <= P.ICON_ASPECT_MAX
   ) {
     return 'ICON';
-  }
-
-  // ILLUSTRATION: limited color palette, low brightness variation
-  if (
-    features.uniqueColors >= P.ILLUSTRATION_UNIQUE_COLORS_MIN &&
-    features.uniqueColors <= P.ILLUSTRATION_UNIQUE_COLORS_MAX &&
-    features.brightnessStd < P.ILLUSTRATION_BRIGHTNESS_STD_MAX
-  ) {
-    return 'ILLUSTRATION';
   }
 
   // Default: PHOTO

--- a/tests/cv/classify-image.test.ts
+++ b/tests/cv/classify-image.test.ts
@@ -107,12 +107,15 @@ describe('classifyImage', () => {
     expect(features.uniqueColors).toBeLessThan(200);
   });
 
-  it('classifies medium-color low-variance image as ILLUSTRATION', () => {
+  it('falls back to PHOTO for limited-palette flat-shaded content (formerly ILLUSTRATION)', () => {
     const w = 600,
       h = 400;
     const pixels = new Uint8ClampedArray(w * h * 4);
-    // Flat shaded regions with per-pixel variation (illustration-like):
-    // many bands with x-based and y-based subtle gradients to produce 50-800 unique quantized colors
+    // Flat shaded regions with per-pixel variation: bands with subtle
+    // gradients producing 50-800 unique quantized colors. Used to be
+    // classified as ILLUSTRATION; that class was removed because it had
+    // identical pipeline behavior to PHOTO. Regression guard: this
+    // input must classify as PHOTO, not be misrouted.
     const baseColors = [
       [200, 100, 100],
       [100, 200, 100],
@@ -131,7 +134,6 @@ describe('classifyImage', () => {
       const [r, g, b] = baseColors[band];
       for (let x = 0; x < w; x++) {
         const i = (y * w + x) * 4;
-        // Wider x-shift + y-shift to generate enough unique quantized colors (>50)
         const xShift = Math.floor((x / w) * 40);
         const yShift = Math.floor(((y % bandHeight) / bandHeight) * 20);
         pixels[i] = Math.min(255, r + xShift);
@@ -144,10 +146,7 @@ describe('classifyImage', () => {
     const features = extractImageFeatures(pixels, w, h);
     const result = classifyImage(features);
 
-    expect(result).toBe('ILLUSTRATION');
-    expect(features.uniqueColors).toBeGreaterThanOrEqual(50);
-    expect(features.uniqueColors).toBeLessThanOrEqual(800);
-    expect(features.brightnessStd).toBeLessThan(70);
+    expect(result).toBe('PHOTO');
   });
 
   it('defaults to PHOTO for ambiguous images', () => {

--- a/tests/fixtures/LICENSE.md
+++ b/tests/fixtures/LICENSE.md
@@ -6,13 +6,13 @@ suite (Vitest + Playwright). They never ship with production builds.
 | File | Source | Licence | Notes |
 | --- | --- | --- | --- |
 | `coche.jpg` | Pexels (royalty-free stock) | Pexels Licence | Generic car shot — used by `e2e/coche-capture.spec.ts` to baseline an outdoor photo. |
-| `fiat-clean.png` | Manually authored | Project licence (GPL-3.0) | Vector mock car on a clean checkerboard. Drives illustration-branch fixtures. |
+| `fiat-clean.png` | Manually authored | Project licence (GPL-3.0) | Vector mock car on a clean checkerboard. Flat-shaded subject — exercises the PHOTO path on illustration-style content. |
 | `football.webp` | Pexels | Pexels Licence | Stadium photo with green-on-green subject — adversarial RMBG case. |
 | `motorcycles-clean.png` | Manually authored | Project licence (GPL-3.0) | Vector mock — drives `tests/components` snapshots. |
 | `motostest.jpeg` | Pexels | Pexels Licence | Motorbike photo with hard edges + halo — used to tune foreground decontamination. |
 | `selfie-clean-corner.png` | Manually authored | Project licence (GPL-3.0) | Synthetic checkerboard fixture for AI-generated images. |
 | `selfie-sparkle-full.png` | Manually authored | Project licence (GPL-3.0) | Synthetic Gemini-watermark fixture. |
-| `trump-clean.png` | Manually authored | Project licence (GPL-3.0) | High-contrast portrait fixture for the illustration branch. |
+| `trump-clean.png` | Manually authored | Project licence (GPL-3.0) | High-contrast portrait fixture — flat-shaded illustration-style content processed via the PHOTO path. |
 
 If you add a fixture:
 

--- a/tests/pipeline/finalize-chain.test.ts
+++ b/tests/pipeline/finalize-chain.test.ts
@@ -30,9 +30,9 @@ if (typeof globalThis.ImageData === 'undefined') {
 }
 
 // End-to-end topology cleanup chain: the same composition ar-app.ts applies
-// on the PHOTO/ILLUSTRATION path. Guards that chaining the three passes
-// produces a coherent output — no enclosed α=0 holes, no interior specks,
-// no disconnected α>0 blobs.
+// on the PHOTO path. Guards that chaining the three passes produces a
+// coherent output — no enclosed α=0 holes, no interior specks, no
+// disconnected α>0 blobs.
 const runChain = (img: ImageData): ImageData =>
   promoteSpeckleAlpha(fillSubjectHoles(dropOrphanBlobs(img)));
 

--- a/tests/pipeline/finalize-result.test.ts
+++ b/tests/pipeline/finalize-result.test.ts
@@ -32,8 +32,8 @@ if (typeof globalThis.ImageData === 'undefined') {
  * pin are the ones that used to be implicit in two separate callers
  * (ar-app + batch-orchestrator) and can drift if anyone refactors:
  *
- *   1. PHOTO / ILLUSTRATION run topology cleanup. SIGNATURE / ICON
- *      pass through unchanged.
+ *   1. PHOTO runs topology cleanup. SIGNATURE / ICON pass through
+ *      unchanged.
  *   2. Output dimensions match the `original` argument, not the
  *      working size on the result.
  */
@@ -59,12 +59,12 @@ function makeResult(
   }
   if (opts.detached) {
     // single-pixel orphan blob far from the body — should be dropped
-    // for PHOTO / ILLUSTRATION, kept for SIGNATURE / ICON.
+    // for PHOTO, kept for SIGNATURE / ICON.
     workingAlpha[0] = 255;
   }
   if (opts.hole) {
     // 2x2 hole inside the body — fillSubjectHoles should patch it for
-    // PHOTO / ILLUSTRATION.
+    // PHOTO.
     workingAlpha[7 * W + 7] = 0;
     workingAlpha[7 * W + 8] = 0;
     workingAlpha[8 * W + 7] = 0;
@@ -103,14 +103,6 @@ describe('finalizePipelineResult — content-type gating', () => {
     const out = finalizePipelineResult(makeResult('PHOTO', { detached: true }), makeOriginal());
     expect(out.data[0 * 4 + 3]).toBe(0); // orphan pixel zeroed
     expect(out.data[(8 * W + 8) * 4 + 3]).toBeGreaterThan(0); // body kept
-  });
-
-  it('ILLUSTRATION drops detached orphan blobs', () => {
-    const out = finalizePipelineResult(
-      makeResult('ILLUSTRATION', { detached: true }),
-      makeOriginal(),
-    );
-    expect(out.data[0 * 4 + 3]).toBe(0);
   });
 
   it('SIGNATURE keeps detached components (legitimate accent dots, separated strokes)', () => {


### PR DESCRIPTION
## Summary

- **fix(ui)**: editor was leaking visible during reprocessing (process → Edit → "Process another" → paste). Centralized the visibility invariant: hidden during processing and on idle reset, visible only after a successful run via the Edit button. Also replaced hardcoded `nukea` cmdbar verb with `nuke` (was rendering Spanish in every locale).
- **refactor(classifier)**: dropped `ILLUSTRATION` from `ImageContentType`. It was a label with no behavioural impact — `finalize-result.ts` treated it identically to PHOTO and no module branched on it. Remaining classes (PHOTO / SIGNATURE / ICON) each correspond to a distinct pipeline path. Illustration-style content still works end-to-end via the PHOTO path; TypeScript union narrowing prevents re-introduction.
- **fix(classifier)**: tightened SIGNATURE with a `uniqueColors < 200` gate to fix a user-reported false positive (a desaturated product photo on white was hitting all four prior SIGNATURE thresholds because the white background drags the saturation mean below the cap). Calibration is intentionally asymmetric — signatures are niche, prefer to misroute a noisy signature to PHOTO over admitting a non-signature into the threshold-based path that corrupts the result.
- **docs**: aligned README, CHANGELOG, index.html, scripts/README and tests/fixtures/LICENSE with the 3-class model.

## Test plan

- [ ] `npm test` — full unit suite (vitest), specifically `tests/cv/classify-image.test.ts` and `tests/pipeline/finalize-result.test.ts`
- [ ] Manual: drop `imagenes nukebg/cochetest.webp` — should now route through the PHOTO path (was SIGNATURE before)
- [ ] Manual: process image → click Edit → click "Process another" → paste new image. Editor must stay hidden during processing; only the progress console + viewer should be visible
- [ ] Manual: any image that was previously SIGNATURE (real ink-on-paper signature) still classifies as SIGNATURE — confirm via the dev console log `[NukeBG] Content type: SIGNATURE`
- [ ] Manual: cmdbar reads `$ nuke <filename> · ...` in any UI language (EN / ES / FR / DE / PT / ZH)