### PR TITLE
security(harden): enforce innerHTML policy with no-unsanitized lint rule

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -263,6 +263,25 @@ infra: add CI workflow with GitHub Actions
 - All magic numbers and algorithm thresholds go in `src/pipeline/constants.ts`.
 - Never hardcode values directly in algorithm modules.
 
+### `innerHTML` policy
+
+NukeBG uses `.innerHTML =` in many places to build Web Component shadow DOM. The audit on PR #257 confirmed every existing site is safe — they fall into three trusted categories:
+
+1. **Static templates** — pure markup with at most `${t(...)}` interpolations from `src/i18n/index.ts` (the i18n trust boundary).
+2. **Internal numeric / enum state** — values like `brushSize: number` or `tool: 'erase' | 'refine'` that never carry user-supplied strings.
+3. **Roundtrip restores** — `el.innerHTML = saved`, where `saved` was previously read from `el.innerHTML` of the same element.
+
+The `no-unsanitized/property` ESLint rule (`eslint-plugin-no-unsanitized`) enforces this contract on every new assignment. The plugin's `escape.methods: ['t']` config recognises the i18n translator as a trusted source — `el.innerHTML = t('key')` and `\`...\${t('key')}...\`` pass without ceremony. Any other dynamic input (user filenames, pasted text, API responses) MUST go through `textContent` or DOM APIs (`createElement`, `appendChild`, `setAttribute`).
+
+If a new site really needs `innerHTML` with a different trusted source (e.g. a hand-authored CSS string, a `buildGuide()` helper that composes only `t()` outputs), add an inline disable with a short reason:
+
+```ts
+// eslint-disable-next-line no-unsanitized/property -- <why this input is trusted>
+el.innerHTML = composedSafeMarkup;
+```
+
+The reason must name the trust boundary — "static template", "trusted i18n", "internal numeric state", "roundtrip of own DOM" — not the symptom ("works fine"). Drive-by disables without justification will be rejected.
+
 ---
 
 ## > contribution_areas

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -10,6 +10,7 @@
 import js from '@eslint/js';
 import tseslint from 'typescript-eslint';
 import globals from 'globals';
