### PR TITLE
feat(cli): implement SharpImageCodec (phase 11)

### DIFF
--- a/openspec/changes/extract-core-cli/tasks.md
+++ b/openspec/changes/extract-core-cli/tasks.md
@@ -283,7 +283,7 @@ _Goal: `PipelineOrchestrator` → `WorkerPipelineRunner`. Browser app satisfies 
 
 _Goal: first Node-side adapter. Strict TDD: encode/decode round-trip._
 
-- [ ] 11.1 Write failing tests for `SharpImageCodec.decode` (REQ-CORE-RUNNERS-3):
+- [x] 11.1 Write failing tests for `SharpImageCodec.decode` (REQ-CORE-RUNNERS-3):
   - File: `packages/nukebg-cli/tests/codecs/sharp-codec.test.ts`
   - Scenarios:
     - Valid PNG bytes → `ImageDataLike` with correct `width`, `height`, non-empty `data` (length = `width * height * 4`).
@@ -291,18 +291,18 @@ _Goal: first Node-side adapter. Strict TDD: encode/decode round-trip._
     - Invalid bytes (non-image) → rejects with `DecodeError`, `error.code === "DECODE_FAILED"`.
     - Alpha channel preserved: encode RGBA with transparent pixels → decode back → alpha values match.
 
-- [ ] 11.2 Implement `packages/nukebg-cli/src/codecs/sharp-codec.ts` — `SharpImageCodec implements ImageCodec` using `sharp`. Format detection by magic bytes. Run tests, expect green.
+- [x] 11.2 Implement `packages/nukebg-cli/src/codecs/sharp-codec.ts` — `SharpImageCodec implements ImageCodec` using `sharp`. Format detection by magic bytes. Run tests, expect green.
 
-- [ ] 11.3 Write failing tests for `SharpImageCodec.encode`:
+- [x] 11.3 Write failing tests for `SharpImageCodec.encode`:
   - PNG output starts with PNG magic bytes.
   - WebP output starts with RIFF/WEBP header.
   - Round-trip: encode PNG then decode → pixel data identical.
 
-- [ ] 11.4 Implement `encode` method in `SharpImageCodec`. Run tests, expect green.
+- [x] 11.4 Implement `encode` method in `SharpImageCodec`. Run tests, expect green.
 
-- [ ] 11.5 Refactor if needed (extract magic-byte detection to a private helper). Run tests, expect green.
+- [x] 11.5 Refactor if needed (extract magic-byte detection to a private helper). Run tests, expect green.
 
-- [ ] 11.6 Verification: `npm test` (CLI project only: `npm test -w nukebg-cli`), `npm run typecheck`. Milestone: "`SharpImageCodec` implemented and round-trip tested".
+- [x] 11.6 Verification: `npm test` (CLI project only: `npm test -w nukebg-cli`), `npm run typecheck`. Milestone: "`SharpImageCodec` implemented and round-trip tested".
 
 ---
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1657,6 +1657,47 @@
         "node": ">=18"
       }
     },
+    "node_modules/color": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/color/-/color-4.2.3.tgz",
+      "integrity": "sha512-1rXeuUUiGGrykh+CeBdu5Ie7OJwinCgQY0bc7GCRxy5xVHy+moaqkpL/jqQq0MtQOeYcrqEz4abc5f0KtU7W4A==",
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1",
+        "color-string": "^1.9.0"
+      },
+      "engines": {
+        "node": ">=12.5.0"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "license": "MIT"
+    },
+    "node_modules/color-string": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/color-string/-/color-string-1.9.1.tgz",
+      "integrity": "sha512-shrVawQFojnZv6xM40anx4CkoDP+fZsw/ZerEMsW/pyzsRbElpsL/DBVW7q3ExxwusdNXI3lXpuhEZkzs8p5Eg==",
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "^1.0.0",
+        "simple-swizzle": "^0.2.2"
+      }
+    },
     "node_modules/convert-source-map": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
