### PR TITLE
refactor(core): move pipeline constants to nukebg-core (phase 4)

### DIFF
--- a/openspec/changes/extract-core-cli/tasks.md
+++ b/openspec/changes/extract-core-cli/tasks.md
@@ -127,11 +127,11 @@ _Goal: `nukebg-core` exports its type layer and `createImageDataLike` factory. N
 
 _Goal: `pipeline/constants.ts` is extracted to core so CV modules can import it in Phase 5._
 
-- [ ] 4.1 Move `packages/nukebg-app/src/pipeline/constants.ts` → `packages/nukebg-core/src/pipeline/constants.ts`. Update all imports in `packages/nukebg-app/src/` from the old path to `nukebg-core`. Co-located tests (if any reference constants directly) move to `packages/nukebg-core/tests/pipeline/constants.test.ts`. Run `npm test`, expect green.
+- [x] 4.1 Move `packages/nukebg-app/src/pipeline/constants.ts` → `packages/nukebg-core/src/pipeline/constants.ts`. Update all imports in `packages/nukebg-app/src/` from the old path to `nukebg-core`. Co-located tests (if any reference constants directly) move to `packages/nukebg-core/tests/pipeline/constants.test.ts`. Run `npm test`, expect green.
 
-- [ ] 4.2 Export constants from `packages/nukebg-core/src/index.ts` per design §B.1. Run `npm test`, expect green.
+- [x] 4.2 Export constants from `packages/nukebg-core/src/index.ts` per design §B.1. Run `npm test`, expect green.
 
