### PR TITLE
fix(async): wrap editor-done handler + log cache-purge fallback

### DIFF
--- a/src/components/ar-app.ts
+++ b/src/components/ar-app.ts
@@ -1397,35 +1397,46 @@ export class ArApp extends HTMLElement {
       this.shadowRoot!,
       'ar:editor-done',
       async ({ imageData: rawEdited }) => {
-        // Refine: foreground decontamination + quintic alpha sharpening so manual
-        // brush strokes inherit the same studio-quality edge as the main pipeline.
-        // Topology cleanup is skipped — keepLargestComponent would discard manual
-        // restores that don't connect to the main subject body.
-        const editedData = await refineEdges(this.pipeline, rawEdited, {
-          skipTopologyCleanup: true,
-        });
-        // Crop for export; slider canvas keeps the full-size frame so
-        // the manual brush strokes still align with the original.
-        const exportImageData = autoCropToSubject(editedData);
-        const blob = await exportPng(exportImageData);
+        try {
+          // Refine: foreground decontamination + quintic alpha sharpening so manual
+          // brush strokes inherit the same studio-quality edge as the main pipeline.
+          // Topology cleanup is skipped — keepLargestComponent would discard manual
+          // restores that don't connect to the main subject body.
+          const editedData = await refineEdges(this.pipeline, rawEdited, {
+            skipTopologyCleanup: true,
+          });
+          // Crop for export; slider canvas keeps the full-size frame so
+          // the manual brush strokes still align with the original.
+          const exportImageData = autoCropToSubject(editedData);
+          const blob = await exportPng(exportImageData);
 
-        // Save pre-edit for discard functionality
-        this.preEditResult = this.lastResultImageData;
-        this.cachedEditResult = editedData;
-        this.lastResultImageData = editedData;
+          // Save pre-edit for discard functionality
+          this.preEditResult = this.lastResultImageData;
+          this.cachedEditResult = editedData;
+          this.lastResultImageData = editedData;
 
-        // "Before" stays as the original input image; only "after" updates
-        this.viewer.setResult(editedData, blob, {
-          width: exportImageData.width,
-          height: exportImageData.height,
-        });
-        await this.download.setResult(exportImageData, this.currentFileName, 0, blob);
+          // "Before" stays as the original input image; only "after" updates
+          this.viewer.setResult(editedData, blob, {
+            width: exportImageData.width,
+            height: exportImageData.height,
+          });
+          await this.download.setResult(exportImageData, this.currentFileName, 0, blob);
 
-        // Hide editor, show discard button
-        (this.shadowRoot!.querySelector('#editor-section') as HTMLElement).style.display = 'none';
-        const editBtn = this.shadowRoot!.querySelector('#edit-btn') as HTMLElement;
-        editBtn.style.display = 'block';
-        editBtn.textContent = t('edit.discard');
+          // Hide editor, show discard button
+          (this.shadowRoot!.querySelector('#editor-section') as HTMLElement).style.display =
+            'none';
+          const editBtn = this.shadowRoot!.querySelector('#edit-btn') as HTMLElement;
+          editBtn.style.display = 'block';
+          editBtn.textContent = t('edit.discard');
+        } catch (err) {
+          // refineEdges / exportPng / setResult can throw on malformed
+          // input or worker errors. Without this catch the rejection
+          // becomes an unhandledrejection and the editor leaves the user
+          // on a stale result with no signal that anything went wrong.
+          console.error('[NukeBG] Editor finalize failed:', err);
+          const msg = err instanceof Error ? err.message : String(err);
+          this.showErrorModal(msg);
+        }
       },
       { signal },
     );

--- a/src/main.ts
+++ b/src/main.ts
@@ -661,7 +661,8 @@ function nukeCache(): void {
       url.searchParams.set('_cb', Date.now().toString());
       window.location.href = url.toString();
     })
-    .catch(() => {
+    .catch((err: unknown) => {
+      console.warn('[NukeBG] Cache purge failed, falling back to plain reload:', err);
       window.location.reload();
     });
 }


### PR DESCRIPTION
## Summary

Two narrow follow-ups from the post-#257 audit. Of the 19 findings the Explore agent produced, only these two survived verification — the other 17 were false positives (full accounting in the closure comments on issues #258, #259, #260, #261, #262, #263).

- **`ar-app.ts:1399`** — `ar:editor-done` handler was an async chain (`refineEdges` → `exportPng` → `download.setResult`) with no try/catch. Any rejection became an unhandled rejection; the user was stuck on a stale result with no signal. Wrapped in try/catch with `console.error` + `showErrorModal(msg)` fallback so the failure surfaces through the same modal the main pipeline uses.
- **`main.ts:664`** — `nukeCache()` caught its `caches.delete()` chain with `() => location.reload()` and no log. Added a `console.warn` before the fallback so post-mortem debugging has a breadcrumb.

## Lesson worth capturing

The audit-then-verify cycle was valuable but the audit itself had ~10% accuracy — it kept applying Web-Component-cleanup patterns to module-level boot code, and "validate at the boundary" patterns to boundaries already covered by TypeScript + structured-clone guarantees. The closure comments on the 5 wontfix'd issues document the specific reasoning so the same false alarms can be dismissed faster next time.

## Test plan

- [ ] `npm test` — no functional changes to the pipeline; existing suite must pass unchanged
- [ ] Manual: open editor, perform a brush stroke, click Done — happy path still updates viewer + download as before
- [ ] Manual: simulate refineEdges failure (e.g. throw inside a worker handler) — error modal should surface with `[NukeBG] Editor finalize failed:` in the console
- [ ] Manual: type `nuke` in the terminal prompt to trigger `nukeCache()` — observe the warn log if cache purge fails (otherwise the cache-busting reload still happens normally)