### PR TITLE
feat(core): type layer, runner interfaces, error classes (phase 3)

### DIFF
--- a/openspec/changes/extract-core-cli/tasks.md
+++ b/openspec/changes/extract-core-cli/tasks.md
@@ -87,39 +87,39 @@ _Goal: all browser app source moves from `src/` (root) → `packages/nukebg-app/
 
 _Goal: `nukebg-core` exports its type layer and `createImageDataLike` factory. No algorithm code yet._
 
-- [ ] 3.1 Write failing tests for `ImageDataLike` structural contract and `createImageDataLike` factory (REQ-CORE-PIPELINE-2):
+- [x] 3.1 Write failing tests for `ImageDataLike` structural contract and `createImageDataLike` factory (REQ-CORE-PIPELINE-2):
   - File: `packages/nukebg-core/tests/types/image-data-like.test.ts`
   - Scenarios: factory returns `{ data, width, height }` plain object; plain object satisfies the interface (type-level compile check via `@ts-expect-error` absence); `colorSpace` field is optional.
 
-- [ ] 3.2 Implement `packages/nukebg-core/src/types/image-data-like.ts` — `ImageDataLike` interface + `createImageDataLike` factory as per design §B.2. Export from `src/index.ts`. Run tests, expect green.
+- [x] 3.2 Implement `packages/nukebg-core/src/types/image-data-like.ts` — `ImageDataLike` interface + `createImageDataLike` factory as per design §B.2. Export from `src/index.ts`. Run tests, expect green.
 
-- [ ] 3.3 Write failing tests for `PipelineOptions`, `PipelineMode`, `PipelinePrecision` types (compile-time structural checks; at least one runtime test for default-value semantics if helpers are added):
+- [x] 3.3 Write failing tests for `PipelineOptions`, `PipelineMode`, `PipelinePrecision` types (compile-time structural checks; at least one runtime test for default-value semantics if helpers are added):
   - File: `packages/nukebg-core/tests/types/pipeline-options.test.ts`
 
-- [ ] 3.4 Implement `packages/nukebg-core/src/types/pipeline-options.ts` and `packages/nukebg-core/src/types/pipeline-result.ts` with shapes from design §B.7. Export from `src/index.ts`. Run tests, expect green.
+- [x] 3.4 Implement `packages/nukebg-core/src/types/pipeline-options.ts` and `packages/nukebg-core/src/types/pipeline-result.ts` with shapes from design §B.7. Export from `src/index.ts`. Run tests, expect green.
 
-- [ ] 3.5 Write failing tests verifying `PipelineResult` shape (at minimum: `output` is `ImageDataLike`, `resolvedMode` is one of the three literal types, `durationMs` is a number, `stageTimings` contains the four required keys — REQ-CORE-PIPELINE-6):
+- [x] 3.5 Write failing tests verifying `PipelineResult` shape (at minimum: `output` is `ImageDataLike`, `resolvedMode` is one of the three literal types, `durationMs` is a number, `stageTimings` contains the four required keys — REQ-CORE-PIPELINE-6):
   - File: `packages/nukebg-core/tests/types/pipeline-result.test.ts`
 
-- [ ] 3.6 Implement `packages/nukebg-core/src/types/cv-results.ts` — `BgColorResult`, `WatermarkResult`, `ClassifyImageResult`, `ImageFeatures`, `GridResult`. Export from `src/index.ts`. Run tests, expect green.
+- [x] 3.6 Implement `packages/nukebg-core/src/types/cv-results.ts` — `BgColorResult`, `WatermarkResult`, `ClassifyImageResult`, `ImageFeatures`, `GridResult`. Export from `src/index.ts`. Run tests, expect green.
 
-- [ ] 3.7 Write failing tests for runner interface structural compliance — type-only tests asserting that an object literal satisfying `RmbgRunner`, `LamaRunner`, `ImageCodec`, `PipelineRunner` does not produce TS errors (REQ-CORE-RUNNERS-1 through 4):
+- [x] 3.7 Write failing tests for runner interface structural compliance — type-only tests asserting that an object literal satisfying `RmbgRunner`, `LamaRunner`, `ImageCodec`, `PipelineRunner` does not produce TS errors (REQ-CORE-RUNNERS-1 through 4):
   - File: `packages/nukebg-core/tests/runners/interfaces.test.ts`
 
-- [ ] 3.8 Implement runner interface files:
+- [x] 3.8 Implement runner interface files:
   - `packages/nukebg-core/src/runners/pipeline-runner.ts` (design §B.3)
   - `packages/nukebg-core/src/runners/rmbg-runner.ts` (design §B.4)
   - `packages/nukebg-core/src/runners/lama-runner.ts` (design §B.5)
   - `packages/nukebg-core/src/runners/image-codec.ts` (design §B.6)
   Export all from `src/index.ts`. Run tests, expect green.
 
-- [ ] 3.9 Write failing tests for `NukebgError` base class and the discriminated error subclasses `RmbgError`, `LamaError`, `DecodeError`, `PipelineAbortError` (REQ-CORE-RUNNERS-5, REQ-CORE-PIPELINE-4):
+- [x] 3.9 Write failing tests for `NukebgError` base class and the discriminated error subclasses `RmbgError`, `LamaError`, `DecodeError`, `PipelineAbortError` (REQ-CORE-RUNNERS-5, REQ-CORE-PIPELINE-4):
   - File: `packages/nukebg-core/tests/pipeline/errors.test.ts`
   - Scenarios: `error instanceof NukebgError` is true for each subclass; `error.code` is correct; `error.cause` is preserved.
 
-- [ ] 3.10 Implement `packages/nukebg-core/src/pipeline/errors.ts` — `NukebgError`, `RmbgError`, `LamaError`, `DecodeError`, `PipelineAbortError`. Export `PipelineAbortError` from `src/index.ts`. Run tests, expect green.
+- [x] 3.10 Implement `packages/nukebg-core/src/pipeline/errors.ts` — `NukebgError`, `RmbgError`, `LamaError`, `DecodeError`, `PipelineAbortError`. Export `PipelineAbortError` from `src/index.ts`. Run tests, expect green.
 
-- [ ] 3.11 Verification: `npm test` green (core + app suites), `npm run typecheck`, `npm run lint`. Milestone: "core type layer + errors exported, zero algorithm code".
+- [x] 3.11 Verification: `npm test` green (core + app suites), `npm run typecheck`, `npm run lint`. Milestone: "core type layer + errors exported, zero algorithm code".
 
 ---
 

--- a/openspec/changes/extract-core-cli/tasks.md
+++ b/openspec/changes/extract-core-cli/tasks.md
@@ -127,11 +127,11 @@ _Goal: `nukebg-core` exports its type layer and `createImageDataLike` factory. N
 
 _Goal: `pipeline/constants.ts` is extracted to core so CV modules can import it in Phase 5._
 
-- [ ] 4.1 Move `packages/nukebg-app/src/pipeline/constants.ts` → `packages/nukebg-core/src/pipeline/constants.ts`. Update all imports in `packages/nukebg-app/src/` from the old path to `nukebg-core`. Co-located tests (if any reference constants directly) move to `packages/nukebg-core/tests/pipeline/constants.test.ts`. Run `npm test`, expect green.
+- [x] 4.1 Move `packages/nukebg-app/src/pipeline/constants.ts` → `packages/nukebg-core/src/pipeline/constants.ts`. Update all imports in `packages/nukebg-app/src/` from the old path to `nukebg-core`. Co-located tests (if any reference constants directly) move to `packages/nukebg-core/tests/pipeline/constants.test.ts`. Run `npm test`, expect green.
 
-- [ ] 4.2 Export constants from `packages/nukebg-core/src/index.ts` per design §B.1. Run `npm test`, expect green.
+- [x] 4.2 Export constants from `packages/nukebg-core/src/index.ts` per design §B.1. Run `npm test`, expect green.
 
-- [ ] 4.3 Verification: `npm test`, `npm run typecheck`, `npm run lint` all green. Milestone: "constants in core, app imports from `nukebg-core`".
+- [x] 4.3 Verification: `npm test`, `npm run typecheck`, `npm run lint` all green. Milestone: "constants in core, app imports from `nukebg-core`".
 
 ---
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -4243,6 +4243,7 @@
       "dependencies": {
         "@huggingface/transformers": "^3.8.1",
         "jszip": "^3.10.1",
+        "nukebg-core": "*",
         "onnxruntime-web": "^1.24.3"
       },
       "devDependencies": {

--- a/packages/nukebg-app/package.json
+++ b/packages/nukebg-app/package.json
@@ -21,6 +21,7 @@
     "format:check": "prettier --check ."
   },
   "dependencies": {
+    "nukebg-core": "*",
     "@huggingface/transformers": "^3.8.1",
     "jszip": "^3.10.1",
     "onnxruntime-web": "^1.24.3"

--- a/packages/nukebg-app/src/components/ar-editor-advanced.ts
+++ b/packages/nukebg-app/src/components/ar-editor-advanced.ts
@@ -34,7 +34,7 @@ import { SamRefiner } from '../controllers/sam-refiner';
 import { processRoi } from '../refine/roi-process';
 import { rasterizePolygon } from '../refine/roi-process';
 import { patchMatchInpaint } from '../workers/cv/patchmatch-inpaint';
-import { PATCHMATCH_PARAMS } from '../pipeline/constants';
+import { PATCHMATCH_PARAMS } from 'nukebg-core';
 import { t } from '../i18n';
 import { type Point } from './lasso-simplify';
 import { LassoModel } from '../lib/lasso-model';

--- a/packages/nukebg-app/src/pipeline/image-processor.ts
+++ b/packages/nukebg-app/src/pipeline/image-processor.ts
@@ -1,6 +1,6 @@
 import type { PipelineResult, PipelineStage, StageStatus } from '../types/pipeline';
 import type { ModelId } from '../types/worker-messages';
-import type { PrecisionMode } from './constants';
+import type { PrecisionMode } from 'nukebg-core';
 
 /**
  * Stage callback the processor invokes to surface progress to the UI.

--- a/packages/nukebg-app/src/pipeline/orchestrator.ts
+++ b/packages/nukebg-app/src/pipeline/orchestrator.ts
@@ -14,8 +14,8 @@ import type {
   ModelId,
   ClassifyImageResult,
 } from '../types/worker-messages';
-import { IMAGE_CLASSIFY_PARAMS, INPAINT_PARAMS, PRECISION_PROFILES } from './constants';
-import type { PrecisionMode } from './constants';
+import { IMAGE_CLASSIFY_PARAMS, INPAINT_PARAMS, PRECISION_PROFILES } from 'nukebg-core';
+import type { PrecisionMode } from 'nukebg-core';
 import { compositeWithFeather, dilateMask } from '../workers/cv/inpaint-blend';
 import { shouldUseLama } from '../workers/cv/lama-router';
 import { WorkerChannel } from './worker-channel';

--- a/packages/nukebg-app/src/utils/device-adaptation.ts
+++ b/packages/nukebg-app/src/utils/device-adaptation.ts
@@ -16,7 +16,7 @@
  */
 
 import { getCapability, type CapabilityTier } from './capability-detector';
-import type { PrecisionMode } from '../pipeline/constants';
+import type { PrecisionMode } from 'nukebg-core';
 
 /**
  * Map a capability tier to the precision mode that strikes the right

--- a/packages/nukebg-app/src/utils/final-composite.ts
+++ b/packages/nukebg-app/src/utils/final-composite.ts
@@ -1,5 +1,5 @@
 import { guidedFilter } from '../workers/cv/alpha-matting';
-import { EDGE_REFINE_PARAMS } from '../pipeline/constants';
+import { EDGE_REFINE_PARAMS } from 'nukebg-core';
 
 /**
  * Compose the final output at the original input resolution.

--- a/packages/nukebg-app/src/workers/cv/alpha-refine.ts
+++ b/packages/nukebg-app/src/workers/cv/alpha-refine.ts
@@ -1,4 +1,4 @@
-import { ALPHA_PARAMS } from '../../pipeline/constants';
+import { ALPHA_PARAMS } from 'nukebg-core';
 
 /**
  * Refine alpha channel: median filter + gaussian blur + threshold.

--- a/packages/nukebg-app/src/workers/cv/classify-image.ts
+++ b/packages/nukebg-app/src/workers/cv/classify-image.ts
@@ -1,4 +1,4 @@
-import { IMAGE_CLASSIFY_PARAMS } from '../../pipeline/constants';
+import { IMAGE_CLASSIFY_PARAMS } from 'nukebg-core';
 
 /** Content type classification for auto-algorithm selection */
 export type ImageContentType = 'PHOTO' | 'SIGNATURE' | 'ICON';

--- a/packages/nukebg-app/src/workers/cv/detect-bg-colors.ts
+++ b/packages/nukebg-app/src/workers/cv/detect-bg-colors.ts
@@ -1,4 +1,4 @@
-import { CV_PARAMS } from '../../pipeline/constants';
+import { CV_PARAMS } from 'nukebg-core';
 import type { BgColorResult } from '../../types/pipeline';
 import { mean, std, median } from './utils';
 

--- a/packages/nukebg-app/src/workers/cv/detect-checker-grid.ts
+++ b/packages/nukebg-app/src/workers/cv/detect-checker-grid.ts
@@ -1,4 +1,4 @@
-import { CV_PARAMS } from '../../pipeline/constants';
+import { CV_PARAMS } from 'nukebg-core';
 import type { GridResult } from '../../types/pipeline';
 import { median } from './utils';
 

--- a/packages/nukebg-app/src/workers/cv/grid-flood-fill.ts
+++ b/packages/nukebg-app/src/workers/cv/grid-flood-fill.ts
@@ -1,4 +1,4 @@
-import { CV_PARAMS } from '../../pipeline/constants';
+import { CV_PARAMS } from 'nukebg-core';
 import { RingBuffer, maxChannelDiff, pixelIndex } from './utils';
 
 /**

--- a/packages/nukebg-app/src/workers/cv/inpaint-telea.ts
+++ b/packages/nukebg-app/src/workers/cv/inpaint-telea.ts
@@ -10,7 +10,7 @@
  * propagates edge information inward naturally.
  */
 
-import { INPAINT_PARAMS } from '../../pipeline/constants';
+import { INPAINT_PARAMS } from 'nukebg-core';
 
 // --- Min-Heap para Fast Marching ---
 

--- a/packages/nukebg-app/src/workers/cv/lama-crop.ts
+++ b/packages/nukebg-app/src/workers/cv/lama-crop.ts
@@ -1,4 +1,4 @@
-import { LAMA_PARAMS } from '../../pipeline/constants';
+import { LAMA_PARAMS } from 'nukebg-core';
 import { clamp255 } from './clamp';
 
 export interface LamaCropRect {

--- a/packages/nukebg-app/src/workers/cv/lama-router.ts
+++ b/packages/nukebg-app/src/workers/cv/lama-router.ts
@@ -1,4 +1,4 @@
-import { LAMA_ROUTER_PARAMS } from '../../pipeline/constants';
+import { LAMA_ROUTER_PARAMS } from 'nukebg-core';
 
 export interface LamaRouterDecision {
   /** True → use LaMa (ONNX, content-aware). False → PatchMatch (CV, instant). */

--- a/packages/nukebg-app/src/workers/cv/shadow-cleanup.ts
+++ b/packages/nukebg-app/src/workers/cv/shadow-cleanup.ts
@@ -1,4 +1,4 @@
-import { SHADOW_PARAMS } from '../../pipeline/constants';
+import { SHADOW_PARAMS } from 'nukebg-core';
 import { pixelIndex } from './utils';
 
 /**

--- a/packages/nukebg-app/src/workers/cv/signature-threshold.ts
+++ b/packages/nukebg-app/src/workers/cv/signature-threshold.ts
@@ -1,4 +1,4 @@
-import { IMAGE_CLASSIFY_PARAMS } from '../../pipeline/constants';
+import { IMAGE_CLASSIFY_PARAMS } from 'nukebg-core';
 
 /**
  * Signature threshold: extract signature strokes from a mostly-white background

--- a/packages/nukebg-app/src/workers/cv/simple-flood-fill.ts
+++ b/packages/nukebg-app/src/workers/cv/simple-flood-fill.ts
@@ -1,4 +1,4 @@
-import { CV_PARAMS } from '../../pipeline/constants';
+import { CV_PARAMS } from 'nukebg-core';
 import { RingBuffer, maxChannelDiff, pixelIndex } from './utils';
 
 /**

--- a/packages/nukebg-app/src/workers/cv/sparkle-detect.ts
+++ b/packages/nukebg-app/src/workers/cv/sparkle-detect.ts
@@ -1,4 +1,4 @@
-import { SPARKLE_PARAMS } from '../../pipeline/constants';
+import { SPARKLE_PARAMS } from 'nukebg-core';
 import type { WatermarkResult } from '../../types/pipeline';
 
 /**

--- a/packages/nukebg-app/src/workers/cv/subject-exclusion.ts
+++ b/packages/nukebg-app/src/workers/cv/subject-exclusion.ts
@@ -1,4 +1,4 @@
-import { CV_PARAMS } from '../../pipeline/constants';
+import { CV_PARAMS } from 'nukebg-core';
 import { pixelIndex, RingBuffer } from './utils';
 
 /**

--- a/packages/nukebg-app/src/workers/cv/watermark-dalle.ts
+++ b/packages/nukebg-app/src/workers/cv/watermark-dalle.ts
@@ -1,4 +1,4 @@
-import { DALLE_WATERMARK_PARAMS } from '../../pipeline/constants';
+import { DALLE_WATERMARK_PARAMS } from 'nukebg-core';
 import type { WatermarkResult } from '../../types/pipeline';
 import { pixelIndex } from './utils';
 

--- a/packages/nukebg-app/src/workers/cv/watermark-detect.ts
+++ b/packages/nukebg-app/src/workers/cv/watermark-detect.ts
@@ -1,4 +1,4 @@
-import { WATERMARK_PARAMS } from '../../pipeline/constants';
+import { WATERMARK_PARAMS } from 'nukebg-core';
 import type { WatermarkResult } from '../../types/pipeline';
 import { pixelIndex } from './utils';
 

--- a/packages/nukebg-app/src/workers/inpaint.worker.ts
+++ b/packages/nukebg-app/src/workers/inpaint.worker.ts
@@ -8,7 +8,7 @@
  */
 import { patchMatchInpaint } from './cv/patchmatch-inpaint';
 import type { InpaintWorkerRequest, InpaintWorkerResponse } from '../types/worker-messages';
-import { PATCHMATCH_PARAMS } from '../pipeline/constants';
+import { PATCHMATCH_PARAMS } from 'nukebg-core';
 
 async function inpaint(
   id: string,

--- a/packages/nukebg-app/src/workers/lama.worker.ts
+++ b/packages/nukebg-app/src/workers/lama.worker.ts
@@ -15,7 +15,7 @@
  */
 import * as ort from 'onnxruntime-web';
 import type { LamaWorkerRequest, LamaWorkerResponse } from '../types/worker-messages';
-import { LAMA_PARAMS } from '../pipeline/constants';
+import { LAMA_PARAMS } from 'nukebg-core';
 import {
   bilinearResizeRGBA,
   computeLamaCropRect,

--- a/packages/nukebg-app/src/workers/ml.worker.ts
+++ b/packages/nukebg-app/src/workers/ml.worker.ts
@@ -10,7 +10,7 @@ import type {
   ModelId,
   WarmupDiagnostic,
 } from '../types/worker-messages';
-import { REFINE_PARAMS, RMBG_PARAMS } from '../pipeline/constants';
+import { REFINE_PARAMS, RMBG_PARAMS } from 'nukebg-core';
 
 const DEFAULT_MODEL: ModelId = 'briaai/RMBG-1.4';
 

--- a/packages/nukebg-app/src/workers/sam.worker.ts
+++ b/packages/nukebg-app/src/workers/sam.worker.ts
@@ -13,7 +13,7 @@
  */
 import * as ort from 'onnxruntime-web';
 import type { SamWorkerRequest, SamWorkerResponse } from '../types/worker-messages';
-import { MOBILESAM_PARAMS } from '../pipeline/constants';
+import { MOBILESAM_PARAMS } from 'nukebg-core';
 const SAM_PARAMS = {
   INPUT_SIZE: 1024,
   MASK_SIZE: 256,

--- a/packages/nukebg-app/tests/cv/lama-crop.test.ts
+++ b/packages/nukebg-app/tests/cv/lama-crop.test.ts
@@ -5,7 +5,7 @@ import {
   nearestResizeMask,
   spliceLamaOutput,
 } from '../../src/workers/cv/lama-crop';
-import { LAMA_PARAMS } from '../../src/pipeline/constants';
+import { LAMA_PARAMS } from 'nukebg-core';
 
 function makeMask(
   w: number,

--- a/packages/nukebg-app/tests/cv/lama-router.test.ts
+++ b/packages/nukebg-app/tests/cv/lama-router.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { shouldUseLama } from '../../src/workers/cv/lama-router';
-import { LAMA_ROUTER_PARAMS } from '../../src/pipeline/constants';
+import { LAMA_ROUTER_PARAMS } from 'nukebg-core';
 
 /** Solid-color RGBA canvas. */
 function solid(w: number, h: number, gray: number): Uint8ClampedArray {

--- a/packages/nukebg-app/tests/integration.test.ts
+++ b/packages/nukebg-app/tests/integration.test.ts
@@ -7,7 +7,7 @@ import { subjectExclusion } from '../src/workers/cv/subject-exclusion';
 import { watermarkDetect } from '../src/workers/cv/watermark-detect';
 import { shadowCleanup } from '../src/workers/cv/shadow-cleanup';
 import { alphaRefine } from '../src/workers/cv/alpha-refine';
-import { CV_PARAMS } from '../src/pipeline/constants';
+import { CV_PARAMS } from 'nukebg-core';
 import { solidImage, checkerboardImage, paintRect } from './helpers';
 
 /**

--- a/packages/nukebg-app/tests/pipeline/model-integrity.test.ts
+++ b/packages/nukebg-app/tests/pipeline/model-integrity.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { LAMA_PARAMS, MOBILESAM_PARAMS, RMBG_PARAMS } from '../../src/pipeline/constants';
+import { LAMA_PARAMS, MOBILESAM_PARAMS, RMBG_PARAMS } from 'nukebg-core';
 
 /**
  * Supply-chain hardening (#132): every model loaded by the app must be

--- a/packages/nukebg-app/tests/pipeline/orchestrator.test.ts
+++ b/packages/nukebg-app/tests/pipeline/orchestrator.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { CV_PARAMS } from '../../src/pipeline/constants';
+import { CV_PARAMS } from 'nukebg-core';
 
 /**
  * Pipeline orchestrator tests.

--- a/packages/nukebg-app/tests/utils/final-composite.test.ts
+++ b/packages/nukebg-app/tests/utils/final-composite.test.ts
@@ -22,7 +22,7 @@ import {
   composeAtOriginal,
   refineUpscaledAlpha,
 } from '../../src/utils/final-composite';
-import { EDGE_REFINE_PARAMS } from '../../src/pipeline/constants';
+import { EDGE_REFINE_PARAMS } from 'nukebg-core';
 
 describe('bilinearUpscaleU8', () => {
   it('returns a copy when sizes match', () => {

--- a/packages/nukebg-app/tests/visual-validation.test.ts
+++ b/packages/nukebg-app/tests/visual-validation.test.ts
@@ -7,7 +7,7 @@ import { simpleFloodFill } from '../src/workers/cv/simple-flood-fill';
 import { watermarkDetect } from '../src/workers/cv/watermark-detect';
 import { shadowCleanup } from '../src/workers/cv/shadow-cleanup';
 import { alphaRefine } from '../src/workers/cv/alpha-refine';
-import { CV_PARAMS } from '../src/pipeline/constants';
+import { CV_PARAMS } from 'nukebg-core';
 import { solidImage, checkerboardImage, paintRect } from './helpers';
 
 /**

--- a/packages/nukebg-app/tests/workers/cv/watermark-dalle.test.ts
+++ b/packages/nukebg-app/tests/workers/cv/watermark-dalle.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { watermarkDetectDalle } from '../../../src/workers/cv/watermark-dalle';
-import { DALLE_WATERMARK_PARAMS } from '../../../src/pipeline/constants';
+import { DALLE_WATERMARK_PARAMS } from 'nukebg-core';
 
 /**
  * Behavioural tests for watermarkDetectDalle (#195).

--- a/packages/nukebg-app/tsconfig.json
+++ b/packages/nukebg-app/tsconfig.json
@@ -15,8 +15,10 @@
     "resolveJsonModule": true,
     "isolatedModules": true,
     "sourceMap": true,
-    "composite": true,
-    "outDir": "./dist"
+    "paths": {
+      "nukebg-core": ["../nukebg-core/src/index.ts"],
+      "nukebg-core/*": ["../nukebg-core/src/*"]
+    }
   },
   "include": ["src/**/*.ts", "tests/**/*.ts"],
   "exclude": ["node_modules", "dist"]

--- a/packages/nukebg-app/vite.config.ts
+++ b/packages/nukebg-app/vite.config.ts
@@ -1,7 +1,18 @@
 /// <reference types="vitest/config" />
 import { defineConfig } from 'vite';
+import { fileURLToPath } from 'node:url';
+import { resolve } from 'node:path';
+
+const __dirname = fileURLToPath(new URL('.', import.meta.url));
 
 export default defineConfig({
+  resolve: {
+    alias: {
+      // Resolve nukebg-core to its TypeScript source during dev and test
+      // so we don't need a prior `tsc -b` build step.
+      'nukebg-core': resolve(__dirname, '../nukebg-core/src/index.ts'),
+    },
+  },
   build: {
     target: 'es2022',
     outDir: 'dist',

--- a/packages/nukebg-core/src/index.ts
+++ b/packages/nukebg-core/src/index.ts
@@ -33,3 +33,25 @@ export {
   DecodeError,
   PipelineAbortError,
 } from './pipeline/errors.js';
+
+// Constants (read-only)
+export {
+  CV_PARAMS,
+  WATERMARK_PARAMS,
+  SPARKLE_PARAMS,
+  DALLE_WATERMARK_PARAMS,
+  SHADOW_PARAMS,
+  ALPHA_PARAMS,
+  EDGE_REFINE_PARAMS,
+  PATCHMATCH_PARAMS,
+  INPAINT_PARAMS,
+  LAMA_PARAMS,
+  LAMA_ROUTER_PARAMS,
+  REFINE_PARAMS,
+  PRECISION_PROFILES,
+  IMAGE_CLASSIFY_PARAMS,
+  MOBILESAM_PARAMS,
+  RMBG_PARAMS,
+  type PrecisionMode,
+  type PrecisionProfile,
+} from './pipeline/constants.js';

--- a/packages/nukebg-core/src/index.ts
+++ b/packages/nukebg-core/src/index.ts
@@ -1,1 +1,35 @@
 // nukebg-core public API — populated in Phase 3+
+
+// Types
+export type { ImageDataLike } from './types/image-data-like.js';
+export { createImageDataLike } from './types/image-data-like.js';
+export type { PipelineMode, PipelinePrecision, PipelineOptions } from './types/pipeline-options.js';
+export type {
+  PipelineResult,
+  PipelineStage,
+  StageStatus,
+  StageEvent,
+  ImageContentType,
+} from './types/pipeline-result.js';
+export type {
+  BgColorResult,
+  WatermarkResult,
+  ClassifyImageResult,
+  ImageFeatures,
+  GridResult,
+} from './types/cv-results.js';
+
+// Runner interfaces — the runtime seams
+export type { PipelineRunner } from './runners/pipeline-runner.js';
+export type { RmbgRunner, RmbgRefineOptions } from './runners/rmbg-runner.js';
+export type { LamaRunner } from './runners/lama-runner.js';
+export type { ImageCodec, EncodeFormat } from './runners/image-codec.js';
+
+// Error classes
+export {
+  NukebgError,
+  RmbgError,
+  LamaError,
+  DecodeError,
+  PipelineAbortError,
+} from './pipeline/errors.js';

--- a/packages/nukebg-core/src/pipeline/constants.ts
+++ b/packages/nukebg-core/src/pipeline/constants.ts
@@ -102,8 +102,8 @@ export const ALPHA_PARAMS = {
  * quintic sharpen lands on the correct pixel.
  *
  * Only applied when a downscale actually occurred (working res < original).
- * The filter is restricted to the trimap band: pixels at α ≤ BAND_LO or
- * α ≥ BAND_HI are passed through verbatim so pure background and pure body
+ * The filter is restricted to the trimap band: pixels at alpha <= BAND_LO or
+ * alpha >= BAND_HI are passed through verbatim so pure background and pure body
  * never drift.
  */
 export const EDGE_REFINE_PARAMS = {
@@ -114,14 +114,14 @@ export const EDGE_REFINE_PARAMS = {
   /** Regularization — small value = stronger structure transfer from the
    *  guide (snap the alpha edge to RGB gradient). Higher = more smoothing. */
   EPSILON: 1e-3,
-  /** Pixels with α ≤ this are kept verbatim (true background). */
+  /** Pixels with alpha <= this are kept verbatim (true background). */
   BAND_LO: 10,
-  /** Pixels with α ≥ this are kept verbatim (true foreground body). */
+  /** Pixels with alpha >= this are kept verbatim (true foreground body). */
   BAND_HI: 245,
 } as const;
 
 export const PATCHMATCH_PARAMS = {
-  /** Patch radius (pixels). 3 → 7×7 patches, the Barnes 2009 sweet-spot
+  /** Patch radius (pixels). 3 -> 7x7 patches, the Barnes 2009 sweet-spot
    *  for texture reconstruction on natural photos. */
   PATCH_RADIUS: 3,
   /** Number of propagation + random-search + voting iterations.
@@ -180,24 +180,24 @@ export const LAMA_PARAMS = {
    *  tight and the reconstruction looks flat. */
   CROP_PADDING: 48,
   /** Minimum square side (in original-image scale) the crop expands
-   *  to if the mask bbox is tiny. Prevents degenerate 20×20 crops
+   *  to if the mask bbox is tiny. Prevents degenerate 20x20 crops
    *  that blow up to 512 and produce mush. */
   MIN_CROP_SIDE: 128,
   /** Feather radius used when compositing the inpainted region back
-   *  into the untouched image. Must be ≥ INPAINT_PARAMS.FEATHER_RADIUS
+   *  into the untouched image. Must be >= INPAINT_PARAMS.FEATHER_RADIUS
    *  so the LaMa-reconstructed core blends as softly as PatchMatch. */
   COMPOSITE_FEATHER: 6,
 } as const;
 
 /** Heuristic that decides whether a detected watermark lives over
- *  structured content (→ LaMa) or uniform background (→ PatchMatch).
+ *  structured content (-> LaMa) or uniform background (-> PatchMatch).
  *  Tuned against real photos with Gemini sparkles / DALL-E bars. */
 export const LAMA_ROUTER_PARAMS = {
-  /** Luminance variance over the mask-bbox sample. Above this → content
+  /** Luminance variance over the mask-bbox sample. Above this -> content
    *  has texture/gradient worth reconstructing with the model. Uniform
    *  sky/wall typically sits around 50-150. */
   VARIANCE_THRESHOLD: 350,
-  /** Mean Sobel gradient magnitude over the sample. Above this → edges
+  /** Mean Sobel gradient magnitude over the sample. Above this -> edges
    *  are present (object outlines, text, rivets). Flat zones score near 0. */
   EDGE_DENSITY_THRESHOLD: 20,
   /** Pixels added around the raw mask bbox when sampling the heuristic.

--- a/packages/nukebg-core/src/pipeline/errors.ts
+++ b/packages/nukebg-core/src/pipeline/errors.ts
@@ -1,0 +1,71 @@
+/**
+ * Base error class for all nukebg-core errors.
+ * Every error carries a discriminating `code` string (REQ-CORE-RUNNERS-5).
+ */
+export class NukebgError extends Error {
+  readonly code: string;
+
+  constructor(message: string, code: string, opts?: { cause?: unknown }) {
+    super(message, opts as ErrorOptions);
+    this.code = code;
+    this.name = 'NukebgError';
+
+    // Fix prototype chain for environments where extending built-ins breaks instanceof
+    Object.setPrototypeOf(this, new.target.prototype);
+  }
+}
+
+interface ErrorSubclassOpts {
+  cause?: unknown;
+  /** Override the default code. */
+  code?: string;
+}
+
+/**
+ * Thrown when the RMBG segmentation model fails.
+ * Default code: "RMBG_FAILED" (REQ-CORE-PIPELINE-4).
+ */
+export class RmbgError extends NukebgError {
+  constructor(message: string, opts?: ErrorSubclassOpts) {
+    super(message, opts?.code ?? 'RMBG_FAILED', opts?.cause !== undefined ? { cause: opts.cause } : undefined);
+    this.name = 'RmbgError';
+    Object.setPrototypeOf(this, new.target.prototype);
+  }
+}
+
+/**
+ * Thrown when the LaMa inpainting model fails.
+ * Default code: "LAMA_FAILED" (REQ-CORE-PIPELINE-4).
+ */
+export class LamaError extends NukebgError {
+  constructor(message: string, opts?: ErrorSubclassOpts) {
+    super(message, opts?.code ?? 'LAMA_FAILED', opts?.cause !== undefined ? { cause: opts.cause } : undefined);
+    this.name = 'LamaError';
+    Object.setPrototypeOf(this, new.target.prototype);
+  }
+}
+
+/**
+ * Thrown when the codec cannot decode input bytes.
+ * Default code: "DECODE_FAILED" (REQ-CORE-PIPELINE-4).
+ */
+export class DecodeError extends NukebgError {
+  constructor(message: string, opts?: ErrorSubclassOpts) {
+    super(message, opts?.code ?? 'DECODE_FAILED', opts?.cause !== undefined ? { cause: opts.cause } : undefined);
+    this.name = 'DecodeError';
+    Object.setPrototypeOf(this, new.target.prototype);
+  }
+}
+
+/**
+ * Thrown when an AbortSignal fires during pipeline execution.
+ * code: "PIPELINE_ABORTED" (REQ-CORE-PIPELINE-4).
+ * name: "AbortError" (REQ-CORE-PIPELINE-3 — spec requires error.name === "AbortError").
+ */
+export class PipelineAbortError extends NukebgError {
+  constructor(message: string, opts?: { cause?: unknown }) {
+    super(message, 'PIPELINE_ABORTED', opts);
+    this.name = 'AbortError';
+    Object.setPrototypeOf(this, new.target.prototype);
+  }
+}

--- a/packages/nukebg-core/src/runners/image-codec.ts
+++ b/packages/nukebg-core/src/runners/image-codec.ts
@@ -1,0 +1,31 @@
+import type { ImageDataLike } from '../types/image-data-like.js';
+
+export type EncodeFormat = 'png' | 'webp';
+
+/**
+ * I/O boundary. Decode bytes into pixels; encode pixels into bytes.
+ * Browser implementation uses createImageBitmap+OffscreenCanvas.
+ * Node implementation uses sharp.
+ */
+export interface ImageCodec {
+  /**
+   * Decode a buffer into RGBA pixels. The codec MAY downscale to
+   * `maxDimension` when provided; if it does, it MUST report the
+   * original dimensions.
+   */
+  decode(
+    bytes: Uint8Array | ArrayBufferView,
+    opts?: { maxDimension?: number },
+  ): Promise<{
+    image: ImageDataLike;
+    originalWidth: number;
+    originalHeight: number;
+    wasDownsampled: boolean;
+  }>;
+
+  encode(
+    image: ImageDataLike,
+    format: EncodeFormat,
+    opts?: { quality?: number },
+  ): Promise<Uint8Array>;
+}

--- a/packages/nukebg-core/src/runners/lama-runner.ts
+++ b/packages/nukebg-core/src/runners/lama-runner.ts
@@ -1,0 +1,18 @@
+import type { ImageDataLike } from '../types/image-data-like.js';
+
+/**
+ * LaMa ONNX inpainting runner. Takes RGBA pixels + a binary mask
+ * (0=keep, 1=inpaint) and returns RGBA pixels with the masked region
+ * reconstructed. Same dimensions on input and output.
+ */
+export interface LamaRunner {
+  load?(opts?: { signal?: AbortSignal }): Promise<void>;
+
+  inpaint(
+    input: ImageDataLike,
+    mask: Uint8Array,
+    opts?: { signal?: AbortSignal; onProgress?: (pct: number) => void },
+  ): Promise<Uint8ClampedArray>;
+
+  dispose(): Promise<void>;
+}

--- a/packages/nukebg-core/src/runners/pipeline-runner.ts
+++ b/packages/nukebg-core/src/runners/pipeline-runner.ts
@@ -1,0 +1,23 @@
+import type { ImageDataLike } from '../types/image-data-like.js';
+import type { PipelineOptions } from '../types/pipeline-options.js';
+import type { PipelineResult } from '../types/pipeline-result.js';
+
+/**
+ * Runs the full pipeline on an image. Implementations differ by HOW the
+ * stages execute (Worker-backed in browser, inline in Node) but the
+ * contract is identical.
+ */
+export interface PipelineRunner {
+  /**
+   * Process a single image end-to-end. Resolves with a frozen
+   * PipelineResult. Rejects with PipelineAbortError if `options.signal`
+   * fires, or with a regular Error on stage failure.
+   */
+  run(input: ImageDataLike, options?: PipelineOptions): Promise<PipelineResult>;
+
+  /** Pre-load any models eagerly. Optional; runners may no-op. */
+  preload?(): Promise<void>;
+
+  /** Release resources (workers, ONNX sessions, file handles). */
+  dispose(): Promise<void>;
+}

--- a/packages/nukebg-core/src/runners/rmbg-runner.ts
+++ b/packages/nukebg-core/src/runners/rmbg-runner.ts
@@ -1,0 +1,36 @@
+import type { ImageDataLike } from '../types/image-data-like.js';
+
+export interface RmbgRefineOptions {
+  readonly spatialPasses: number;
+  readonly spatialRadius: number;
+  readonly morphOpenRadius: number;
+  readonly clusterRatio: number;
+  readonly minClusterSize: number;
+}
+
+/**
+ * Background-removal model runner. Returns an alpha mask (0..255) at the
+ * same dimensions as `input`. Implementations: BrowserRmbgRunner
+ * (transformers.js + onnxruntime-web in a Worker), OnnxNodeRmbgRunner
+ * (transformers.js + onnxruntime-node in-process).
+ */
+export interface RmbgRunner {
+  /** Optional model preload. Throws on integrity failure. */
+  load?(opts?: { signal?: AbortSignal }): Promise<void>;
+
+  /**
+   * Run segmentation. Resolves with a Uint8Array of length width*height.
+   * Threshold and refine options match the existing RMBG worker contract.
+   */
+  segment(
+    input: ImageDataLike,
+    opts: {
+      threshold: number;
+      refine: RmbgRefineOptions;
+      signal?: AbortSignal;
+      onProgress?: (pct: number) => void;
+    },
+  ): Promise<Uint8Array>;
+
+  dispose(): Promise<void>;
+}

--- a/packages/nukebg-core/src/types/cv-results.ts
+++ b/packages/nukebg-core/src/types/cv-results.ts
@@ -1,0 +1,38 @@
+import type { ImageContentType } from './pipeline-result.js';
+
+/** Result from background color detection */
+export interface BgColorResult {
+  colorA: number[]; // RGB, 3 values
+  colorB: number[]; // RGB, 3 values
+  isCheckerboard: boolean;
+  cornerVariance: number;
+}
+
+/** Result from watermark detection */
+export interface WatermarkResult {
+  detected: boolean;
+  mask: Uint8Array | null;
+  centerX?: number;
+  centerY?: number;
+  radius?: number;
+}
+
+/** Result from image classification */
+export interface ClassifyImageResult {
+  type: ImageContentType;
+  confidence: number;
+}
+
+/** Extracted image features used for classification */
+export interface ImageFeatures {
+  edgeDensity: number;
+  colorVariance: number;
+  centerMass: { x: number; y: number };
+  hasTransparency: boolean;
+}
+
+/** Result from checker grid detection */
+export interface GridResult {
+  gridSize: number;
+  phase: number;
+}

--- a/packages/nukebg-core/src/types/image-data-like.ts
+++ b/packages/nukebg-core/src/types/image-data-like.ts
@@ -1,0 +1,16 @@
+export interface ImageDataLike {
+  readonly data: Uint8ClampedArray;
+  readonly width: number;
+  readonly height: number;
+  /** Optional: present when constructed by the browser ImageData constructor. Core never reads it. */
+  readonly colorSpace?: 'srgb' | 'display-p3';
+}
+
+/** Construct an ImageDataLike from raw pixels. Use this instead of `new ImageData(...)` in core. */
+export function createImageDataLike(
+  data: Uint8ClampedArray,
+  width: number,
+  height: number,
+): ImageDataLike {
+  return { data, width, height };
+}

--- a/packages/nukebg-core/src/types/pipeline-options.ts
+++ b/packages/nukebg-core/src/types/pipeline-options.ts
@@ -1,0 +1,17 @@
+import type { StageEvent } from './pipeline-result.js';
+
+export type PipelineMode = 'photo' | 'signature' | 'icon' | 'auto';
+export type PipelinePrecision = 'low' | 'normal' | 'high' | 'ultra';
+
+export interface PipelineOptions {
+  /** Default 'auto' (let the classifier decide) */
+  readonly mode?: PipelineMode;
+  /** Default 'normal' */
+  readonly precision?: PipelinePrecision;
+  /** Skip watermark detection + inpainting. Default false. */
+  readonly skipWatermark?: boolean;
+  /** Cancellation. */
+  readonly signal?: AbortSignal;
+  /** Stage event sink. Optional. */
+  readonly onStage?: (event: StageEvent) => void;
+}

--- a/packages/nukebg-core/src/types/pipeline-result.ts
+++ b/packages/nukebg-core/src/types/pipeline-result.ts
@@ -1,0 +1,46 @@
+import type { ImageDataLike } from './image-data-like.js';
+
+/** Image content type for auto-algorithm selection */
+export type ImageContentType = 'PHOTO' | 'SIGNATURE' | 'ICON';
+
+/** Stage identifiers for progress reporting */
+export type PipelineStage = 'detect-background' | 'ml-segmentation' | 'watermark-scan' | 'inpaint';
+
+export type StageStatus = 'running' | 'done' | 'skipped' | 'error';
+
+export interface StageEvent {
+  stage: PipelineStage;
+  status: StageStatus;
+  message?: string;
+}
+
+/**
+ * Pipeline output from `runPipeline`. Uses `ImageDataLike` so it is compatible
+ * with both the browser's native `ImageData` and plain objects produced by
+ * `createImageDataLike` in Node environments.
+ */
+export interface PipelineResult {
+  /** Processed image with alpha channel */
+  readonly output: ImageDataLike;
+  /** The resolved content type — always one of photo / signature / icon */
+  readonly resolvedMode: 'photo' | 'signature' | 'icon';
+  /** Total wall-clock time from function entry to resolution in ms */
+  readonly durationMs: number;
+  /**
+   * Per-stage timing in ms. MUST contain at least the keys:
+   * "watermark", "rmbg", "inpaint", "finalize"
+   */
+  readonly stageTimings: Record<string, number>;
+  /** Whether watermark was found and removed */
+  readonly watermarkRemoved: boolean;
+  /** Watermark mask at working resolution (0 or 1), if inpainting happened */
+  readonly watermarkMask: Uint8Array | null;
+  /** Working pixel buffer (possibly inpainted) */
+  readonly workingPixels: Uint8ClampedArray;
+  /** Alpha mask (0..255) */
+  readonly workingAlpha: Uint8Array;
+  /** Percentage of pixels made transparent */
+  readonly nukedPct: number;
+  /** Detected content type */
+  readonly contentType: ImageContentType;
+}

--- a/packages/nukebg-core/tests/pipeline/constants.test.ts
+++ b/packages/nukebg-core/tests/pipeline/constants.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
-import { PRECISION_PROFILES, REFINE_PARAMS } from 'nukebg-core';
-import type { PrecisionMode, PrecisionProfile } from 'nukebg-core';
+import { PRECISION_PROFILES, REFINE_PARAMS } from '../../src/pipeline/constants.js';
+import type { PrecisionMode, PrecisionProfile } from '../../src/pipeline/constants.js';
 
 describe('PrecisionProfiles', () => {
   const modes: PrecisionMode[] = ['low-power', 'normal', 'high-power', 'full-nuke'];

--- a/packages/nukebg-core/tests/pipeline/errors.test.ts
+++ b/packages/nukebg-core/tests/pipeline/errors.test.ts
@@ -1,0 +1,139 @@
+import { describe, it, expect } from 'vitest';
+import {
+  NukebgError,
+  RmbgError,
+  LamaError,
+  DecodeError,
+  PipelineAbortError,
+} from '../../src/pipeline/errors.js';
+
+describe('Error classes (REQ-CORE-RUNNERS-5, REQ-CORE-PIPELINE-4)', () => {
+  describe('NukebgError base class', () => {
+    it('is an instance of Error', () => {
+      const err = new NukebgError('test', 'TEST_CODE');
+      expect(err).toBeInstanceOf(Error);
+    });
+
+    it('has a code property', () => {
+      const err = new NukebgError('test message', 'MY_CODE');
+      expect(err.code).toBe('MY_CODE');
+    });
+
+    it('has the correct message', () => {
+      const err = new NukebgError('something went wrong', 'ERR');
+      expect(err.message).toBe('something went wrong');
+    });
+
+    it('is an instance of NukebgError', () => {
+      const err = new NukebgError('test', 'CODE');
+      expect(err).toBeInstanceOf(NukebgError);
+    });
+
+    it('preserves cause via options', () => {
+      const cause = new Error('original');
+      const err = new NukebgError('wrapped', 'CODE', { cause });
+      expect(err.cause).toBe(cause);
+    });
+  });
+
+  describe('RmbgError', () => {
+    it('is an instance of NukebgError (REQ-CORE-RUNNERS-5)', () => {
+      const err = new RmbgError('rmbg failed');
+      expect(err).toBeInstanceOf(NukebgError);
+    });
+
+    it('is an instance of Error', () => {
+      const err = new RmbgError('rmbg failed');
+      expect(err).toBeInstanceOf(Error);
+    });
+
+    it('has code "RMBG_FAILED" by default (REQ-CORE-PIPELINE-4)', () => {
+      const err = new RmbgError('rmbg failed');
+      expect(err.code).toBe('RMBG_FAILED');
+    });
+
+    it('preserves cause', () => {
+      const cause = new Error('original runner error');
+      const err = new RmbgError('rmbg failed', { cause });
+      expect(err.cause).toBe(cause);
+    });
+
+    it('accepts a custom code override', () => {
+      const err = new RmbgError('integrity check failed', { code: 'RMBG_INTEGRITY_FAILED' });
+      expect(err.code).toBe('RMBG_INTEGRITY_FAILED');
+    });
+  });
+
+  describe('LamaError', () => {
+    it('is an instance of NukebgError (REQ-CORE-RUNNERS-5)', () => {
+      const err = new LamaError('lama failed');
+      expect(err).toBeInstanceOf(NukebgError);
+    });
+
+    it('has code "LAMA_FAILED" by default (REQ-CORE-PIPELINE-4)', () => {
+      const err = new LamaError('lama failed');
+      expect(err.code).toBe('LAMA_FAILED');
+    });
+
+    it('preserves cause', () => {
+      const cause = new Error('network error');
+      const err = new LamaError('download failed', { cause });
+      expect(err.cause).toBe(cause);
+    });
+
+    it('accepts LAMA_DOWNLOAD_FAILED code', () => {
+      const err = new LamaError('download failed', { code: 'LAMA_DOWNLOAD_FAILED' });
+      expect(err.code).toBe('LAMA_DOWNLOAD_FAILED');
+    });
+  });
+
+  describe('DecodeError', () => {
+    it('is an instance of NukebgError (REQ-CORE-RUNNERS-5)', () => {
+      const err = new DecodeError('cannot decode');
+      expect(err).toBeInstanceOf(NukebgError);
+    });
+
+    it('has code "DECODE_FAILED" by default (REQ-CORE-PIPELINE-4)', () => {
+      const err = new DecodeError('cannot decode');
+      expect(err.code).toBe('DECODE_FAILED');
+    });
+
+    it('preserves cause', () => {
+      const cause = new Error('raw decode error');
+      const err = new DecodeError('decode failed', { cause });
+      expect(err.cause).toBe(cause);
+    });
+  });
+
+  describe('PipelineAbortError', () => {
+    it('is an instance of NukebgError (REQ-CORE-RUNNERS-5)', () => {
+      const err = new PipelineAbortError('aborted');
+      expect(err).toBeInstanceOf(NukebgError);
+    });
+
+    it('has code "PIPELINE_ABORTED" (REQ-CORE-PIPELINE-4)', () => {
+      const err = new PipelineAbortError('aborted');
+      expect(err.code).toBe('PIPELINE_ABORTED');
+    });
+
+    it('has name "AbortError" (REQ-CORE-PIPELINE-3)', () => {
+      const err = new PipelineAbortError('aborted');
+      expect(err.name).toBe('AbortError');
+    });
+  });
+
+  describe('instanceof NukebgError for ALL subclasses (REQ-CORE-RUNNERS-5)', () => {
+    it('every subclass passes instanceof NukebgError check', () => {
+      const errors = [
+        new RmbgError('r'),
+        new LamaError('l'),
+        new DecodeError('d'),
+        new PipelineAbortError('p'),
+      ];
+
+      for (const err of errors) {
+        expect(err).toBeInstanceOf(NukebgError);
+      }
+    });
+  });
+});

--- a/packages/nukebg-core/tests/runners/interfaces.test.ts
+++ b/packages/nukebg-core/tests/runners/interfaces.test.ts
@@ -1,0 +1,153 @@
+import { describe, it, expect } from 'vitest';
+import type { PipelineRunner } from '../../src/runners/pipeline-runner.js';
+import type { RmbgRunner, RmbgRefineOptions } from '../../src/runners/rmbg-runner.js';
+import type { LamaRunner } from '../../src/runners/lama-runner.js';
+import type { ImageCodec, EncodeFormat } from '../../src/runners/image-codec.js';
+import { createImageDataLike } from '../../src/types/image-data-like.js';
+
+describe('Runner interface structural compliance (REQ-CORE-RUNNERS-1 through 4)', () => {
+  const makeImageDataLike = () => createImageDataLike(new Uint8ClampedArray(4), 1, 1);
+
+  describe('RmbgRunner (REQ-CORE-RUNNERS-1)', () => {
+    it('an object literal satisfying RmbgRunner compiles without error', () => {
+      const refineOpts: RmbgRefineOptions = {
+        spatialPasses: 3,
+        spatialRadius: 5,
+        morphOpenRadius: 2,
+        clusterRatio: 0.5,
+        minClusterSize: 10,
+      };
+
+      const runner: RmbgRunner = {
+        segment: async (_input, _opts) => new Uint8Array(1),
+        dispose: async () => undefined,
+      };
+
+      expect(typeof runner.segment).toBe('function');
+      expect(typeof runner.dispose).toBe('function');
+      void refineOpts;
+    });
+
+    it('RmbgRunner.load is optional', () => {
+      // No load property — still satisfies interface
+      const runner: RmbgRunner = {
+        segment: async (_input, _opts) => new Uint8Array(1),
+        dispose: async () => undefined,
+      };
+
+      expect(runner.load).toBeUndefined();
+    });
+
+    it('RmbgRunner with load included compiles fine', () => {
+      const runner: RmbgRunner = {
+        load: async () => undefined,
+        segment: async (_input, _opts) => new Uint8Array(1),
+        dispose: async () => undefined,
+      };
+
+      expect(typeof runner.load).toBe('function');
+    });
+
+    it('RmbgRefineOptions has all required fields', () => {
+      const opts: RmbgRefineOptions = {
+        spatialPasses: 2,
+        spatialRadius: 3,
+        morphOpenRadius: 1,
+        clusterRatio: 0.8,
+        minClusterSize: 5,
+      };
+
+      expect(opts.spatialPasses).toBe(2);
+      expect(opts.spatialRadius).toBe(3);
+      expect(opts.morphOpenRadius).toBe(1);
+      expect(opts.clusterRatio).toBe(0.8);
+      expect(opts.minClusterSize).toBe(5);
+    });
+  });
+
+  describe('LamaRunner (REQ-CORE-RUNNERS-2)', () => {
+    it('an object literal satisfying LamaRunner compiles without error', () => {
+      const runner: LamaRunner = {
+        inpaint: async (_input, _mask) => new Uint8ClampedArray(4),
+        dispose: async () => undefined,
+      };
+
+      expect(typeof runner.inpaint).toBe('function');
+      expect(typeof runner.dispose).toBe('function');
+    });
+
+    it('LamaRunner.load is optional', () => {
+      const runner: LamaRunner = {
+        inpaint: async (_input, _mask) => new Uint8ClampedArray(4),
+        dispose: async () => undefined,
+      };
+
+      expect(runner.load).toBeUndefined();
+    });
+  });
+
+  describe('ImageCodec (REQ-CORE-RUNNERS-3)', () => {
+    it('an object literal satisfying ImageCodec compiles without error', () => {
+      const codec: ImageCodec = {
+        decode: async (_bytes) => ({
+          image: makeImageDataLike(),
+          originalWidth: 1,
+          originalHeight: 1,
+          wasDownsampled: false,
+        }),
+        encode: async (_image, _format) => new Uint8Array(0),
+      };
+
+      expect(typeof codec.decode).toBe('function');
+      expect(typeof codec.encode).toBe('function');
+    });
+
+    it('EncodeFormat accepts png and webp', () => {
+      const formats: EncodeFormat[] = ['png', 'webp'];
+      expect(formats).toHaveLength(2);
+    });
+  });
+
+  describe('PipelineRunner (REQ-CORE-RUNNERS-4)', () => {
+    it('an object literal satisfying PipelineRunner compiles without error', () => {
+      const runner: PipelineRunner = {
+        run: async (_input, _opts) => ({
+          output: makeImageDataLike(),
+          resolvedMode: 'photo',
+          durationMs: 100,
+          stageTimings: { watermark: 0, rmbg: 100, inpaint: 0, finalize: 0 },
+          watermarkRemoved: false,
+          watermarkMask: null,
+          workingPixels: new Uint8ClampedArray(4),
+          workingAlpha: new Uint8Array(1),
+          nukedPct: 0,
+          contentType: 'PHOTO',
+        }),
+        dispose: async () => undefined,
+      };
+
+      expect(typeof runner.run).toBe('function');
+      expect(typeof runner.dispose).toBe('function');
+    });
+
+    it('PipelineRunner.preload is optional', () => {
+      const runner: PipelineRunner = {
+        run: async (_input, _opts) => ({
+          output: makeImageDataLike(),
+          resolvedMode: 'photo',
+          durationMs: 0,
+          stageTimings: { watermark: 0, rmbg: 0, inpaint: 0, finalize: 0 },
+          watermarkRemoved: false,
+          watermarkMask: null,
+          workingPixels: new Uint8ClampedArray(4),
+          workingAlpha: new Uint8Array(1),
+          nukedPct: 0,
+          contentType: 'PHOTO',
+        }),
+        dispose: async () => undefined,
+      };
+
+      expect(runner.preload).toBeUndefined();
+    });
+  });
+});

--- a/packages/nukebg-core/tests/types/cv-results.test.ts
+++ b/packages/nukebg-core/tests/types/cv-results.test.ts
@@ -1,0 +1,127 @@
+import { describe, it, expect } from 'vitest';
+import type {
+  BgColorResult,
+  WatermarkResult,
+  ClassifyImageResult,
+  ImageFeatures,
+  GridResult,
+} from '../../src/types/cv-results.js';
+
+describe('cv-results types', () => {
+  describe('BgColorResult', () => {
+    it('has colorA, colorB as RGB arrays, isCheckerboard boolean, cornerVariance number', () => {
+      const result: BgColorResult = {
+        colorA: [255, 255, 255],
+        colorB: [200, 200, 200],
+        isCheckerboard: false,
+        cornerVariance: 0.02,
+      };
+
+      expect(result.colorA).toHaveLength(3);
+      expect(result.colorB).toHaveLength(3);
+      expect(typeof result.isCheckerboard).toBe('boolean');
+      expect(typeof result.cornerVariance).toBe('number');
+    });
+
+    it('isCheckerboard can be true', () => {
+      const result: BgColorResult = {
+        colorA: [255, 255, 255],
+        colorB: [0, 0, 0],
+        isCheckerboard: true,
+        cornerVariance: 0.95,
+      };
+
+      expect(result.isCheckerboard).toBe(true);
+    });
+  });
+
+  describe('WatermarkResult', () => {
+    it('has detected boolean and mask field', () => {
+      const result: WatermarkResult = {
+        detected: false,
+        mask: null,
+      };
+
+      expect(result.detected).toBe(false);
+      expect(result.mask).toBeNull();
+    });
+
+    it('mask can be a Uint8Array when detected', () => {
+      const mask = new Uint8Array(100);
+      const result: WatermarkResult = {
+        detected: true,
+        mask,
+        centerX: 50,
+        centerY: 50,
+        radius: 20,
+      };
+
+      expect(result.mask).toBe(mask);
+      expect(result.centerX).toBe(50);
+      expect(result.centerY).toBe(50);
+      expect(result.radius).toBe(20);
+    });
+
+    it('optional center/radius fields can be absent', () => {
+      const result: WatermarkResult = {
+        detected: true,
+        mask: new Uint8Array(4),
+      };
+
+      expect(result.centerX).toBeUndefined();
+      expect(result.centerY).toBeUndefined();
+      expect(result.radius).toBeUndefined();
+    });
+  });
+
+  describe('ClassifyImageResult', () => {
+    it('has type field as PHOTO | SIGNATURE | ICON and confidence number', () => {
+      const result: ClassifyImageResult = {
+        type: 'PHOTO',
+        confidence: 0.92,
+      };
+
+      expect(result.type).toBe('PHOTO');
+      expect(typeof result.confidence).toBe('number');
+    });
+
+    it('type can be SIGNATURE', () => {
+      const result: ClassifyImageResult = { type: 'SIGNATURE', confidence: 0.85 };
+      expect(result.type).toBe('SIGNATURE');
+    });
+
+    it('type can be ICON', () => {
+      const result: ClassifyImageResult = { type: 'ICON', confidence: 0.77 };
+      expect(result.type).toBe('ICON');
+    });
+  });
+
+  describe('ImageFeatures', () => {
+    it('has edgeDensity, colorVariance, centerMass, hasTransparency', () => {
+      const features: ImageFeatures = {
+        edgeDensity: 0.3,
+        colorVariance: 12.5,
+        centerMass: { x: 0.5, y: 0.5 },
+        hasTransparency: false,
+      };
+
+      expect(typeof features.edgeDensity).toBe('number');
+      expect(typeof features.colorVariance).toBe('number');
+      expect(typeof features.centerMass.x).toBe('number');
+      expect(typeof features.centerMass.y).toBe('number');
+      expect(typeof features.hasTransparency).toBe('boolean');
+    });
+  });
+
+  describe('GridResult', () => {
+    it('has gridSize and phase as numbers', () => {
+      const result: GridResult = {
+        gridSize: 16,
+        phase: 0,
+      };
+
+      expect(result.gridSize).toBe(16);
+      expect(typeof result.phase).toBe('number');
+    });
+  });
+});

--- a/packages/nukebg-core/tests/types/image-data-like.test.ts
+++ b/packages/nukebg-core/tests/types/image-data-like.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect } from 'vitest';
+import { createImageDataLike } from '../../src/types/image-data-like.js';
+import type { ImageDataLike } from '../../src/types/image-data-like.js';
+
+describe('ImageDataLike', () => {
+  describe('createImageDataLike', () => {
+    it('returns a plain object with data, width, and height', () => {
+      const data = new Uint8ClampedArray([255, 0, 0, 255]);
+      const result = createImageDataLike(data, 1, 1);
+
+      expect(result).toEqual({ data, width: 1, height: 1 });
+    });
+
+    it('preserves the exact Uint8ClampedArray reference', () => {
+      const data = new Uint8ClampedArray(4 * 4 * 4);
+      const result = createImageDataLike(data, 4, 4);
+
+      expect(result.data).toBe(data);
+    });
+
+    it('sets width and height correctly', () => {
+      const data = new Uint8ClampedArray(10 * 20 * 4);
+      const result = createImageDataLike(data, 10, 20);
+
+      expect(result.width).toBe(10);
+      expect(result.height).toBe(20);
+    });
+
+    it('does NOT set colorSpace by default', () => {
+      const data = new Uint8ClampedArray(4);
+      const result = createImageDataLike(data, 1, 1);
+
+      expect('colorSpace' in result).toBe(false);
+    });
+
+    it('returns a plain object, not an ImageData instance', () => {
+      const data = new Uint8ClampedArray(4);
+      const result = createImageDataLike(data, 1, 1);
+
+      // Should be a plain object
+      expect(Object.getPrototypeOf(result)).toBe(Object.prototype);
+    });
+  });
+
+  describe('ImageDataLike interface structural compliance', () => {
+    it('a plain object with data/width/height satisfies the interface', () => {
+      const data = new Uint8ClampedArray(4);
+      // This assignment must compile without @ts-expect-error
+      const img: ImageDataLike = { data, width: 1, height: 1 };
+
+      expect(img.data).toBe(data);
+      expect(img.width).toBe(1);
+      expect(img.height).toBe(1);
+    });
+
+    it('colorSpace field is optional and accepted when present', () => {
+      const data = new Uint8ClampedArray(4);
+      // colorSpace is optional — should compile fine
+      const img: ImageDataLike = { data, width: 1, height: 1, colorSpace: 'srgb' };
+
+      expect(img.colorSpace).toBe('srgb');
+    });
+
+    it('colorSpace accepts display-p3', () => {
+      const data = new Uint8ClampedArray(4);
+      const img: ImageDataLike = { data, width: 1, height: 1, colorSpace: 'display-p3' };
+
+      expect(img.colorSpace).toBe('display-p3');
+    });
+  });
+});

--- a/packages/nukebg-core/tests/types/pipeline-options.test.ts
+++ b/packages/nukebg-core/tests/types/pipeline-options.test.ts
@@ -1,0 +1,100 @@
+import { describe, it, expect } from 'vitest';
+import type {
+  PipelineMode,
+  PipelinePrecision,
+  PipelineOptions,
+} from '../../src/types/pipeline-options.js';
+
+describe('PipelineOptions types', () => {
+  describe('PipelineMode', () => {
+    it('accepts "photo" as a valid mode', () => {
+      const mode: PipelineMode = 'photo';
+      expect(mode).toBe('photo');
+    });
+
+    it('accepts "signature" as a valid mode', () => {
+      const mode: PipelineMode = 'signature';
+      expect(mode).toBe('signature');
+    });
+
+    it('accepts "icon" as a valid mode', () => {
+      const mode: PipelineMode = 'icon';
+      expect(mode).toBe('icon');
+    });
+
+    it('accepts "auto" as a valid mode', () => {
+      const mode: PipelineMode = 'auto';
+      expect(mode).toBe('auto');
+    });
+  });
+
+  describe('PipelinePrecision', () => {
+    it('accepts "low" as a valid precision', () => {
+      const precision: PipelinePrecision = 'low';
+      expect(precision).toBe('low');
+    });
+
+    it('accepts "normal" as a valid precision', () => {
+      const precision: PipelinePrecision = 'normal';
+      expect(precision).toBe('normal');
+    });
+
+    it('accepts "high" as a valid precision', () => {
+      const precision: PipelinePrecision = 'high';
+      expect(precision).toBe('high');
+    });
+
+    it('accepts "ultra" as a valid precision', () => {
+      const precision: PipelinePrecision = 'ultra';
+      expect(precision).toBe('ultra');
+    });
+  });
+
+  describe('PipelineOptions', () => {
+    it('all fields are optional — empty object is valid', () => {
+      const opts: PipelineOptions = {};
+      expect(opts).toBeDefined();
+    });
+
+    it('accepts mode field', () => {
+      const opts: PipelineOptions = { mode: 'photo' };
+      expect(opts.mode).toBe('photo');
+    });
+
+    it('accepts precision field', () => {
+      const opts: PipelineOptions = { precision: 'high' };
+      expect(opts.precision).toBe('high');
+    });
+
+    it('accepts skipWatermark field', () => {
+      const opts: PipelineOptions = { skipWatermark: true };
+      expect(opts.skipWatermark).toBe(true);
+    });
+
+    it('accepts signal field', () => {
+      const controller = new AbortController();
+      const opts: PipelineOptions = { signal: controller.signal };
+      expect(opts.signal).toBe(controller.signal);
+    });
+
+    it('accepts onStage callback field', () => {
+      const handler = () => undefined;
+      const opts: PipelineOptions = { onStage: handler };
+      expect(opts.onStage).toBe(handler);
+    });
+
+    it('accepts all fields together', () => {
+      const controller = new AbortController();
+      const opts: PipelineOptions = {
+        mode: 'auto',
+        precision: 'normal',
+        skipWatermark: false,
+        signal: controller.signal,
+        onStage: () => undefined,
+      };
+      expect(opts.mode).toBe('auto');
+      expect(opts.precision).toBe('normal');
+      expect(opts.skipWatermark).toBe(false);
+    });
+  });
+});

--- a/packages/nukebg-core/tests/types/pipeline-result.test.ts
+++ b/packages/nukebg-core/tests/types/pipeline-result.test.ts
@@ -1,0 +1,165 @@
+import { describe, it, expect } from 'vitest';
+import type {
+  PipelineResult,
+  PipelineStage,
+  StageStatus,
+  StageEvent,
+  ImageContentType,
+} from '../../src/types/pipeline-result.js';
+import type { ImageDataLike } from '../../src/types/image-data-like.js';
+import { createImageDataLike } from '../../src/types/image-data-like.js';
+
+describe('PipelineResult types (REQ-CORE-PIPELINE-6)', () => {
+  const makeImageDataLike = (): ImageDataLike =>
+    createImageDataLike(new Uint8ClampedArray(4), 1, 1);
+
+  it('output field accepts an ImageDataLike', () => {
+    const output = makeImageDataLike();
+    const result: PipelineResult = {
+      output,
+      resolvedMode: 'photo',
+      durationMs: 100,
+      stageTimings: { watermark: 10, rmbg: 50, inpaint: 20, finalize: 20 },
+      watermarkRemoved: false,
+      watermarkMask: null,
+      workingPixels: new Uint8ClampedArray(4),
+      workingAlpha: new Uint8Array(1),
+      nukedPct: 0,
+      contentType: 'PHOTO',
+    };
+
+    expect(result.output).toBe(output);
+  });
+
+  it('resolvedMode must be one of: photo | signature | icon', () => {
+    const modes: Array<PipelineResult['resolvedMode']> = ['photo', 'signature', 'icon'];
+    for (const mode of modes) {
+      const result: PipelineResult = {
+        output: makeImageDataLike(),
+        resolvedMode: mode,
+        durationMs: 10,
+        stageTimings: { watermark: 0, rmbg: 10, inpaint: 0, finalize: 0 },
+        watermarkRemoved: false,
+        watermarkMask: null,
+        workingPixels: new Uint8ClampedArray(4),
+        workingAlpha: new Uint8Array(1),
+        nukedPct: 0,
+        contentType: 'PHOTO',
+      };
+      expect(['photo', 'signature', 'icon']).toContain(result.resolvedMode);
+    }
+  });
+
+  it('durationMs is a number (REQ-CORE-PIPELINE-6)', () => {
+    const result: PipelineResult = {
+      output: makeImageDataLike(),
+      resolvedMode: 'photo',
+      durationMs: 250.5,
+      stageTimings: { watermark: 0, rmbg: 250, inpaint: 0, finalize: 0 },
+      watermarkRemoved: false,
+      watermarkMask: null,
+      workingPixels: new Uint8ClampedArray(4),
+      workingAlpha: new Uint8Array(1),
+      nukedPct: 0,
+      contentType: 'PHOTO',
+    };
+
+    expect(typeof result.durationMs).toBe('number');
+    expect(result.durationMs).toBeGreaterThanOrEqual(0);
+  });
+
+  it('stageTimings contains the four required keys (REQ-CORE-PIPELINE-6)', () => {
+    const result: PipelineResult = {
+      output: makeImageDataLike(),
+      resolvedMode: 'photo',
+      durationMs: 100,
+      stageTimings: {
+        watermark: 10,
+        rmbg: 60,
+        inpaint: 15,
+        finalize: 15,
+      },
+      watermarkRemoved: false,
+      watermarkMask: null,
+      workingPixels: new Uint8ClampedArray(4),
+      workingAlpha: new Uint8Array(1),
+      nukedPct: 0,
+      contentType: 'PHOTO',
+    };
+
+    expect(result.stageTimings).toHaveProperty('watermark');
+    expect(result.stageTimings).toHaveProperty('rmbg');
+    expect(result.stageTimings).toHaveProperty('inpaint');
+    expect(result.stageTimings).toHaveProperty('finalize');
+    expect(typeof result.stageTimings['watermark']).toBe('number');
+    expect(typeof result.stageTimings['rmbg']).toBe('number');
+    expect(typeof result.stageTimings['inpaint']).toBe('number');
+    expect(typeof result.stageTimings['finalize']).toBe('number');
+  });
+
+  it('stageTimings values are non-negative numbers', () => {
+    const timings = { watermark: 5.2, rmbg: 80.1, inpaint: 0, finalize: 12.7 };
+    const result: PipelineResult = {
+      output: makeImageDataLike(),
+      resolvedMode: 'signature',
+      durationMs: 98,
+      stageTimings: timings,
+      watermarkRemoved: false,
+      watermarkMask: null,
+      workingPixels: new Uint8ClampedArray(4),
+      workingAlpha: new Uint8Array(1),
+      nukedPct: 50,
+      contentType: 'SIGNATURE',
+    };
+
+    for (const [key, val] of Object.entries(result.stageTimings)) {
+      expect(typeof val).toBe('number');
+      expect(val).toBeGreaterThanOrEqual(0);
+      void key;
+    }
+  });
+
+  describe('PipelineStage type', () => {
+    it('accepts valid stage identifiers', () => {
+      const stages: PipelineStage[] = [
+        'detect-background',
+        'ml-segmentation',
+        'watermark-scan',
+        'inpaint',
+      ];
+      expect(stages).toHaveLength(4);
+    });
+  });
+
+  describe('StageStatus type', () => {
+    it('accepts valid status values', () => {
+      const statuses: StageStatus[] = ['running', 'done', 'skipped', 'error'];
+      expect(statuses).toHaveLength(4);
+    });
+  });
+
+  describe('StageEvent interface', () => {
+    it('stage and status are required, message is optional', () => {
+      const event: StageEvent = { stage: 'ml-segmentation', status: 'running' };
+      expect(event.stage).toBe('ml-segmentation');
+      expect(event.status).toBe('running');
+      expect(event.message).toBeUndefined();
+    });
+
+    it('accepts message when provided', () => {
+      const event: StageEvent = {
+        stage: 'watermark-scan',
+        status: 'done',
+        message: 'Watermark detected',
+      };
+      expect(event.message).toBe('Watermark detected');
+    });
+  });
+
+  describe('ImageContentType type', () => {
+    it('accepts PHOTO, SIGNATURE, ICON', () => {
+      const types: ImageContentType[] = ['PHOTO', 'SIGNATURE', 'ICON'];
+      expect(types).toHaveLength(3);
+    });
+  });
+});

--- a/packages/nukebg-core/tsconfig.json
+++ b/packages/nukebg-core/tsconfig.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "composite": true,
     "outDir": "./dist",
-    "rootDir": "./src"
+    "rootDir": "./src",
+    "ignoreDeprecations": "6.0"
   },
   "include": ["src/**/*.ts"],
   "exclude": ["node_modules", "dist"]

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,6 @@
 {
   "files": [],
   "references": [
-    { "path": "./packages/nukebg-app" },
     { "path": "./packages/nukebg-core" },
     { "path": "./packages/nukebg-cli" }
   ]


### PR DESCRIPTION
## Summary

Phase 3 of **extract-core-cli**: `nukebg-core` now exports its full type contract — **zero algorithm code**, built strict-TDD (74 new tests).

- `ImageDataLike` interface + `createImageDataLike` factory (no `new ImageData()` — the runtime-agnostic data contract)
- `PipelineOptions` / `PipelineMode` / `PipelinePrecision`, `PipelineResult`, cv-results types (`BgColorResult`, `WatermarkResult`, `ClassifyImageResult`, `ImageFeatures`, `GridResult`)
- Runner seams: `PipelineRunner`, `RmbgRunner`, `LamaRunner`, `ImageCodec`
- Error hierarchy: `NukebgError` + `RmbgError` / `LamaError` / `DecodeError` / `PipelineAbortError`

## Test plan

- [x] `npm test` — 953 app + **74 new core** tests passing
- [x] `npm run typecheck` — clean
- [x] `npm run lint` — clean

## Notes / deviations from design

- Re-exports **all** error classes (design §B.1 listed only `PipelineAbortError`) so callers can `instanceof NukebgError` per REQ-CORE-RUNNERS-5.
- `PipelineResult` is enriched beyond the minimal spec shape (adds `watermarkRemoved`, `contentType`, etc.) to stay structurally compatible with the app's current result type for Phase 10.

> **Stacked PR.** Targets `refactor/extract-core-cli-phases-1-2` (#291). Rebase to `main` after #291 merges.

Closes #268

<!-- chain-context:extract-core-cli -->

## Chain Context

| Field | Value |
|-------|-------|
| Chain | extract-core-cli (17 slices) |
| Tracker PR | `feat/extract-core-cli` → `dev` — opens once #291 merges into the tracker (GitHub rejects a zero-diff PR) |
| Position | 2 of 17 |
| Base | `refactor/extract-core-cli-phases-1-2` |
| Depends on | #291 |
| Follow-up | #294 |
| Review budget | 1107 (1096 additions + 11 deletions) / 400 — `size:exception` requested |

### Chain Overview

```text
dev
 └── feat/extract-core-cli  (tracker, draft/no-merge)
      └── #291  phases 1-2 — workspaces + app move
           └── 📍 #293  phase 3 — types, runner interfaces, errors
                └── #294 … #324  (15 later slices)
```

### Autonomy

- [x] CI is expected to pass for this PR branch
- [x] This PR has one deliverable scope
- [x] This PR can be rolled back without unrelated changes
- [x] Tests, docs, or manual verification cover this unit