@@ -2259,6 +2300,12 @@
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "license": "ISC"
+    },
+    "node_modules/is-arrayish": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.4.tgz",
+      "integrity": "sha512-m6UrgzFVUYawGBh1dUsWR5M2Clqic9RVXC/9f8ceNlv2IcO9j9J/z8UoCLPqtsPBFNzEpfR3xftohbfqDx8EQA==",
+      "license": "MIT"
     },
     "node_modules/is-extglob": {
       "version": "2.1.1",
@@ -3263,6 +3310,15 @@
       "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/simple-swizzle": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.4.tgz",
+      "integrity": "sha512-nAu1WFPQSMNr2Zn9PGSZK9AGn4t/y97lEm+MXTtUDwfP0ksAIX4nO+6ruD9Jwut4C49SB1Ws+fbXsm/yScWOHw==",
+      "license": "MIT",
+      "dependencies": {
+        "is-arrayish": "^0.3.1"
+      }
     },
     "node_modules/source-map-js": {
       "version": "1.2.1",
@@ -4269,7 +4325,8 @@
       "version": "0.1.0",
       "license": "GPL-3.0-only",
       "dependencies": {
-        "nukebg-core": "0.1.0"
+        "nukebg-core": "0.1.0",
+        "sharp": "^0.33.5"
       },
       "bin": {
         "nukebg": "dist/cli.js"
@@ -4277,6 +4334,442 @@
       "devDependencies": {},
       "engines": {
         "node": ">=20.0.0"
+      }
+    },
+    "packages/nukebg-cli/node_modules/@img/sharp-darwin-arm64": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.33.5.tgz",
+      "integrity": "sha512-UT4p+iz/2H4twwAoLCqfA9UH5pI6DggwKEGuaPy7nCVQ8ZsiY5PIcrRvD1DzuY3qYL07NtIQcWnBSY/heikIFQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-arm64": "1.0.4"
+      }
+    },
+    "packages/nukebg-cli/node_modules/@img/sharp-darwin-x64": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.33.5.tgz",
+      "integrity": "sha512-fyHac4jIc1ANYGRDxtiqelIbdWkIuQaI84Mv45KvGRRxSAa7o7d1ZKAOBaYbnepLC1WqxfpimdeWfvqqSGwR2Q==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-x64": "1.0.4"
+      }
+    },
+    "packages/nukebg-cli/node_modules/@img/sharp-libvips-darwin-arm64": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.0.4.tgz",
+      "integrity": "sha512-XblONe153h0O2zuFfTAbQYAX2JhYmDHeWikp1LM9Hul9gVPjFY427k6dFEcOL72O01QxQsWi761svJ/ev9xEDg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "packages/nukebg-cli/node_modules/@img/sharp-libvips-darwin-x64": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.0.4.tgz",
+      "integrity": "sha512-xnGR8YuZYfJGmWPvmlunFaWJsb9T/AO2ykoP3Fz/0X5XV2aoYBPkX6xqCQvUTKKiLddarLaxpzNe+b1hjeWHAQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "packages/nukebg-cli/node_modules/@img/sharp-libvips-linux-arm": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.0.5.tgz",
+      "integrity": "sha512-gvcC4ACAOPRNATg/ov8/MnbxFDJqf/pDePbBnuBDcjsI8PssmjoKMAz4LtLaVi+OnSb5FK/yIOamqDwGmXW32g==",
+      "cpu": [
+        "arm"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "packages/nukebg-cli/node_modules/@img/sharp-libvips-linux-arm64": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.0.4.tgz",
+      "integrity": "sha512-9B+taZ8DlyyqzZQnoeIvDVR/2F4EbMepXMc/NdVbkzsJbzkUjhXv/70GQJ7tdLA4YJgNP25zukcxpX2/SueNrA==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "packages/nukebg-cli/node_modules/@img/sharp-libvips-linux-s390x": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.0.4.tgz",
+      "integrity": "sha512-u7Wz6ntiSSgGSGcjZ55im6uvTrOxSIS8/dgoVMoiGE9I6JAfU50yH5BoDlYA1tcuGS7g/QNtetJnxA6QEsCVTA==",
+      "cpu": [
+        "s390x"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "packages/nukebg-cli/node_modules/@img/sharp-libvips-linux-x64": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.0.4.tgz",
+      "integrity": "sha512-MmWmQ3iPFZr0Iev+BAgVMb3ZyC4KeFc3jFxnNbEPas60e1cIfevbtuyf9nDGIzOaW9PdnDciJm+wFFaTlj5xYw==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "packages/nukebg-cli/node_modules/@img/sharp-libvips-linuxmusl-arm64": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.0.4.tgz",
+      "integrity": "sha512-9Ti+BbTYDcsbp4wfYib8Ctm1ilkugkA/uscUn6UXK1ldpC1JjiXbLfFZtRlBhjPZ5o1NCLiDbg8fhUPKStHoTA==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "packages/nukebg-cli/node_modules/@img/sharp-libvips-linuxmusl-x64": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.0.4.tgz",
+      "integrity": "sha512-viYN1KX9m+/hGkJtvYYp+CCLgnJXwiQB39damAO7WMdKWlIhmYTfHjwSbQeUK/20vY154mwezd9HflVFM1wVSw==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "packages/nukebg-cli/node_modules/@img/sharp-linux-arm": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.33.5.tgz",
+      "integrity": "sha512-JTS1eldqZbJxjvKaAkxhZmBqPRGmxgu+qFKSInv8moZ2AmT5Yib3EQ1c6gp493HvrvV8QgdOXdyaIBrhvFhBMQ==",
+      "cpu": [
+        "arm"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm": "1.0.5"
+      }
+    },
+    "packages/nukebg-cli/node_modules/@img/sharp-linux-arm64": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.33.5.tgz",
+      "integrity": "sha512-JMVv+AMRyGOHtO1RFBiJy/MBsgz0x4AWrT6QoEVVTyh1E39TrCUpTRI7mx9VksGX4awWASxqCYLCV4wBZHAYxA==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm64": "1.0.4"
+      }
+    },
+    "packages/nukebg-cli/node_modules/@img/sharp-linux-s390x": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.33.5.tgz",
+      "integrity": "sha512-y/5PCd+mP4CA/sPDKl2961b+C9d+vPAveS33s6Z3zfASk2j5upL6fXVPZi7ztePZ5CuH+1kW8JtvxgbuXHRa4Q==",
+      "cpu": [
+        "s390x"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-s390x": "1.0.4"
+      }
+    },
+    "packages/nukebg-cli/node_modules/@img/sharp-linux-x64": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.33.5.tgz",
+      "integrity": "sha512-opC+Ok5pRNAzuvq1AG0ar+1owsu842/Ab+4qvU879ippJBHvyY5n2mxF1izXqkPYlGuP/M556uh53jRLJmzTWA==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-x64": "1.0.4"
+      }
+    },
+    "packages/nukebg-cli/node_modules/@img/sharp-linuxmusl-arm64": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.33.5.tgz",
+      "integrity": "sha512-XrHMZwGQGvJg2V/oRSUfSAfjfPxO+4DkiRh6p2AFjLQztWUuY/o8Mq0eMQVIY7HJ1CDQUJlxGGZRw1a5bqmd1g==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-arm64": "1.0.4"
+      }
+    },
+    "packages/nukebg-cli/node_modules/@img/sharp-linuxmusl-x64": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.33.5.tgz",
+      "integrity": "sha512-WT+d/cgqKkkKySYmqoZ8y3pxx7lx9vVejxW/W4DOFMYVSkErR+w7mf2u8m/y4+xHe7yY9DAXQMWQhpnMuFfScw==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-x64": "1.0.4"
+      }
+    },
+    "packages/nukebg-cli/node_modules/@img/sharp-wasm32": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.33.5.tgz",
+      "integrity": "sha512-ykUW4LVGaMcU9lu9thv85CbRMAwfeadCJHRsg2GmeRa/cJxsVY9Rbd57JcMxBkKHag5U/x7TSBpScF4U8ElVzg==",
+      "cpu": [
+        "wasm32"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/runtime": "^1.2.0"
+      },
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "packages/nukebg-cli/node_modules/@img/sharp-win32-ia32": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.33.5.tgz",
+      "integrity": "sha512-T36PblLaTwuVJ/zw/LaH0PdZkRz5rd3SmMHX8GSmR7vtNSP5Z6bQkExdSK7xGWyxLw4sUknBuugTelgw2faBbQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "packages/nukebg-cli/node_modules/@img/sharp-win32-x64": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.33.5.tgz",
+      "integrity": "sha512-MpY/o8/8kj+EcnxwvrP4aTJSWw/aZ7JIGR4aBeZkZw5B7/Jn+tY9/VNwtcoGmdT7GfggGIU4kygOMSbYnOrAbg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "packages/nukebg-cli/node_modules/sharp": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.33.5.tgz",
+      "integrity": "sha512-haPVm1EkS9pgvHrQ/F3Xy+hgcuMV0Wm9vfIBSiwZ05k+xgb0PkBQpGsAA/oWdDobNaZTH5ppvHtzCFbnSEwHVw==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "color": "^4.2.3",
+        "detect-libc": "^2.0.3",
+        "semver": "^7.6.3"
+      },
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-darwin-arm64": "0.33.5",
+        "@img/sharp-darwin-x64": "0.33.5",
+        "@img/sharp-libvips-darwin-arm64": "1.0.4",
+        "@img/sharp-libvips-darwin-x64": "1.0.4",
+        "@img/sharp-libvips-linux-arm": "1.0.5",
+        "@img/sharp-libvips-linux-arm64": "1.0.4",
+        "@img/sharp-libvips-linux-s390x": "1.0.4",
+        "@img/sharp-libvips-linux-x64": "1.0.4",
+        "@img/sharp-libvips-linuxmusl-arm64": "1.0.4",
+        "@img/sharp-libvips-linuxmusl-x64": "1.0.4",
+        "@img/sharp-linux-arm": "0.33.5",
+        "@img/sharp-linux-arm64": "0.33.5",
+        "@img/sharp-linux-s390x": "0.33.5",
+        "@img/sharp-linux-x64": "0.33.5",
+        "@img/sharp-linuxmusl-arm64": "0.33.5",
+        "@img/sharp-linuxmusl-x64": "0.33.5",
+        "@img/sharp-wasm32": "0.33.5",
+        "@img/sharp-win32-ia32": "0.33.5",
+        "@img/sharp-win32-x64": "0.33.5"
       }
     },
     "packages/nukebg-core": {

--- a/packages/nukebg-cli/package.json
+++ b/packages/nukebg-cli/package.json
@@ -4,17 +4,24 @@
   "type": "module",
   "license": "GPL-3.0-only",
   "description": "CLI for nukebg — Node-only background removal using nukebg-core.",
-  "bin": { "nukebg": "./dist/cli.js" },
+  "bin": {
+    "nukebg": "./dist/cli.js"
+  },
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
-  "files": ["dist", "README.md", "LICENSE"],
+  "files": [
+    "dist",
+    "README.md",
+    "LICENSE"
+  ],
   "scripts": {
-    "test": "vitest run --passWithNoTests"
+    "test": "vitest run --passWithNoTests",
+    "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "nukebg-core": "0.1.0"
+    "nukebg-core": "0.1.0",
+    "sharp": "^0.34.5"
   },
-  "devDependencies": {},
   "engines": {
     "node": ">=20.0.0"
   }

--- a/packages/nukebg-cli/src/codecs/sharp-codec.ts
+++ b/packages/nukebg-cli/src/codecs/sharp-codec.ts
@@ -1,0 +1,170 @@
+import sharp from 'sharp';
+import type { ImageCodec, EncodeFormat } from 'nukebg-core';
+import type { ImageDataLike } from 'nukebg-core';
+import { DecodeError, createImageDataLike } from 'nukebg-core';
+
+// ---------------------------------------------------------------------------
+// Magic-byte detection — identifies image format from the first bytes of the
+// buffer before handing off to sharp. This allows early rejection of clearly
+// non-image data with a clear DecodeError rather than a cryptic sharp error.
+// ---------------------------------------------------------------------------
+
+function detectFormat(bytes: Uint8Array): 'png' | 'jpeg' | 'webp' | 'gif' | 'unknown' {
+  if (bytes.length < 4) return 'unknown';
+
+  // PNG: 89 50 4E 47 (the classic PNG magic)
+  if (
+    bytes[0] === 0x89 &&
+    bytes[1] === 0x50 &&
+    bytes[2] === 0x4e &&
+    bytes[3] === 0x47
+  ) {
+    return 'png';
+  }
+
+  // JPEG: FF D8 FF
+  if (bytes[0] === 0xff && bytes[1] === 0xd8 && bytes[2] === 0xff) {
+    return 'jpeg';
+  }
+
+  // WebP: RIFF????WEBP
+  if (
+    bytes.length >= 12 &&
+    bytes[0] === 0x52 && // R
+    bytes[1] === 0x49 && // I
+    bytes[2] === 0x46 && // F
+    bytes[3] === 0x46 && // F
+    bytes[8] === 0x57 && // W
+    bytes[9] === 0x45 && // E
+    bytes[10] === 0x42 && // B
+    bytes[11] === 0x50 // P
+  ) {
+    return 'webp';
+  }
+
+  // GIF: 47 49 46 38
+  if (
+    bytes[0] === 0x47 &&
+    bytes[1] === 0x49 &&
+    bytes[2] === 0x46 &&
+    bytes[3] === 0x38
+  ) {
+    return 'gif';
+  }
+
+  return 'unknown';
+}
+
+// ---------------------------------------------------------------------------
+// SharpImageCodec
+// ---------------------------------------------------------------------------
+
+/**
+ * Node-only implementation of the `ImageCodec` interface backed by `sharp`.
+ *
+ * decode: accepts PNG, JPEG, WebP (and other formats sharp supports).
+ *         Always returns 4-channel RGBA via `.ensureAlpha()`.
+ *         Rejects with `DecodeError` ("DECODE_FAILED") for unrecognised bytes.
+ *
+ * encode: converts an `ImageDataLike` (RGBA flat array) back to PNG or WebP.
+ */
+export class SharpImageCodec implements ImageCodec {
+  async decode(
+    bytes: Uint8Array | ArrayBufferView,
+    opts?: { maxDimension?: number },
+  ): Promise<{
+    image: ImageDataLike;
+    originalWidth: number;
+    originalHeight: number;
+    wasDownsampled: boolean;
+  }> {
+    const buf = bytes instanceof Uint8Array
+      ? Buffer.from(bytes.buffer, bytes.byteOffset, bytes.byteLength)
+      : Buffer.from((bytes as ArrayBufferView).buffer);
+
+    // Quick magic-byte check — reject obviously non-image data early
+    const asUint8 = new Uint8Array(buf.buffer, buf.byteOffset, buf.byteLength);
+    const fmt = detectFormat(asUint8);
+    if (fmt === 'unknown') {
+      throw new DecodeError(
+        `Cannot decode bytes: unrecognised image format (first bytes: ${Array.from(asUint8.slice(0, 4))
+          .map((b) => `0x${b.toString(16).padStart(2, '0')}`)
+          .join(' ')})`,
+      );
+    }
+
+    let img = sharp(buf).ensureAlpha();
+
+    // Retrieve metadata to know original dimensions before any resize
+    let metadata: sharp.Metadata;
+    try {
+      metadata = await sharp(buf).metadata();
+    } catch (cause) {
+      throw new DecodeError(`Failed to read image metadata`, { cause });
+    }
+
+    const originalWidth = metadata.width ?? 0;
+    const originalHeight = metadata.height ?? 0;
+
+    let wasDownsampled = false;
+
+    if (opts?.maxDimension !== undefined) {
+      const maxDim = opts.maxDimension;
+      if (originalWidth > maxDim || originalHeight > maxDim) {
+        wasDownsampled = true;
+        img = img.resize({
+          width: maxDim,
+          height: maxDim,
+          fit: 'inside',
+          withoutEnlargement: true,
+        });
+      }
+    }
+
+    let rawBuf: Buffer;
+    let info: sharp.OutputInfo;
+    try {
+      ({ data: rawBuf, info } = await img.raw().toBuffer({ resolveWithObject: true }));
+    } catch (cause) {
+      throw new DecodeError(`sharp failed to decode image`, { cause });
+    }
+
+    const data = new Uint8ClampedArray(rawBuf.buffer, rawBuf.byteOffset, rawBuf.byteLength);
+    const image = createImageDataLike(data, info.width, info.height);
+
+    return { image, originalWidth, originalHeight, wasDownsampled };
+  }
+
+  async encode(
+    image: ImageDataLike,
+    format: EncodeFormat,
+    opts?: { quality?: number },
+  ): Promise<Uint8Array> {
+    const { data, width, height } = image;
+
+    // sharp expects a plain Buffer; Uint8ClampedArray is compatible in layout
+    const buf = Buffer.from(data.buffer, data.byteOffset, data.byteLength);
+
+    let pipeline = sharp(buf, {
+      raw: { width, height, channels: 4 },
+    });
+
+    let outBuf: Buffer;
+    switch (format) {
+      case 'png':
+        outBuf = await pipeline.png().toBuffer();
+        break;
+      case 'webp':
+        outBuf = await pipeline
+          .webp({ quality: opts?.quality ?? 80, lossless: false })
+          .toBuffer();
+        break;
+      default: {
+        const _exhaustive: never = format;
+        throw new Error(`Unsupported format: ${_exhaustive as string}`);
+      }
+    }
+
+    return new Uint8Array(outBuf.buffer, outBuf.byteOffset, outBuf.byteLength);
+  }
+}

--- a/packages/nukebg-cli/tests/codecs/sharp-codec.test.ts
+++ b/packages/nukebg-cli/tests/codecs/sharp-codec.test.ts
@@ -1,0 +1,197 @@
+import { describe, it, expect, beforeAll } from 'vitest';
+import sharp from 'sharp';
+import { SharpImageCodec } from '../../src/codecs/sharp-codec.js';
+import { DecodeError } from 'nukebg-core';
+
+// ---------------------------------------------------------------------------
+// Test fixture generators — produce image bytes programmatically via sharp
+// so no binary fixtures need to be committed.
+// ---------------------------------------------------------------------------
+
+let pngBytes: Uint8Array;
+let jpegBytes: Uint8Array;
+let rgbaPngBytes: Uint8Array; // RGBA with a transparent region
+
+const WIDTH = 8;
+const HEIGHT = 8;
+
+beforeAll(async () => {
+  // Solid red 8x8 PNG (opaque)
+  pngBytes = new Uint8Array(
+    await sharp({
+      create: {
+        width: WIDTH,
+        height: HEIGHT,
+        channels: 3,
+        background: { r: 255, g: 0, b: 0 },
+      },
+    })
+      .png()
+      .toBuffer(),
+  );
+
+  // Solid blue 8x8 JPEG
+  jpegBytes = new Uint8Array(
+    await sharp({
+      create: {
+        width: WIDTH,
+        height: HEIGHT,
+        channels: 3,
+        background: { r: 0, g: 0, b: 255 },
+      },
+    })
+      .jpeg({ quality: 95 })
+      .toBuffer(),
+  );
+
+  // RGBA 8x8 PNG: top half fully opaque (alpha=255), bottom half fully transparent (alpha=0)
+  const rgbaPixels = new Uint8Array(WIDTH * HEIGHT * 4);
+  for (let y = 0; y < HEIGHT; y++) {
+    for (let x = 0; x < WIDTH; x++) {
+      const i = (y * WIDTH + x) * 4;
+      rgbaPixels[i] = 0; // R
+      rgbaPixels[i + 1] = 200; // G
+      rgbaPixels[i + 2] = 100; // B
+      rgbaPixels[i + 3] = y < HEIGHT / 2 ? 255 : 0; // A
+    }
+  }
+  rgbaPngBytes = new Uint8Array(
+    await sharp(Buffer.from(rgbaPixels), {
+      raw: { width: WIDTH, height: HEIGHT, channels: 4 },
+    })
+      .png()
+      .toBuffer(),
+  );
+});
+
+// ---------------------------------------------------------------------------
+// decode — Task 11.1 tests (RED phase → will fail until 11.2 is implemented)
+// ---------------------------------------------------------------------------
+
+describe('SharpImageCodec.decode', () => {
+  it('decodes a valid PNG into ImageDataLike with correct dimensions', async () => {
+    const codec = new SharpImageCodec();
+    const result = await codec.decode(pngBytes);
+
+    expect(result.image.width).toBe(WIDTH);
+    expect(result.image.height).toBe(HEIGHT);
+    expect(result.image.data.length).toBe(WIDTH * HEIGHT * 4);
+    expect(result.originalWidth).toBe(WIDTH);
+    expect(result.originalHeight).toBe(HEIGHT);
+    expect(result.wasDownsampled).toBe(false);
+  });
+
+  it('decodes a valid JPEG into ImageDataLike with correct dimensions', async () => {
+    const codec = new SharpImageCodec();
+    const result = await codec.decode(jpegBytes);
+
+    expect(result.image.width).toBe(WIDTH);
+    expect(result.image.height).toBe(HEIGHT);
+    expect(result.image.data.length).toBe(WIDTH * HEIGHT * 4);
+    expect(result.wasDownsampled).toBe(false);
+  });
+
+  it('rejects with DecodeError (code "DECODE_FAILED") for invalid/non-image bytes', async () => {
+    const codec = new SharpImageCodec();
+    const garbage = new Uint8Array([0x00, 0x01, 0x02, 0x03, 0x04, 0x05]);
+
+    await expect(codec.decode(garbage)).rejects.toSatisfy(
+      (e: unknown) => e instanceof DecodeError && (e as DecodeError).code === 'DECODE_FAILED',
+    );
+  });
+
+  it('preserves alpha channel: transparent pixels stay alpha=0 after decode', async () => {
+    const codec = new SharpImageCodec();
+    const result = await codec.decode(rgbaPngBytes);
+
+    const { data, width, height } = result.image;
+    expect(data.length).toBe(width * height * 4);
+
+    // Bottom half should be fully transparent (alpha = 0)
+    for (let y = Math.floor(height / 2); y < height; y++) {
+      for (let x = 0; x < width; x++) {
+        const alpha = data[(y * width + x) * 4 + 3];
+        expect(alpha).toBe(0);
+      }
+    }
+
+    // Top half should be fully opaque (alpha = 255)
+    for (let y = 0; y < Math.floor(height / 2); y++) {
+      for (let x = 0; x < width; x++) {
+        const alpha = data[(y * width + x) * 4 + 3];
+        expect(alpha).toBe(255);
+      }
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// encode — Task 11.3 tests (RED phase → will fail until 11.4 is implemented)
+// ---------------------------------------------------------------------------
+
+describe('SharpImageCodec.encode', () => {
+  it('encodes ImageDataLike to PNG with valid PNG magic bytes', async () => {
+    const codec = new SharpImageCodec();
+
+    // Build a simple 4x4 RGBA image
+    const pixels = new Uint8ClampedArray(4 * 4 * 4).fill(128);
+    const image = { data: pixels, width: 4, height: 4 };
+
+    const encoded = await codec.encode(image, 'png');
+
+    // PNG magic: 0x89 0x50 0x4E 0x47
+    expect(encoded[0]).toBe(0x89);
+    expect(encoded[1]).toBe(0x50); // P
+    expect(encoded[2]).toBe(0x4e); // N
+    expect(encoded[3]).toBe(0x47); // G
+  });
+
+  it('encodes ImageDataLike to WebP with valid RIFF/WEBP header', async () => {
+    const codec = new SharpImageCodec();
+
+    const pixels = new Uint8ClampedArray(4 * 4 * 4).fill(200);
+    const image = { data: pixels, width: 4, height: 4 };
+
+    const encoded = await codec.encode(image, 'webp');
+
+    // RIFF header: 0x52 0x49 0x46 0x46 (RIFF)
+    expect(encoded[0]).toBe(0x52); // R
+    expect(encoded[1]).toBe(0x49); // I
+    expect(encoded[2]).toBe(0x46); // F
+    expect(encoded[3]).toBe(0x46); // F
+
+    // Bytes 8–11 should be WEBP: 0x57 0x45 0x42 0x50
+    expect(encoded[8]).toBe(0x57); // W
+    expect(encoded[9]).toBe(0x45); // E
+    expect(encoded[10]).toBe(0x42); // B
+    expect(encoded[11]).toBe(0x50); // P
+  });
+
+  it('round-trip: encode PNG then decode → pixel data is identical', async () => {
+    const codec = new SharpImageCodec();
+
+    // Build a known RGBA image
+    const width = 4;
+    const height = 4;
+    const pixels = new Uint8ClampedArray(width * height * 4);
+    for (let i = 0; i < pixels.length; i += 4) {
+      pixels[i] = 100; // R
+      pixels[i + 1] = 150; // G
+      pixels[i + 2] = 200; // B
+      pixels[i + 3] = 128; // A (semi-transparent)
+    }
+    const image = { data: pixels, width, height };
+
+    const encoded = await codec.encode(image, 'png');
+    const decoded = await codec.decode(new Uint8Array(encoded.buffer, encoded.byteOffset, encoded.byteLength));
+
+    expect(decoded.image.width).toBe(width);
+    expect(decoded.image.height).toBe(height);
+    expect(decoded.image.data.length).toBe(pixels.length);
+
+    // PNG is lossless — pixels must be identical
+    for (let i = 0; i < pixels.length; i++) {
+      expect(decoded.image.data[i]).toBe(pixels[i]);
+    }
+  });
+});

--- a/packages/nukebg-cli/tsconfig.json
+++ b/packages/nukebg-cli/tsconfig.json
@@ -1,13 +1,12 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "composite": true,
-    "outDir": "./dist",
-    "rootDir": "./src"
+    "ignoreDeprecations": "6.0",
+    "paths": {
+      "nukebg-core": ["../nukebg-core/src/index.ts"],
+      "nukebg-core/*": ["../nukebg-core/src/*"]
+    }
   },
-  "references": [
-    { "path": "../nukebg-core" }
-  ],
-  "include": ["src/**/*.ts"],
+  "include": ["src/**/*.ts", "tests/**/*.ts"],
   "exclude": ["node_modules", "dist"]
 }

--- a/packages/nukebg-cli/vitest.config.ts
+++ b/packages/nukebg-cli/vitest.config.ts
@@ -1,0 +1,27 @@
+import { defineConfig } from 'vitest/config';
+import { fileURLToPath } from 'node:url';
+import { resolve } from 'node:path';
+
+const __dirname = fileURLToPath(new URL('.', import.meta.url));
+
+export default defineConfig({
+  resolve: {
+    alias: [
+      // Resolve nukebg-core sub-path imports to core source (must come before bare alias)
+      {
+        find: /^nukebg-core\/(.+)$/,
+        replacement: resolve(__dirname, '../nukebg-core/src/$1'),
+      },
+      // Resolve bare 'nukebg-core' to its TypeScript barrel (no pre-built dist required)
+      {
+        find: 'nukebg-core',
+        replacement: resolve(__dirname, '../nukebg-core/src/index.ts'),
+      },
+    ],
+  },
+  test: {
+    include: ['tests/**/*.test.ts'],
+    environment: 'node',
+    globals: true,
+  },
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,6 @@
 {
   "files": [],
   "references": [
-    { "path": "./packages/nukebg-core" },
-    { "path": "./packages/nukebg-cli" }
+    { "path": "./packages/nukebg-core" }
   ]
 }


### PR DESCRIPTION
## Summary

Phase 11 of **extract-core-cli**: first Node-side adapter — `SharpImageCodec implements ImageCodec` in `nukebg-cli`.

- `decode` (magic-byte format detection PNG/JPEG/WebP/GIF; `DecodeError` code `DECODE_FAILED` on bad bytes; alpha preserved) and `encode` (PNG/WebP)
- 7 strict-TDD tests with programmatically-generated images (no committed fixtures); lossless PNG round-trip verified
- Wired `nukebg-core` resolution for the cli mirroring the app (tsconfig `paths` + new `vitest.config.ts` alias to core source; cli is non-composite, removed from root references; bundled by tsup later)
- Added cli `typecheck: tsc --noEmit` → the gate now covers all 3 packages

## Test plan

- [x] `npm run typecheck` — clean across app + core (`tsc -b`) + cli, no pre-built dist
- [x] `npm test` — 737 app + **7 cli** + 314 core
- [x] `npm run lint` — clean

## Note

The cli is **not yet in the lint/format gate** (root `lint`/`format:check` target `nukebg-app` only). CLI code is kept clean manually; wiring cli into eslint/prettier can land in a later phase (18/20).

> **Stacked PR.** Targets `fix/core-strict-indexing` (#301). `sharp@^0.34` added to cli deps (installs + loads on win32-x64).

Closes #276

<!-- chain-context:extract-core-cli -->

## Chain Context

| Field | Value |
|-------|-------|
| Chain | extract-core-cli (17 slices) |
| Tracker PR | `feat/extract-core-cli` → `dev` — opens once #291 merges into the tracker (GitHub rejects a zero-diff PR) |
| Position | 11 of 17 |
| Base | `fix/core-strict-indexing` |
| Depends on | #301 |
| Follow-up | #319 |
| Review budget | 934 (913 additions + 21 deletions) / 400 — `size:exception` requested |

### Chain Overview

```text
dev
 └── feat/extract-core-cli  (tracker, draft/no-merge)
      └── #291 … #301  (10 earlier slices)
           └── 📍 #302  phase 11 — SharpImageCodec
                └── #319 … #324  (6 later slices)
```

### Autonomy

- [x] CI is expected to pass for this PR branch
- [x] This PR has one deliverable scope
- [x] This PR can be rolled back without unrelated changes
- [x] Tests, docs, or manual verification cover this unit