-- [ ] 4.3 Verification: `npm test`, `npm run typecheck`, `npm run lint` all green. Milestone: "constants in core, app imports from `nukebg-core`".
+- [x] 4.3 Verification: `npm test`, `npm run typecheck`, `npm run lint` all green. Milestone: "constants in core, app imports from `nukebg-core`".
 
 ---
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -4243,6 +4243,7 @@
       "dependencies": {
         "@huggingface/transformers": "^3.8.1",
         "jszip": "^3.10.1",
+        "nukebg-core": "*",
         "onnxruntime-web": "^1.24.3"
       },
       "devDependencies": {

--- a/packages/nukebg-app/package.json
+++ b/packages/nukebg-app/package.json
@@ -21,6 +21,7 @@
     "format:check": "prettier --check ."
   },
   "dependencies": {
+    "nukebg-core": "*",
     "@huggingface/transformers": "^3.8.1",
     "jszip": "^3.10.1",
     "onnxruntime-web": "^1.24.3"

--- a/packages/nukebg-app/src/components/ar-editor-advanced.ts
+++ b/packages/nukebg-app/src/components/ar-editor-advanced.ts
@@ -34,7 +34,7 @@ import { SamRefiner } from '../controllers/sam-refiner';
 import { processRoi } from '../refine/roi-process';
 import { rasterizePolygon } from '../refine/roi-process';
 import { patchMatchInpaint } from '../workers/cv/patchmatch-inpaint';
-import { PATCHMATCH_PARAMS } from '../pipeline/constants';
+import { PATCHMATCH_PARAMS } from 'nukebg-core';
 import { t } from '../i18n';
 import { type Point } from './lasso-simplify';
 import { LassoModel } from '../lib/lasso-model';

--- a/packages/nukebg-app/src/pipeline/image-processor.ts
+++ b/packages/nukebg-app/src/pipeline/image-processor.ts
@@ -1,6 +1,6 @@
 import type { PipelineResult, PipelineStage, StageStatus } from '../types/pipeline';
 import type { ModelId } from '../types/worker-messages';
-import type { PrecisionMode } from './constants';
+import type { PrecisionMode } from 'nukebg-core';
 
 /**
  * Stage callback the processor invokes to surface progress to the UI.

--- a/packages/nukebg-app/src/pipeline/orchestrator.ts
+++ b/packages/nukebg-app/src/pipeline/orchestrator.ts
@@ -14,8 +14,8 @@ import type {
   ModelId,
   ClassifyImageResult,
 } from '../types/worker-messages';
-import { IMAGE_CLASSIFY_PARAMS, INPAINT_PARAMS, PRECISION_PROFILES } from './constants';
-import type { PrecisionMode } from './constants';
+import { IMAGE_CLASSIFY_PARAMS, INPAINT_PARAMS, PRECISION_PROFILES } from 'nukebg-core';
+import type { PrecisionMode } from 'nukebg-core';
 import { compositeWithFeather, dilateMask } from '../workers/cv/inpaint-blend';
 import { shouldUseLama } from '../workers/cv/lama-router';
 import { WorkerChannel } from './worker-channel';

--- a/packages/nukebg-app/src/utils/device-adaptation.ts
+++ b/packages/nukebg-app/src/utils/device-adaptation.ts
@@ -16,7 +16,7 @@
  */
 
 import { getCapability, type CapabilityTier } from './capability-detector';
-import type { PrecisionMode } from '../pipeline/constants';
+import type { PrecisionMode } from 'nukebg-core';
 
 /**
  * Map a capability tier to the precision mode that strikes the right

--- a/packages/nukebg-app/src/utils/final-composite.ts
+++ b/packages/nukebg-app/src/utils/final-composite.ts
@@ -1,5 +1,5 @@
 import { guidedFilter } from '../workers/cv/alpha-matting';
-import { EDGE_REFINE_PARAMS } from '../pipeline/constants';
+import { EDGE_REFINE_PARAMS } from 'nukebg-core';
 
 /**
  * Compose the final output at the original input resolution.

--- a/packages/nukebg-app/src/workers/cv/alpha-refine.ts
+++ b/packages/nukebg-app/src/workers/cv/alpha-refine.ts
@@ -1,4 +1,4 @@
-import { ALPHA_PARAMS } from '../../pipeline/constants';
+import { ALPHA_PARAMS } from 'nukebg-core';
 
 /**
  * Refine alpha channel: median filter + gaussian blur + threshold.

--- a/packages/nukebg-app/src/workers/cv/classify-image.ts
+++ b/packages/nukebg-app/src/workers/cv/classify-image.ts
@@ -1,4 +1,4 @@
-import { IMAGE_CLASSIFY_PARAMS } from '../../pipeline/constants';
+import { IMAGE_CLASSIFY_PARAMS } from 'nukebg-core';
 
 /** Content type classification for auto-algorithm selection */
 export type ImageContentType = 'PHOTO' | 'SIGNATURE' | 'ICON';

--- a/packages/nukebg-app/src/workers/cv/detect-bg-colors.ts
+++ b/packages/nukebg-app/src/workers/cv/detect-bg-colors.ts
@@ -1,4 +1,4 @@
-import { CV_PARAMS } from '../../pipeline/constants';
+import { CV_PARAMS } from 'nukebg-core';
 import type { BgColorResult } from '../../types/pipeline';
 import { mean, std, median } from './utils';
 

--- a/packages/nukebg-app/src/workers/cv/detect-checker-grid.ts
+++ b/packages/nukebg-app/src/workers/cv/detect-checker-grid.ts
@@ -1,4 +1,4 @@
-import { CV_PARAMS } from '../../pipeline/constants';
+import { CV_PARAMS } from 'nukebg-core';
 import type { GridResult } from '../../types/pipeline';
 import { median } from './utils';
 

--- a/packages/nukebg-app/src/workers/cv/grid-flood-fill.ts
+++ b/packages/nukebg-app/src/workers/cv/grid-flood-fill.ts
@@ -1,4 +1,4 @@
-import { CV_PARAMS } from '../../pipeline/constants';
+import { CV_PARAMS } from 'nukebg-core';
 import { RingBuffer, maxChannelDiff, pixelIndex } from './utils';
 
 /**

--- a/packages/nukebg-app/src/workers/cv/inpaint-telea.ts
+++ b/packages/nukebg-app/src/workers/cv/inpaint-telea.ts
@@ -10,7 +10,7 @@
  * propagates edge information inward naturally.
  */
 
-import { INPAINT_PARAMS } from '../../pipeline/constants';
+import { INPAINT_PARAMS } from 'nukebg-core';
 
 // --- Min-Heap para Fast Marching ---
 

--- a/packages/nukebg-app/src/workers/cv/lama-crop.ts
+++ b/packages/nukebg-app/src/workers/cv/lama-crop.ts
@@ -1,4 +1,4 @@
-import { LAMA_PARAMS } from '../../pipeline/constants';
+import { LAMA_PARAMS } from 'nukebg-core';
 import { clamp255 } from './clamp';
 
 export interface LamaCropRect {

--- a/packages/nukebg-app/src/workers/cv/lama-router.ts
+++ b/packages/nukebg-app/src/workers/cv/lama-router.ts
@@ -1,4 +1,4 @@
-import { LAMA_ROUTER_PARAMS } from '../../pipeline/constants';
+import { LAMA_ROUTER_PARAMS } from 'nukebg-core';
 
 export interface LamaRouterDecision {
   /** True → use LaMa (ONNX, content-aware). False → PatchMatch (CV, instant). */

--- a/packages/nukebg-app/src/workers/cv/shadow-cleanup.ts
+++ b/packages/nukebg-app/src/workers/cv/shadow-cleanup.ts
@@ -1,4 +1,4 @@
-import { SHADOW_PARAMS } from '../../pipeline/constants';
+import { SHADOW_PARAMS } from 'nukebg-core';
 import { pixelIndex } from './utils';
 
 /**

--- a/packages/nukebg-app/src/workers/cv/signature-threshold.ts
+++ b/packages/nukebg-app/src/workers/cv/signature-threshold.ts
@@ -1,4 +1,4 @@
-import { IMAGE_CLASSIFY_PARAMS } from '../../pipeline/constants';
+import { IMAGE_CLASSIFY_PARAMS } from 'nukebg-core';
 
 /**
  * Signature threshold: extract signature strokes from a mostly-white background

--- a/packages/nukebg-app/src/workers/cv/simple-flood-fill.ts
+++ b/packages/nukebg-app/src/workers/cv/simple-flood-fill.ts
@@ -1,4 +1,4 @@
-import { CV_PARAMS } from '../../pipeline/constants';
+import { CV_PARAMS } from 'nukebg-core';
 import { RingBuffer, maxChannelDiff, pixelIndex } from './utils';
 
 /**

--- a/packages/nukebg-app/src/workers/cv/sparkle-detect.ts
+++ b/packages/nukebg-app/src/workers/cv/sparkle-detect.ts
@@ -1,4 +1,4 @@
-import { SPARKLE_PARAMS } from '../../pipeline/constants';
+import { SPARKLE_PARAMS } from 'nukebg-core';
 import type { WatermarkResult } from '../../types/pipeline';
 
 /**

--- a/packages/nukebg-app/src/workers/cv/subject-exclusion.ts
+++ b/packages/nukebg-app/src/workers/cv/subject-exclusion.ts
@@ -1,4 +1,4 @@
-import { CV_PARAMS } from '../../pipeline/constants';
+import { CV_PARAMS } from 'nukebg-core';
 import { pixelIndex, RingBuffer } from './utils';
 
 /**

--- a/packages/nukebg-app/src/workers/cv/watermark-dalle.ts
+++ b/packages/nukebg-app/src/workers/cv/watermark-dalle.ts
@@ -1,4 +1,4 @@
-import { DALLE_WATERMARK_PARAMS } from '../../pipeline/constants';
+import { DALLE_WATERMARK_PARAMS } from 'nukebg-core';
 import type { WatermarkResult } from '../../types/pipeline';
 import { pixelIndex } from './utils';
 

--- a/packages/nukebg-app/src/workers/cv/watermark-detect.ts
+++ b/packages/nukebg-app/src/workers/cv/watermark-detect.ts
@@ -1,4 +1,4 @@
-import { WATERMARK_PARAMS } from '../../pipeline/constants';
+import { WATERMARK_PARAMS } from 'nukebg-core';
 import type { WatermarkResult } from '../../types/pipeline';
 import { pixelIndex } from './utils';
 

--- a/packages/nukebg-app/src/workers/inpaint.worker.ts
+++ b/packages/nukebg-app/src/workers/inpaint.worker.ts
@@ -8,7 +8,7 @@
  */
 import { patchMatchInpaint } from './cv/patchmatch-inpaint';
 import type { InpaintWorkerRequest, InpaintWorkerResponse } from '../types/worker-messages';
-import { PATCHMATCH_PARAMS } from '../pipeline/constants';
+import { PATCHMATCH_PARAMS } from 'nukebg-core';
 
 async function inpaint(
   id: string,

--- a/packages/nukebg-app/src/workers/lama.worker.ts
+++ b/packages/nukebg-app/src/workers/lama.worker.ts
@@ -15,7 +15,7 @@
  */
 import * as ort from 'onnxruntime-web';
 import type { LamaWorkerRequest, LamaWorkerResponse } from '../types/worker-messages';
-import { LAMA_PARAMS } from '../pipeline/constants';
+import { LAMA_PARAMS } from 'nukebg-core';
 import {
   bilinearResizeRGBA,
   computeLamaCropRect,

--- a/packages/nukebg-app/src/workers/ml.worker.ts
+++ b/packages/nukebg-app/src/workers/ml.worker.ts
@@ -10,7 +10,7 @@ import type {
   ModelId,
   WarmupDiagnostic,
 } from '../types/worker-messages';
-import { REFINE_PARAMS, RMBG_PARAMS } from '../pipeline/constants';
+import { REFINE_PARAMS, RMBG_PARAMS } from 'nukebg-core';
 
 const DEFAULT_MODEL: ModelId = 'briaai/RMBG-1.4';
 

--- a/packages/nukebg-app/src/workers/sam.worker.ts
+++ b/packages/nukebg-app/src/workers/sam.worker.ts
@@ -13,7 +13,7 @@
  */
 import * as ort from 'onnxruntime-web';
 import type { SamWorkerRequest, SamWorkerResponse } from '../types/worker-messages';
-import { MOBILESAM_PARAMS } from '../pipeline/constants';
+import { MOBILESAM_PARAMS } from 'nukebg-core';
 const SAM_PARAMS = {
   INPUT_SIZE: 1024,
   MASK_SIZE: 256,

--- a/packages/nukebg-app/tests/cv/lama-crop.test.ts
+++ b/packages/nukebg-app/tests/cv/lama-crop.test.ts
@@ -5,7 +5,7 @@ import {
   nearestResizeMask,
   spliceLamaOutput,
 } from '../../src/workers/cv/lama-crop';
-import { LAMA_PARAMS } from '../../src/pipeline/constants';
+import { LAMA_PARAMS } from 'nukebg-core';
 
 function makeMask(
   w: number,

--- a/packages/nukebg-app/tests/cv/lama-router.test.ts
+++ b/packages/nukebg-app/tests/cv/lama-router.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { shouldUseLama } from '../../src/workers/cv/lama-router';
-import { LAMA_ROUTER_PARAMS } from '../../src/pipeline/constants';
+import { LAMA_ROUTER_PARAMS } from 'nukebg-core';
 
 /** Solid-color RGBA canvas. */
 function solid(w: number, h: number, gray: number): Uint8ClampedArray {

--- a/packages/nukebg-app/tests/integration.test.ts
+++ b/packages/nukebg-app/tests/integration.test.ts
@@ -7,7 +7,7 @@ import { subjectExclusion } from '../src/workers/cv/subject-exclusion';
 import { watermarkDetect } from '../src/workers/cv/watermark-detect';
 import { shadowCleanup } from '../src/workers/cv/shadow-cleanup';
 import { alphaRefine } from '../src/workers/cv/alpha-refine';
-import { CV_PARAMS } from '../src/pipeline/constants';
+import { CV_PARAMS } from 'nukebg-core';
 import { solidImage, checkerboardImage, paintRect } from './helpers';
 
 /**

--- a/packages/nukebg-app/tests/pipeline/model-integrity.test.ts
+++ b/packages/nukebg-app/tests/pipeline/model-integrity.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { LAMA_PARAMS, MOBILESAM_PARAMS, RMBG_PARAMS } from '../../src/pipeline/constants';
+import { LAMA_PARAMS, MOBILESAM_PARAMS, RMBG_PARAMS } from 'nukebg-core';
 
 /**
  * Supply-chain hardening (#132): every model loaded by the app must be

--- a/packages/nukebg-app/tests/pipeline/orchestrator.test.ts
+++ b/packages/nukebg-app/tests/pipeline/orchestrator.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { CV_PARAMS } from '../../src/pipeline/constants';
+import { CV_PARAMS } from 'nukebg-core';
 
 /**
  * Pipeline orchestrator tests.

--- a/packages/nukebg-app/tests/utils/final-composite.test.ts
+++ b/packages/nukebg-app/tests/utils/final-composite.test.ts
@@ -22,7 +22,7 @@ import {
   composeAtOriginal,
   refineUpscaledAlpha,
 } from '../../src/utils/final-composite';
-import { EDGE_REFINE_PARAMS } from '../../src/pipeline/constants';
+import { EDGE_REFINE_PARAMS } from 'nukebg-core';
 
 describe('bilinearUpscaleU8', () => {
   it('returns a copy when sizes match', () => {

--- a/packages/nukebg-app/tests/visual-validation.test.ts
+++ b/packages/nukebg-app/tests/visual-validation.test.ts
@@ -7,7 +7,7 @@ import { simpleFloodFill } from '../src/workers/cv/simple-flood-fill';
 import { watermarkDetect } from '../src/workers/cv/watermark-detect';
 import { shadowCleanup } from '../src/workers/cv/shadow-cleanup';
 import { alphaRefine } from '../src/workers/cv/alpha-refine';
-import { CV_PARAMS } from '../src/pipeline/constants';
+import { CV_PARAMS } from 'nukebg-core';
 import { solidImage, checkerboardImage, paintRect } from './helpers';
 
 /**

--- a/packages/nukebg-app/tests/workers/cv/watermark-dalle.test.ts
+++ b/packages/nukebg-app/tests/workers/cv/watermark-dalle.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { watermarkDetectDalle } from '../../../src/workers/cv/watermark-dalle';
-import { DALLE_WATERMARK_PARAMS } from '../../../src/pipeline/constants';
+import { DALLE_WATERMARK_PARAMS } from 'nukebg-core';
 
 /**
  * Behavioural tests for watermarkDetectDalle (#195).

--- a/packages/nukebg-app/tsconfig.json
+++ b/packages/nukebg-app/tsconfig.json
@@ -15,8 +15,10 @@
     "resolveJsonModule": true,
     "isolatedModules": true,
     "sourceMap": true,
-    "composite": true,
-    "outDir": "./dist"
+    "paths": {
+      "nukebg-core": ["../nukebg-core/src/index.ts"],
+      "nukebg-core/*": ["../nukebg-core/src/*"]
+    }
   },
   "include": ["src/**/*.ts", "tests/**/*.ts"],
   "exclude": ["node_modules", "dist"]

--- a/packages/nukebg-app/vite.config.ts
+++ b/packages/nukebg-app/vite.config.ts
@@ -1,7 +1,18 @@
 /// <reference types="vitest/config" />
 import { defineConfig } from 'vite';
+import { fileURLToPath } from 'node:url';
+import { resolve } from 'node:path';
+
+const __dirname = fileURLToPath(new URL('.', import.meta.url));
 
 export default defineConfig({
+  resolve: {
+    alias: {
+      // Resolve nukebg-core to its TypeScript source during dev and test
+      // so we don't need a prior `tsc -b` build step.
+      'nukebg-core': resolve(__dirname, '../nukebg-core/src/index.ts'),
+    },
+  },
   build: {
     target: 'es2022',
     outDir: 'dist',

--- a/packages/nukebg-core/src/index.ts
+++ b/packages/nukebg-core/src/index.ts
@@ -33,3 +33,25 @@ export {
   DecodeError,
   PipelineAbortError,
 } from './pipeline/errors.js';
+
+// Constants (read-only)
+export {
+  CV_PARAMS,
+  WATERMARK_PARAMS,
+  SPARKLE_PARAMS,
+  DALLE_WATERMARK_PARAMS,
+  SHADOW_PARAMS,
+  ALPHA_PARAMS,
+  EDGE_REFINE_PARAMS,
+  PATCHMATCH_PARAMS,
+  INPAINT_PARAMS,
+  LAMA_PARAMS,
+  LAMA_ROUTER_PARAMS,
+  REFINE_PARAMS,
+  PRECISION_PROFILES,
+  IMAGE_CLASSIFY_PARAMS,
+  MOBILESAM_PARAMS,
+  RMBG_PARAMS,
+  type PrecisionMode,
+  type PrecisionProfile,
+} from './pipeline/constants.js';

--- a/packages/nukebg-core/src/pipeline/constants.ts
+++ b/packages/nukebg-core/src/pipeline/constants.ts
@@ -102,8 +102,8 @@ export const ALPHA_PARAMS = {
  * quintic sharpen lands on the correct pixel.
  *
  * Only applied when a downscale actually occurred (working res < original).
- * The filter is restricted to the trimap band: pixels at α ≤ BAND_LO or
- * α ≥ BAND_HI are passed through verbatim so pure background and pure body
+ * The filter is restricted to the trimap band: pixels at alpha <= BAND_LO or
+ * alpha >= BAND_HI are passed through verbatim so pure background and pure body
  * never drift.
  */
 export const EDGE_REFINE_PARAMS = {
@@ -114,14 +114,14 @@ export const EDGE_REFINE_PARAMS = {
   /** Regularization — small value = stronger structure transfer from the
    *  guide (snap the alpha edge to RGB gradient). Higher = more smoothing. */
   EPSILON: 1e-3,
-  /** Pixels with α ≤ this are kept verbatim (true background). */
+  /** Pixels with alpha <= this are kept verbatim (true background). */
   BAND_LO: 10,
-  /** Pixels with α ≥ this are kept verbatim (true foreground body). */
+  /** Pixels with alpha >= this are kept verbatim (true foreground body). */
   BAND_HI: 245,
 } as const;
 
 export const PATCHMATCH_PARAMS = {
-  /** Patch radius (pixels). 3 → 7×7 patches, the Barnes 2009 sweet-spot
+  /** Patch radius (pixels). 3 -> 7x7 patches, the Barnes 2009 sweet-spot
    *  for texture reconstruction on natural photos. */
   PATCH_RADIUS: 3,
   /** Number of propagation + random-search + voting iterations.
@@ -180,24 +180,24 @@ export const LAMA_PARAMS = {
    *  tight and the reconstruction looks flat. */
   CROP_PADDING: 48,
   /** Minimum square side (in original-image scale) the crop expands
-   *  to if the mask bbox is tiny. Prevents degenerate 20×20 crops
+   *  to if the mask bbox is tiny. Prevents degenerate 20x20 crops
    *  that blow up to 512 and produce mush. */
   MIN_CROP_SIDE: 128,
   /** Feather radius used when compositing the inpainted region back
-   *  into the untouched image. Must be ≥ INPAINT_PARAMS.FEATHER_RADIUS
+   *  into the untouched image. Must be >= INPAINT_PARAMS.FEATHER_RADIUS
    *  so the LaMa-reconstructed core blends as softly as PatchMatch. */
   COMPOSITE_FEATHER: 6,
 } as const;
 
 /** Heuristic that decides whether a detected watermark lives over
- *  structured content (→ LaMa) or uniform background (→ PatchMatch).
+ *  structured content (-> LaMa) or uniform background (-> PatchMatch).
  *  Tuned against real photos with Gemini sparkles / DALL-E bars. */
 export const LAMA_ROUTER_PARAMS = {
-  /** Luminance variance over the mask-bbox sample. Above this → content
+  /** Luminance variance over the mask-bbox sample. Above this -> content
    *  has texture/gradient worth reconstructing with the model. Uniform
    *  sky/wall typically sits around 50-150. */
   VARIANCE_THRESHOLD: 350,
-  /** Mean Sobel gradient magnitude over the sample. Above this → edges
+  /** Mean Sobel gradient magnitude over the sample. Above this -> edges
    *  are present (object outlines, text, rivets). Flat zones score near 0. */
   EDGE_DENSITY_THRESHOLD: 20,
   /** Pixels added around the raw mask bbox when sampling the heuristic.

--- a/packages/nukebg-core/tests/pipeline/constants.test.ts
+++ b/packages/nukebg-core/tests/pipeline/constants.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
-import { PRECISION_PROFILES, REFINE_PARAMS } from 'nukebg-core';
-import type { PrecisionMode, PrecisionProfile } from 'nukebg-core';
+import { PRECISION_PROFILES, REFINE_PARAMS } from '../../src/pipeline/constants.js';
+import type { PrecisionMode, PrecisionProfile } from '../../src/pipeline/constants.js';
 
 describe('PrecisionProfiles', () => {
   const modes: PrecisionMode[] = ['low-power', 'normal', 'high-power', 'full-nuke'];

--- a/packages/nukebg-core/tsconfig.json
+++ b/packages/nukebg-core/tsconfig.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "composite": true,
     "outDir": "./dist",
-    "rootDir": "./src"
+    "rootDir": "./src",
+    "ignoreDeprecations": "6.0"
   },
   "include": ["src/**/*.ts"],
   "exclude": ["node_modules", "dist"]

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,6 @@
 {
   "files": [],
   "references": [
-    { "path": "./packages/nukebg-app" },
     { "path": "./packages/nukebg-core" },
     { "path": "./packages/nukebg-cli" }
   ]


### PR DESCRIPTION
## Summary

Phase 4 of **extract-core-cli**: `pipeline/constants.ts` moves into `nukebg-core` so CV modules can import it from the shared package in later phases.

- `constants.ts` moved app → core (git-detected rename, values unchanged)
- All **25 app src files + tests** rewired to `import { ... } from 'nukebg-core'`
- Constants re-exported from core's barrel; core constants test added (**84 core tests**)

## TS resolution decision (deviation worth a look)

The app now resolves `nukebg-core` to **source** via `tsconfig` `paths` (mirroring the existing vite alias for vitest/build), rather than a project-reference to core's built `dist/`.

**Why:** the app is a Vite app — never built by `tsc`, never published. Making it a composite project that consumes core's emitted `.d.ts` forces a build-before-typecheck ordering that **breaks CI** (the `typecheck` step runs before `build`, so `dist/` wouldn't exist). Source resolution is build-order-independent and consistent across dev/test/typecheck. The app was dropped from the root `tsconfig` references; `nukebg-core`/`nukebg-cli` stay composite + referenced for publishing.

## Test plan

- [x] `npm test` — 953 app + 84 core passing
- [x] `npm run typecheck` — clean **with no pre-built dist** (verified after `rm -rf packages/*/dist`)
- [x] `npm run lint` — clean
- [x] `npm run build` — output OK at `packages/nukebg-app/dist`

> **Stacked PR.** Targets `feat/extract-core-cli-phase-3` (#293).

Closes #269

<!-- chain-context:extract-core-cli -->

## Chain Context

| Field | Value |
|-------|-------|
| Chain | extract-core-cli (17 slices) |
| Tracker PR | `feat/extract-core-cli` → `dev` — opens once #291 merges into the tracker (GitHub rejects a zero-diff PR) |
| Position | 3 of 17 |
| Base | `feat/extract-core-cli-phase-3` |
| Depends on | #293 |
| Follow-up | #295 |
| Review budget | 240 (188 additions + 52 deletions) / 400 |

### Chain Overview

```text
dev
 └── feat/extract-core-cli  (tracker, draft/no-merge)
      └── #291 … #293  (2 earlier slices)
           └── 📍 #294  phase 4 — constants to core
                └── #295 … #324  (14 later slices)
```

### Autonomy

- [x] CI is expected to pass for this PR branch
- [x] This PR has one deliverable scope
- [x] This PR can be rolled back without unrelated changes
- [x] Tests, docs, or manual verification cover this unit