+import noUnsanitized from 'eslint-plugin-no-unsanitized';
 
 export default tseslint.config(
   {
@@ -32,6 +33,7 @@ export default tseslint.config(
   js.configs.recommended,
   ...tseslint.configs.recommended,
   {
+    plugins: { 'no-unsanitized': noUnsanitized },
     languageOptions: {
       ecmaVersion: 2022,
       sourceType: 'module',
@@ -59,6 +61,32 @@ export default tseslint.config(
       'prefer-const': 'error',
       // No var declarations.
       'no-var': 'error',
+
+      // Defense-in-depth against XSS from `innerHTML` / `outerHTML`. The
+      // current codebase is safe (audit on PR #257 confirmed every site
+      // uses static templates, trusted i18n via `t()`, or internal
+      // numeric state — never user input). This rule prevents future
+      // regressions: any new dynamic innerHTML assignment trips lint
+      // unless explicitly disabled with a // eslint-disable-next-line
+      // comment that documents why the input is trusted. See
+      // CONTRIBUTING.md > "innerHTML policy" for the full convention.
+      //
+      // `escape.methods` whitelists the i18n translator: `t(...)` returns
+      // strings sourced from `src/i18n/index.ts`, a trust boundary the
+      // project owns. Adding new escape methods requires the same
+      // ownership argument.
+      'no-unsanitized/property': [
+        'error',
+        {
+          escape: { methods: ['t'] },
+        },
+      ],
+      'no-unsanitized/method': [
+        'error',
+        {
+          escape: { methods: ['t'] },
+        },
+      ],
     },
   },
   {

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "@eslint/js": "^9.17.0",
         "@playwright/test": "^1.59.1",
         "eslint": "^10.3.0",
+        "eslint-plugin-no-unsanitized": "^4.1.5",
         "globals": "^15.14.0",
         "happy-dom": "^20.9.0",
         "prettier": "^3.4.2",
@@ -1885,6 +1886,16 @@
         "jiti": {
           "optional": true
         }
+      }
+    },
+    "node_modules/eslint-plugin-no-unsanitized": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-no-unsanitized/-/eslint-plugin-no-unsanitized-4.1.5.tgz",
+      "integrity": "sha512-MSB4hXPVFQrI8weqzs6gzl7reP2k/qSjtCoL2vUMSDejIIq9YL1ZKvq5/ORBXab/PvfBBrWO2jWviYpL+4Ghfg==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "peerDependencies": {
+        "eslint": "^9 || ^10"
       }
     },
     "node_modules/eslint-scope": {

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "@eslint/js": "^9.17.0",
     "@playwright/test": "^1.59.1",
     "eslint": "^10.3.0",
+    "eslint-plugin-no-unsanitized": "^4.1.5",
     "globals": "^15.14.0",
     "happy-dom": "^20.9.0",
     "prettier": "^3.4.2",

--- a/src/components/ar-app.ts
+++ b/src/components/ar-app.ts
@@ -142,6 +142,7 @@ export class ArApp extends HTMLElement {
   }
 
   private render(): void {
+    // eslint-disable-next-line no-unsanitized/property -- Static shadow DOM template; only `${t(...)}` interpolations from src/i18n/index.ts. No user input.
     this.shadowRoot!.innerHTML = `
       <style>
         :host {
@@ -1125,6 +1126,7 @@ export class ArApp extends HTMLElement {
         `<span class="hero-title-short"><span class="accent">${t('hero.title.short')}</span></span>`;
     const subline = root.querySelector('.subline');
     if (subline)
+      // eslint-disable-next-line no-unsanitized/property -- Trusted i18n only (`t(...)` from src/i18n/index.ts); the `.replace` is on i18n output.
       subline.innerHTML =
         `<span class="subline-long">${t('hero.subtitle').replace(/\n/g, ' ')}</span>` +
         `<span class="subline-short"># ${t('hero.subtitle.short')}</span>`;

--- a/src/components/ar-download.ts
+++ b/src/components/ar-download.ts
@@ -108,6 +108,7 @@ export class ArDownload extends HTMLElement {
   }
 
   private render(): void {
+    // eslint-disable-next-line no-unsanitized/property -- Static shadow DOM template; only `${t(...)}` interpolations from src/i18n/index.ts. No user input.
     this.shadowRoot!.innerHTML = `
       <style>
         :host { display: block; width: 100%; }
@@ -348,6 +349,7 @@ export class ArDownload extends HTMLElement {
       } catch {
         // Clipboard API not supported or permission denied - show feedback
         const btn = this.shadowRoot!.querySelector('#copy-btn')!;
+        // eslint-disable-next-line no-unsanitized/property -- Trusted i18n with literal English fallback; both branches are static-content sources.
         btn.innerHTML = `${t('download.copyFailed') || 'Copy not supported'}`;
         setTimeout(() => {
           btn.innerHTML = `${t('download.copy')}<br><small>PNG</small>`;

--- a/src/components/ar-editor-advanced.ts
+++ b/src/components/ar-editor-advanced.ts
@@ -308,6 +308,7 @@ export class ArEditorAdvanced extends HTMLElement {
 
   private render(): void {
     const shadow = this.attachShadow({ mode: 'open' });
+    // eslint-disable-next-line no-unsanitized/property -- Static shadow DOM template; only `${t(...)}` interpolations from src/i18n/index.ts. No user input.
     shadow.innerHTML = `
       <style>
         :host {

--- a/src/components/ar-editor.ts
+++ b/src/components/ar-editor.ts
@@ -162,6 +162,7 @@ export class ArEditor extends HTMLElement {
   }
 
   private render(): void {
+    // eslint-disable-next-line no-unsanitized/property -- Static shadow DOM template; only `${t(...)}` interpolations from src/i18n/index.ts. No user input.
     this.shadowRoot!.innerHTML = `
       <style>
         :host {
@@ -967,6 +968,7 @@ export class ArEditor extends HTMLElement {
     const meta = this.shadowRoot?.querySelector('#editor-cmd-meta');
     if (!meta) return;
     const letter = this.tool === 'erase' ? 'E' : 'R';
+    // eslint-disable-next-line no-unsanitized/property -- Internal numeric/enum state only (`brushSize: number`, `letter: 'E' | 'R'`); no user input path.
     meta.innerHTML = `·&nbsp;brush=${this.brushSize}&nbsp;·&nbsp;tool=${letter}`;
   }
 

--- a/src/components/ar-post-cta.ts
+++ b/src/components/ar-post-cta.ts
@@ -93,6 +93,7 @@ class ArPostCta extends HTMLElement {
       return;
     }
     const copy = COPY[this.currentKey];
+    // eslint-disable-next-line no-unsanitized/property -- Static template: `this.styles()` returns a hand-authored CSS string and `${t(...)}` is trusted i18n. No user input.
     this.shadowRoot!.innerHTML = `
       <style>${this.styles()}</style>
       <div class="cta-bar" role="status" aria-live="polite">

--- a/src/components/ar-progress.ts
+++ b/src/components/ar-progress.ts
@@ -298,6 +298,7 @@ export class ArProgress extends HTMLElement {
       return true;
     });
 
+    // eslint-disable-next-line no-unsanitized/property -- Composed from internal pipeline state; the only string from outside (`s.message`) is run through `escapeHtml` on the line below.
     container.innerHTML = visibleStages
       .map((s) => {
         const icon = this.getIcon(s.status);

--- a/src/components/ar-reactor.ts
+++ b/src/components/ar-reactor.ts
@@ -70,6 +70,7 @@ class ArReactor extends HTMLElement {
     const runtimeLabel = formatRuntime(monthsFloat);
     const burnLabel = `€${MONTHLY_BURN_EUR.toFixed(2)}/mo`;
 
+    // eslint-disable-next-line no-unsanitized/property -- Static template: `this.styles()` returns a hand-authored CSS string; the rest interpolates trusted i18n + computed labels from internal numeric state.
     this.shadowRoot!.innerHTML = `
       <style>${this.styles()}</style>
       <article class="reactor">

--- a/src/components/ar-viewer.ts
+++ b/src/components/ar-viewer.ts
@@ -55,6 +55,7 @@ export class ArViewer extends HTMLElement {
   }
 
   private render(): void {
+    // eslint-disable-next-line no-unsanitized/property -- Static shadow DOM template; only `${t(...)}` interpolations from src/i18n/index.ts. No user input.
     this.shadowRoot!.innerHTML = `
       <style>
         :host { display: block; width: 100%; }

--- a/src/controllers/app-install.ts
+++ b/src/controllers/app-install.ts
@@ -68,6 +68,7 @@ export class AppInstaller {
           return;
         }
         // Browser-specific instructions for non-Chromium installs.
+        // eslint-disable-next-line no-unsanitized/property -- `buildGuide()` returns a string composed entirely of trusted `t(...)` i18n values selected by user-agent sniffing; no user input.
         this.installGuide.innerHTML = this.buildGuide();
         this.installGuide.classList.toggle('visible');
         const closeBtn = this.installGuide.querySelector('.install-guide-close');

--- a/src/main.ts
+++ b/src/main.ts
@@ -333,6 +333,7 @@ function activateUltraNukeMode(reducedMotion: boolean): void {
   const dismiss = (): void => {
     const style = document.getElementById('ultra-nuke-style');
     if (style) style.remove();
+    // eslint-disable-next-line no-unsanitized/property -- Roundtrip restore of `originalH1`, captured directly from `heroH1.innerHTML` a few lines above. Same DOM, no external input.
     if (heroH1 && originalH1) heroH1.innerHTML = originalH1;
     if (toast) {
       toast.textContent = '> normal mode restored_';


### PR DESCRIPTION
Closes #256.

## Summary

Defense-in-depth against XSS regressions. The audit on PR #257 confirmed every existing `innerHTML` site is safe — static templates, trusted i18n via `t()`, or internal numeric/enum state. This rule prevents the next careless `el.innerHTML = \`...\${userInput}\`` from slipping through review.

- **Lint** — adds `eslint-plugin-no-unsanitized` (MPL-2.0, single dep, no transitives) configured with `escape.methods: ['t']` so the i18n translator is recognised as a trust boundary. \`el.innerHTML = t('key')\` and template literals where every interpolation is \`t(...)\` pass without ceremony.
- **Disables with reasoning** — 13 existing safe sites got inline disables that name the trust boundary (static template / trusted i18n / internal numeric state / roundtrip of own DOM), not the symptom.
- **Docs** — new `innerHTML policy` section in CONTRIBUTING.md under \`code_style\` spells out the four trust boundaries and the procedure for new disables.

## Test plan

- [ ] \`npm run lint\` — clean (verified locally: 0 errors, 0 warnings)
- [ ] CI \`Lint + format\` job stays green
- [ ] Manual review: each disable comment in this PR names a real trust boundary (no \"works fine\" placeholders)
- [ ] No behaviour change — pure lint config + comments + docs