### PR TITLE
feat(cli): implement SharpImageCodec (phase 11)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ node_modules/
 dist/
 test-output/
 packages/*/dist/
+*.tsbuildinfo
 
 # Environment
 .env

--- a/openspec/changes/extract-core-cli/tasks.md
+++ b/openspec/changes/extract-core-cli/tasks.md
@@ -283,7 +283,7 @@ _Goal: `PipelineOrchestrator` → `WorkerPipelineRunner`. Browser app satisfies 
 
 _Goal: first Node-side adapter. Strict TDD: encode/decode round-trip._
 
-- [ ] 11.1 Write failing tests for `SharpImageCodec.decode` (REQ-CORE-RUNNERS-3):
+- [x] 11.1 Write failing tests for `SharpImageCodec.decode` (REQ-CORE-RUNNERS-3):
   - File: `packages/nukebg-cli/tests/codecs/sharp-codec.test.ts`
   - Scenarios:
     - Valid PNG bytes → `ImageDataLike` with correct `width`, `height`, non-empty `data` (length = `width * height * 4`).
@@ -291,18 +291,18 @@ _Goal: first Node-side adapter. Strict TDD: encode/decode round-trip._
     - Invalid bytes (non-image) → rejects with `DecodeError`, `error.code === "DECODE_FAILED"`.
     - Alpha channel preserved: encode RGBA with transparent pixels → decode back → alpha values match.
 
-- [ ] 11.2 Implement `packages/nukebg-cli/src/codecs/sharp-codec.ts` — `SharpImageCodec implements ImageCodec` using `sharp`. Format detection by magic bytes. Run tests, expect green.
+- [x] 11.2 Implement `packages/nukebg-cli/src/codecs/sharp-codec.ts` — `SharpImageCodec implements ImageCodec` using `sharp`. Format detection by magic bytes. Run tests, expect green.
 
-- [ ] 11.3 Write failing tests for `SharpImageCodec.encode`:
+- [x] 11.3 Write failing tests for `SharpImageCodec.encode`:
   - PNG output starts with PNG magic bytes.
   - WebP output starts with RIFF/WEBP header.
   - Round-trip: encode PNG then decode → pixel data identical.
 
-- [ ] 11.4 Implement `encode` method in `SharpImageCodec`. Run tests, expect green.
+- [x] 11.4 Implement `encode` method in `SharpImageCodec`. Run tests, expect green.
 
-- [ ] 11.5 Refactor if needed (extract magic-byte detection to a private helper). Run tests, expect green.
+- [x] 11.5 Refactor if needed (extract magic-byte detection to a private helper). Run tests, expect green.
 
-- [ ] 11.6 Verification: `npm test` (CLI project only: `npm test -w nukebg-cli`), `npm run typecheck`. Milestone: "`SharpImageCodec` implemented and round-trip tested".
+- [x] 11.6 Verification: `npm test` (CLI project only: `npm test -w nukebg-cli`), `npm run typecheck`. Milestone: "`SharpImageCodec` implemented and round-trip tested".
 
 ---
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1657,6 +1657,47 @@
         "node": ">=18"
       }
     },
+    "node_modules/color": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/color/-/color-4.2.3.tgz",
+      "integrity": "sha512-1rXeuUUiGGrykh+CeBdu5Ie7OJwinCgQY0bc7GCRxy5xVHy+moaqkpL/jqQq0MtQOeYcrqEz4abc5f0KtU7W4A==",
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1",
+        "color-string": "^1.9.0"
+      },
+      "engines": {
+        "node": ">=12.5.0"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "license": "MIT"
+    },
+    "node_modules/color-string": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/color-string/-/color-string-1.9.1.tgz",
+      "integrity": "sha512-shrVawQFojnZv6xM40anx4CkoDP+fZsw/ZerEMsW/pyzsRbElpsL/DBVW7q3ExxwusdNXI3lXpuhEZkzs8p5Eg==",
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "^1.0.0",
+        "simple-swizzle": "^0.2.2"
+      }
+    },
     "node_modules/convert-source-map": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
@@ -2259,6 +2300,12 @@
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "license": "ISC"
+    },
+    "node_modules/is-arrayish": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.4.tgz",
+      "integrity": "sha512-m6UrgzFVUYawGBh1dUsWR5M2Clqic9RVXC/9f8ceNlv2IcO9j9J/z8UoCLPqtsPBFNzEpfR3xftohbfqDx8EQA==",
+      "license": "MIT"
     },
     "node_modules/is-extglob": {
       "version": "2.1.1",
@@ -3263,6 +3310,15 @@
       "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/simple-swizzle": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.4.tgz",
+      "integrity": "sha512-nAu1WFPQSMNr2Zn9PGSZK9AGn4t/y97lEm+MXTtUDwfP0ksAIX4nO+6ruD9Jwut4C49SB1Ws+fbXsm/yScWOHw==",
+      "license": "MIT",
+      "dependencies": {
+        "is-arrayish": "^0.3.1"
+      }
     },
     "node_modules/source-map-js": {
       "version": "1.2.1",
@@ -4269,7 +4325,8 @@
       "version": "0.1.0",
       "license": "GPL-3.0-only",
       "dependencies": {
-        "nukebg-core": "0.1.0"
+        "nukebg-core": "0.1.0",
+        "sharp": "^0.33.5"
       },
       "bin": {
         "nukebg": "dist/cli.js"
@@ -4277,6 +4334,442 @@
       "devDependencies": {},
       "engines": {
         "node": ">=20.0.0"
+      }
+    },
+    "packages/nukebg-cli/node_modules/@img/sharp-darwin-arm64": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.33.5.tgz",
+      "integrity": "sha512-UT4p+iz/2H4twwAoLCqfA9UH5pI6DggwKEGuaPy7nCVQ8ZsiY5PIcrRvD1DzuY3qYL07NtIQcWnBSY/heikIFQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-arm64": "1.0.4"
+      }
+    },
+    "packages/nukebg-cli/node_modules/@img/sharp-darwin-x64": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.33.5.tgz",
+      "integrity": "sha512-fyHac4jIc1ANYGRDxtiqelIbdWkIuQaI84Mv45KvGRRxSAa7o7d1ZKAOBaYbnepLC1WqxfpimdeWfvqqSGwR2Q==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-x64": "1.0.4"
+      }
+    },
+    "packages/nukebg-cli/node_modules/@img/sharp-libvips-darwin-arm64": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.0.4.tgz",
+      "integrity": "sha512-XblONe153h0O2zuFfTAbQYAX2JhYmDHeWikp1LM9Hul9gVPjFY427k6dFEcOL72O01QxQsWi761svJ/ev9xEDg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "packages/nukebg-cli/node_modules/@img/sharp-libvips-darwin-x64": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.0.4.tgz",
+      "integrity": "sha512-xnGR8YuZYfJGmWPvmlunFaWJsb9T/AO2ykoP3Fz/0X5XV2aoYBPkX6xqCQvUTKKiLddarLaxpzNe+b1hjeWHAQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "packages/nukebg-cli/node_modules/@img/sharp-libvips-linux-arm": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.0.5.tgz",
+      "integrity": "sha512-gvcC4ACAOPRNATg/ov8/MnbxFDJqf/pDePbBnuBDcjsI8PssmjoKMAz4LtLaVi+OnSb5FK/yIOamqDwGmXW32g==",
+      "cpu": [
+        "arm"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "packages/nukebg-cli/node_modules/@img/sharp-libvips-linux-arm64": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.0.4.tgz",
+      "integrity": "sha512-9B+taZ8DlyyqzZQnoeIvDVR/2F4EbMepXMc/NdVbkzsJbzkUjhXv/70GQJ7tdLA4YJgNP25zukcxpX2/SueNrA==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "packages/nukebg-cli/node_modules/@img/sharp-libvips-linux-s390x": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.0.4.tgz",
+      "integrity": "sha512-u7Wz6ntiSSgGSGcjZ55im6uvTrOxSIS8/dgoVMoiGE9I6JAfU50yH5BoDlYA1tcuGS7g/QNtetJnxA6QEsCVTA==",
+      "cpu": [
+        "s390x"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "packages/nukebg-cli/node_modules/@img/sharp-libvips-linux-x64": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.0.4.tgz",
+      "integrity": "sha512-MmWmQ3iPFZr0Iev+BAgVMb3ZyC4KeFc3jFxnNbEPas60e1cIfevbtuyf9nDGIzOaW9PdnDciJm+wFFaTlj5xYw==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "packages/nukebg-cli/node_modules/@img/sharp-libvips-linuxmusl-arm64": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.0.4.tgz",
+      "integrity": "sha512-9Ti+BbTYDcsbp4wfYib8Ctm1ilkugkA/uscUn6UXK1ldpC1JjiXbLfFZtRlBhjPZ5o1NCLiDbg8fhUPKStHoTA==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "packages/nukebg-cli/node_modules/@img/sharp-libvips-linuxmusl-x64": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.0.4.tgz",
+      "integrity": "sha512-viYN1KX9m+/hGkJtvYYp+CCLgnJXwiQB39damAO7WMdKWlIhmYTfHjwSbQeUK/20vY154mwezd9HflVFM1wVSw==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "packages/nukebg-cli/node_modules/@img/sharp-linux-arm": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.33.5.tgz",
+      "integrity": "sha512-JTS1eldqZbJxjvKaAkxhZmBqPRGmxgu+qFKSInv8moZ2AmT5Yib3EQ1c6gp493HvrvV8QgdOXdyaIBrhvFhBMQ==",
+      "cpu": [
+        "arm"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm": "1.0.5"
+      }
+    },
+    "packages/nukebg-cli/node_modules/@img/sharp-linux-arm64": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.33.5.tgz",
+      "integrity": "sha512-JMVv+AMRyGOHtO1RFBiJy/MBsgz0x4AWrT6QoEVVTyh1E39TrCUpTRI7mx9VksGX4awWASxqCYLCV4wBZHAYxA==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm64": "1.0.4"
+      }
+    },
+    "packages/nukebg-cli/node_modules/@img/sharp-linux-s390x": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.33.5.tgz",
+      "integrity": "sha512-y/5PCd+mP4CA/sPDKl2961b+C9d+vPAveS33s6Z3zfASk2j5upL6fXVPZi7ztePZ5CuH+1kW8JtvxgbuXHRa4Q==",
+      "cpu": [
+        "s390x"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-s390x": "1.0.4"
+      }
+    },
+    "packages/nukebg-cli/node_modules/@img/sharp-linux-x64": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.33.5.tgz",
+      "integrity": "sha512-opC+Ok5pRNAzuvq1AG0ar+1owsu842/Ab+4qvU879ippJBHvyY5n2mxF1izXqkPYlGuP/M556uh53jRLJmzTWA==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-x64": "1.0.4"
+      }
+    },
+    "packages/nukebg-cli/node_modules/@img/sharp-linuxmusl-arm64": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.33.5.tgz",
+      "integrity": "sha512-XrHMZwGQGvJg2V/oRSUfSAfjfPxO+4DkiRh6p2AFjLQztWUuY/o8Mq0eMQVIY7HJ1CDQUJlxGGZRw1a5bqmd1g==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-arm64": "1.0.4"
+      }
+    },
+    "packages/nukebg-cli/node_modules/@img/sharp-linuxmusl-x64": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.33.5.tgz",
+      "integrity": "sha512-WT+d/cgqKkkKySYmqoZ8y3pxx7lx9vVejxW/W4DOFMYVSkErR+w7mf2u8m/y4+xHe7yY9DAXQMWQhpnMuFfScw==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-x64": "1.0.4"
+      }
+    },
+    "packages/nukebg-cli/node_modules/@img/sharp-wasm32": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.33.5.tgz",
+      "integrity": "sha512-ykUW4LVGaMcU9lu9thv85CbRMAwfeadCJHRsg2GmeRa/cJxsVY9Rbd57JcMxBkKHag5U/x7TSBpScF4U8ElVzg==",
+      "cpu": [
+        "wasm32"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/runtime": "^1.2.0"
+      },
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "packages/nukebg-cli/node_modules/@img/sharp-win32-ia32": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.33.5.tgz",
+      "integrity": "sha512-T36PblLaTwuVJ/zw/LaH0PdZkRz5rd3SmMHX8GSmR7vtNSP5Z6bQkExdSK7xGWyxLw4sUknBuugTelgw2faBbQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "packages/nukebg-cli/node_modules/@img/sharp-win32-x64": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.33.5.tgz",
+      "integrity": "sha512-MpY/o8/8kj+EcnxwvrP4aTJSWw/aZ7JIGR4aBeZkZw5B7/Jn+tY9/VNwtcoGmdT7GfggGIU4kygOMSbYnOrAbg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "packages/nukebg-cli/node_modules/sharp": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.33.5.tgz",
+      "integrity": "sha512-haPVm1EkS9pgvHrQ/F3Xy+hgcuMV0Wm9vfIBSiwZ05k+xgb0PkBQpGsAA/oWdDobNaZTH5ppvHtzCFbnSEwHVw==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "color": "^4.2.3",
+        "detect-libc": "^2.0.3",
+        "semver": "^7.6.3"
+      },
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-darwin-arm64": "0.33.5",
+        "@img/sharp-darwin-x64": "0.33.5",
+        "@img/sharp-libvips-darwin-arm64": "1.0.4",
+        "@img/sharp-libvips-darwin-x64": "1.0.4",
+        "@img/sharp-libvips-linux-arm": "1.0.5",
+        "@img/sharp-libvips-linux-arm64": "1.0.4",
+        "@img/sharp-libvips-linux-s390x": "1.0.4",
+        "@img/sharp-libvips-linux-x64": "1.0.4",
+        "@img/sharp-libvips-linuxmusl-arm64": "1.0.4",
+        "@img/sharp-libvips-linuxmusl-x64": "1.0.4",
+        "@img/sharp-linux-arm": "0.33.5",
+        "@img/sharp-linux-arm64": "0.33.5",
+        "@img/sharp-linux-s390x": "0.33.5",
+        "@img/sharp-linux-x64": "0.33.5",
+        "@img/sharp-linuxmusl-arm64": "0.33.5",
+        "@img/sharp-linuxmusl-x64": "0.33.5",
+        "@img/sharp-wasm32": "0.33.5",
+        "@img/sharp-win32-ia32": "0.33.5",
+        "@img/sharp-win32-x64": "0.33.5"
       }
     },
     "packages/nukebg-core": {

--- a/packages/nukebg-cli/package.json
+++ b/packages/nukebg-cli/package.json
@@ -4,17 +4,24 @@
   "type": "module",
   "license": "GPL-3.0-only",
   "description": "CLI for nukebg — Node-only background removal using nukebg-core.",
-  "bin": { "nukebg": "./dist/cli.js" },
+  "bin": {
+    "nukebg": "./dist/cli.js"
+  },
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
-  "files": ["dist", "README.md", "LICENSE"],
+  "files": [
+    "dist",
+    "README.md",
+    "LICENSE"
+  ],
   "scripts": {
-    "test": "vitest run --passWithNoTests"
+    "test": "vitest run --passWithNoTests",
+    "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "nukebg-core": "0.1.0"
+    "nukebg-core": "0.1.0",
+    "sharp": "^0.34.5"
   },
-  "devDependencies": {},
   "engines": {
     "node": ">=20.0.0"
   }

--- a/packages/nukebg-cli/src/codecs/sharp-codec.ts
+++ b/packages/nukebg-cli/src/codecs/sharp-codec.ts
@@ -1,0 +1,170 @@
+import sharp from 'sharp';
+import type { ImageCodec, EncodeFormat } from 'nukebg-core';
+import type { ImageDataLike } from 'nukebg-core';
+import { DecodeError, createImageDataLike } from 'nukebg-core';
+
+// ---------------------------------------------------------------------------
+// Magic-byte detection — identifies image format from the first bytes of the
+// buffer before handing off to sharp. This allows early rejection of clearly
+// non-image data with a clear DecodeError rather than a cryptic sharp error.
+// ---------------------------------------------------------------------------
+
+function detectFormat(bytes: Uint8Array): 'png' | 'jpeg' | 'webp' | 'gif' | 'unknown' {
+  if (bytes.length < 4) return 'unknown';
+
+  // PNG: 89 50 4E 47 (the classic PNG magic)
+  if (
+    bytes[0] === 0x89 &&
+    bytes[1] === 0x50 &&
+    bytes[2] === 0x4e &&
+    bytes[3] === 0x47
+  ) {
+    return 'png';
+  }
+
+  // JPEG: FF D8 FF
+  if (bytes[0] === 0xff && bytes[1] === 0xd8 && bytes[2] === 0xff) {
+    return 'jpeg';
+  }
+
+  // WebP: RIFF????WEBP
+  if (
+    bytes.length >= 12 &&
+    bytes[0] === 0x52 && // R
+    bytes[1] === 0x49 && // I
+    bytes[2] === 0x46 && // F
+    bytes[3] === 0x46 && // F
+    bytes[8] === 0x57 && // W
+    bytes[9] === 0x45 && // E
+    bytes[10] === 0x42 && // B
+    bytes[11] === 0x50 // P
+  ) {
+    return 'webp';
+  }
+
+  // GIF: 47 49 46 38
+  if (
+    bytes[0] === 0x47 &&
+    bytes[1] === 0x49 &&
+    bytes[2] === 0x46 &&
+    bytes[3] === 0x38
+  ) {
+    return 'gif';
+  }
+
+  return 'unknown';
+}
+
+// ---------------------------------------------------------------------------
+// SharpImageCodec
+// ---------------------------------------------------------------------------
+
+/**
+ * Node-only implementation of the `ImageCodec` interface backed by `sharp`.
+ *
+ * decode: accepts PNG, JPEG, WebP (and other formats sharp supports).
+ *         Always returns 4-channel RGBA via `.ensureAlpha()`.
+ *         Rejects with `DecodeError` ("DECODE_FAILED") for unrecognised bytes.
+ *
+ * encode: converts an `ImageDataLike` (RGBA flat array) back to PNG or WebP.
+ */
+export class SharpImageCodec implements ImageCodec {
+  async decode(
+    bytes: Uint8Array | ArrayBufferView,
+    opts?: { maxDimension?: number },
+  ): Promise<{
+    image: ImageDataLike;
+    originalWidth: number;
+    originalHeight: number;
+    wasDownsampled: boolean;
+  }> {
+    const buf = bytes instanceof Uint8Array
+      ? Buffer.from(bytes.buffer, bytes.byteOffset, bytes.byteLength)
+      : Buffer.from((bytes as ArrayBufferView).buffer);
+
+    // Quick magic-byte check — reject obviously non-image data early
+    const asUint8 = new Uint8Array(buf.buffer, buf.byteOffset, buf.byteLength);
+    const fmt = detectFormat(asUint8);
+    if (fmt === 'unknown') {
+      throw new DecodeError(
+        `Cannot decode bytes: unrecognised image format (first bytes: ${Array.from(asUint8.slice(0, 4))
+          .map((b) => `0x${b.toString(16).padStart(2, '0')}`)
+          .join(' ')})`,
+      );
+    }
+
+    let img = sharp(buf).ensureAlpha();
+
+    // Retrieve metadata to know original dimensions before any resize
+    let metadata: sharp.Metadata;
+    try {
+      metadata = await sharp(buf).metadata();
+    } catch (cause) {
+      throw new DecodeError(`Failed to read image metadata`, { cause });
+    }
+
+    const originalWidth = metadata.width ?? 0;
+    const originalHeight = metadata.height ?? 0;
+
+    let wasDownsampled = false;
+
+    if (opts?.maxDimension !== undefined) {
+      const maxDim = opts.maxDimension;
+      if (originalWidth > maxDim || originalHeight > maxDim) {
+        wasDownsampled = true;
+        img = img.resize({
+          width: maxDim,
+          height: maxDim,
+          fit: 'inside',
+          withoutEnlargement: true,
+        });
+      }
+    }
+
+    let rawBuf: Buffer;
+    let info: sharp.OutputInfo;
+    try {
+      ({ data: rawBuf, info } = await img.raw().toBuffer({ resolveWithObject: true }));
+    } catch (cause) {
+      throw new DecodeError(`sharp failed to decode image`, { cause });
+    }
+
+    const data = new Uint8ClampedArray(rawBuf.buffer, rawBuf.byteOffset, rawBuf.byteLength);
+    const image = createImageDataLike(data, info.width, info.height);
+
+    return { image, originalWidth, originalHeight, wasDownsampled };
+  }
+
+  async encode(
+    image: ImageDataLike,
+    format: EncodeFormat,
+    opts?: { quality?: number },
+  ): Promise<Uint8Array> {
+    const { data, width, height } = image;
+
+    // sharp expects a plain Buffer; Uint8ClampedArray is compatible in layout
+    const buf = Buffer.from(data.buffer, data.byteOffset, data.byteLength);
+
+    let pipeline = sharp(buf, {
+      raw: { width, height, channels: 4 },
+    });
+
+    let outBuf: Buffer;
+    switch (format) {
+      case 'png':
+        outBuf = await pipeline.png().toBuffer();
+        break;
+      case 'webp':
+        outBuf = await pipeline
+          .webp({ quality: opts?.quality ?? 80, lossless: false })
+          .toBuffer();
+        break;
+      default: {
+        const _exhaustive: never = format;
+        throw new Error(`Unsupported format: ${_exhaustive as string}`);
+      }
+    }
+
+    return new Uint8Array(outBuf.buffer, outBuf.byteOffset, outBuf.byteLength);
+  }
+}

--- a/packages/nukebg-cli/tests/codecs/sharp-codec.test.ts
+++ b/packages/nukebg-cli/tests/codecs/sharp-codec.test.ts
@@ -1,0 +1,197 @@
+import { describe, it, expect, beforeAll } from 'vitest';
+import sharp from 'sharp';
+import { SharpImageCodec } from '../../src/codecs/sharp-codec.js';
+import { DecodeError } from 'nukebg-core';
+
+// ---------------------------------------------------------------------------
+// Test fixture generators — produce image bytes programmatically via sharp
+// so no binary fixtures need to be committed.
+// ---------------------------------------------------------------------------
+
+let pngBytes: Uint8Array;
+let jpegBytes: Uint8Array;
+let rgbaPngBytes: Uint8Array; // RGBA with a transparent region
+
+const WIDTH = 8;
+const HEIGHT = 8;
+
+beforeAll(async () => {
+  // Solid red 8x8 PNG (opaque)
+  pngBytes = new Uint8Array(
+    await sharp({
+      create: {
+        width: WIDTH,
+        height: HEIGHT,
+        channels: 3,
+        background: { r: 255, g: 0, b: 0 },
+      },
+    })
+      .png()
+      .toBuffer(),
+  );
+
+  // Solid blue 8x8 JPEG
+  jpegBytes = new Uint8Array(
+    await sharp({
+      create: {
+        width: WIDTH,
+        height: HEIGHT,
+        channels: 3,
+        background: { r: 0, g: 0, b: 255 },
+      },
+    })
+      .jpeg({ quality: 95 })
+      .toBuffer(),
+  );
+
+  // RGBA 8x8 PNG: top half fully opaque (alpha=255), bottom half fully transparent (alpha=0)
+  const rgbaPixels = new Uint8Array(WIDTH * HEIGHT * 4);
+  for (let y = 0; y < HEIGHT; y++) {
+    for (let x = 0; x < WIDTH; x++) {
+      const i = (y * WIDTH + x) * 4;
+      rgbaPixels[i] = 0; // R
+      rgbaPixels[i + 1] = 200; // G
+      rgbaPixels[i + 2] = 100; // B
+      rgbaPixels[i + 3] = y < HEIGHT / 2 ? 255 : 0; // A
+    }
+  }
+  rgbaPngBytes = new Uint8Array(
+    await sharp(Buffer.from(rgbaPixels), {
+      raw: { width: WIDTH, height: HEIGHT, channels: 4 },
+    })
+      .png()
+      .toBuffer(),
+  );
+});
+
+// ---------------------------------------------------------------------------
+// decode — Task 11.1 tests (RED phase → will fail until 11.2 is implemented)
+// ---------------------------------------------------------------------------
+
+describe('SharpImageCodec.decode', () => {
+  it('decodes a valid PNG into ImageDataLike with correct dimensions', async () => {
+    const codec = new SharpImageCodec();
+    const result = await codec.decode(pngBytes);
+
+    expect(result.image.width).toBe(WIDTH);
+    expect(result.image.height).toBe(HEIGHT);
+    expect(result.image.data.length).toBe(WIDTH * HEIGHT * 4);
+    expect(result.originalWidth).toBe(WIDTH);
+    expect(result.originalHeight).toBe(HEIGHT);
+    expect(result.wasDownsampled).toBe(false);
+  });
+
+  it('decodes a valid JPEG into ImageDataLike with correct dimensions', async () => {
+    const codec = new SharpImageCodec();
+    const result = await codec.decode(jpegBytes);
+
+    expect(result.image.width).toBe(WIDTH);
+    expect(result.image.height).toBe(HEIGHT);
+    expect(result.image.data.length).toBe(WIDTH * HEIGHT * 4);
+    expect(result.wasDownsampled).toBe(false);
+  });
+
+  it('rejects with DecodeError (code "DECODE_FAILED") for invalid/non-image bytes', async () => {
+    const codec = new SharpImageCodec();
+    const garbage = new Uint8Array([0x00, 0x01, 0x02, 0x03, 0x04, 0x05]);
+
+    await expect(codec.decode(garbage)).rejects.toSatisfy(
+      (e: unknown) => e instanceof DecodeError && (e as DecodeError).code === 'DECODE_FAILED',
+    );
+  });
+
+  it('preserves alpha channel: transparent pixels stay alpha=0 after decode', async () => {
+    const codec = new SharpImageCodec();
+    const result = await codec.decode(rgbaPngBytes);
+
+    const { data, width, height } = result.image;
+    expect(data.length).toBe(width * height * 4);
+
+    // Bottom half should be fully transparent (alpha = 0)
+    for (let y = Math.floor(height / 2); y < height; y++) {
+      for (let x = 0; x < width; x++) {
+        const alpha = data[(y * width + x) * 4 + 3];
+        expect(alpha).toBe(0);
+      }
+    }
+
+    // Top half should be fully opaque (alpha = 255)
+    for (let y = 0; y < Math.floor(height / 2); y++) {
+      for (let x = 0; x < width; x++) {
+        const alpha = data[(y * width + x) * 4 + 3];
+        expect(alpha).toBe(255);
+      }
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// encode — Task 11.3 tests (RED phase → will fail until 11.4 is implemented)
+// ---------------------------------------------------------------------------
+
+describe('SharpImageCodec.encode', () => {
+  it('encodes ImageDataLike to PNG with valid PNG magic bytes', async () => {
+    const codec = new SharpImageCodec();
+
+    // Build a simple 4x4 RGBA image
+    const pixels = new Uint8ClampedArray(4 * 4 * 4).fill(128);
+    const image = { data: pixels, width: 4, height: 4 };
+
+    const encoded = await codec.encode(image, 'png');
+
+    // PNG magic: 0x89 0x50 0x4E 0x47
+    expect(encoded[0]).toBe(0x89);
+    expect(encoded[1]).toBe(0x50); // P
+    expect(encoded[2]).toBe(0x4e); // N
+    expect(encoded[3]).toBe(0x47); // G
+  });
+
+  it('encodes ImageDataLike to WebP with valid RIFF/WEBP header', async () => {
+    const codec = new SharpImageCodec();
+
+    const pixels = new Uint8ClampedArray(4 * 4 * 4).fill(200);
+    const image = { data: pixels, width: 4, height: 4 };
+
+    const encoded = await codec.encode(image, 'webp');
+
+    // RIFF header: 0x52 0x49 0x46 0x46 (RIFF)
+    expect(encoded[0]).toBe(0x52); // R
+    expect(encoded[1]).toBe(0x49); // I
+    expect(encoded[2]).toBe(0x46); // F
+    expect(encoded[3]).toBe(0x46); // F
+
+    // Bytes 8–11 should be WEBP: 0x57 0x45 0x42 0x50
+    expect(encoded[8]).toBe(0x57); // W
+    expect(encoded[9]).toBe(0x45); // E
+    expect(encoded[10]).toBe(0x42); // B
+    expect(encoded[11]).toBe(0x50); // P
+  });
+
+  it('round-trip: encode PNG then decode → pixel data is identical', async () => {
+    const codec = new SharpImageCodec();
+
+    // Build a known RGBA image
+    const width = 4;
+    const height = 4;
+    const pixels = new Uint8ClampedArray(width * height * 4);
+    for (let i = 0; i < pixels.length; i += 4) {
+      pixels[i] = 100; // R
+      pixels[i + 1] = 150; // G
+      pixels[i + 2] = 200; // B
+      pixels[i + 3] = 128; // A (semi-transparent)
+    }
+    const image = { data: pixels, width, height };
+
+    const encoded = await codec.encode(image, 'png');
+    const decoded = await codec.decode(new Uint8Array(encoded.buffer, encoded.byteOffset, encoded.byteLength));
+
+    expect(decoded.image.width).toBe(width);
+    expect(decoded.image.height).toBe(height);
+    expect(decoded.image.data.length).toBe(pixels.length);
+
+    // PNG is lossless — pixels must be identical
+    for (let i = 0; i < pixels.length; i++) {
+      expect(decoded.image.data[i]).toBe(pixels[i]);
+    }
+  });
+});

--- a/packages/nukebg-cli/tsconfig.json
+++ b/packages/nukebg-cli/tsconfig.json
@@ -1,13 +1,12 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "composite": true,
-    "outDir": "./dist",
-    "rootDir": "./src"
+    "ignoreDeprecations": "6.0",
+    "paths": {
+      "nukebg-core": ["../nukebg-core/src/index.ts"],
+      "nukebg-core/*": ["../nukebg-core/src/*"]
+    }
   },
-  "references": [
-    { "path": "../nukebg-core" }
-  ],
-  "include": ["src/**/*.ts"],
+  "include": ["src/**/*.ts", "tests/**/*.ts"],
   "exclude": ["node_modules", "dist"]
 }

--- a/packages/nukebg-cli/vitest.config.ts
+++ b/packages/nukebg-cli/vitest.config.ts
@@ -1,0 +1,27 @@
+import { defineConfig } from 'vitest/config';
+import { fileURLToPath } from 'node:url';
+import { resolve } from 'node:path';
+
+const __dirname = fileURLToPath(new URL('.', import.meta.url));
+
+export default defineConfig({
+  resolve: {
+    alias: [
+      // Resolve nukebg-core sub-path imports to core source (must come before bare alias)
+      {
+        find: /^nukebg-core\/(.+)$/,
+        replacement: resolve(__dirname, '../nukebg-core/src/$1'),
+      },
+      // Resolve bare 'nukebg-core' to its TypeScript barrel (no pre-built dist required)
+      {
+        find: 'nukebg-core',
+        replacement: resolve(__dirname, '../nukebg-core/src/index.ts'),
+      },
+    ],
+  },
+  test: {
+    include: ['tests/**/*.test.ts'],
+    environment: 'node',
+    globals: true,
+  },
+});

--- a/packages/nukebg-core/package.json
+++ b/packages/nukebg-core/package.json
@@ -15,6 +15,7 @@
   "files": ["dist", "README.md", "LICENSE"],
   "scripts": {
     "build": "tsc -b",
+    "typecheck": "tsc -b",
     "test": "vitest run --passWithNoTests"
   },
   "dependencies": {},

--- a/packages/nukebg-core/src/cv/alpha-matting.ts
+++ b/packages/nukebg-core/src/cv/alpha-matting.ts
@@ -21,13 +21,13 @@ function boxMean(src: Float32Array, w: number, h: number, radius: number): Float
     let sum = 0;
     // Initialize window [0, radius]
     const initEnd = Math.min(radius, w - 1);
-    for (let x = 0; x <= initEnd; x++) sum += src[yOff + x];
+    for (let x = 0; x <= initEnd; x++) sum += src[yOff + x]!;
 
     for (let x = 0; x < w; x++) {
       // Expand right edge
-      if (x + radius < w && x > 0) sum += src[yOff + x + radius];
+      if (x + radius < w && x > 0) sum += src[yOff + x + radius]!;
       // Shrink left edge
-      if (x - radius - 1 >= 0) sum -= src[yOff + x - radius - 1];
+      if (x - radius - 1 >= 0) sum -= src[yOff + x - radius - 1]!;
       const x0 = Math.max(x - radius, 0);
       const x1 = Math.min(x + radius, w - 1);
       tmp[yOff + x] = sum / (x1 - x0 + 1);
@@ -38,11 +38,11 @@ function boxMean(src: Float32Array, w: number, h: number, radius: number): Float
   for (let x = 0; x < w; x++) {
     let sum = 0;
     const initEnd = Math.min(radius, h - 1);
-    for (let y = 0; y <= initEnd; y++) sum += tmp[y * w + x];
+    for (let y = 0; y <= initEnd; y++) sum += tmp[y * w + x]!;
 
     for (let y = 0; y < h; y++) {
-      if (y + radius < h && y > 0) sum += tmp[(y + radius) * w + x];
-      if (y - radius - 1 >= 0) sum -= tmp[(y - radius - 1) * w + x];
+      if (y + radius < h && y > 0) sum += tmp[(y + radius) * w + x]!;
+      if (y - radius - 1 >= 0) sum -= tmp[(y - radius - 1) * w + x]!;
       const y0 = Math.max(y - radius, 0);
       const y1 = Math.min(y + radius, h - 1);
       out[y * w + x] = sum / (y1 - y0 + 1);
@@ -60,7 +60,7 @@ function toLuminance(pixels: Uint8ClampedArray, w: number, h: number): Float32Ar
   const lum = new Float32Array(w * h);
   for (let i = 0; i < w * h; i++) {
     const off = i * 4;
-    lum[i] = (0.299 * pixels[off] + 0.587 * pixels[off + 1] + 0.114 * pixels[off + 2]) / 255;
+    lum[i] = (0.299 * pixels[off]! + 0.587 * pixels[off + 1]! + 0.114 * pixels[off + 2]!) / 255;
   }
   return lum;
 }
@@ -70,7 +70,7 @@ function toLuminance(pixels: Uint8ClampedArray, w: number, h: number): Float32Ar
  */
 function multiply(a: Float32Array, b: Float32Array): Float32Array {
   const out = new Float32Array(a.length);
-  for (let i = 0; i < a.length; i++) out[i] = a[i] * b[i];
+  for (let i = 0; i < a.length; i++) out[i] = a[i]! * b[i]!;
   return out;
 }
 
@@ -98,7 +98,7 @@ export function guidedFilter(
   // Convert inputs to float [0, 1]
   const I = toLuminance(pixels, w, h);
   const p = new Float32Array(n);
-  for (let i = 0; i < n; i++) p[i] = alpha[i] / 255;
+  for (let i = 0; i < n; i++) p[i] = alpha[i]! / 255;
 
   // Step 1: Compute means
   const meanI = boxMean(I, w, h, radius);
@@ -114,10 +114,10 @@ export function guidedFilter(
   const a = new Float32Array(n);
   const b = new Float32Array(n);
   for (let i = 0; i < n; i++) {
-    const varI = corrII[i] - meanI[i] * meanI[i];
-    const covIp = corrIp[i] - meanI[i] * meanP[i];
+    const varI = corrII[i]! - meanI[i]! * meanI[i]!;
+    const covIp = corrIp[i]! - meanI[i]! * meanP[i]!;
     a[i] = covIp / (varI + epsilon);
-    b[i] = meanP[i] - a[i] * meanI[i];
+    b[i] = meanP[i]! - a[i]! * meanI[i]!;
   }
 
   // Step 4: Compute mean of a and b
@@ -127,7 +127,7 @@ export function guidedFilter(
   // Step 5: Compute output
   const result = new Uint8Array(n);
   for (let i = 0; i < n; i++) {
-    const val = meanA[i] * I[i] + meanB[i];
+    const val = meanA[i]! * I[i]! + meanB[i]!;
     result[i] = Math.max(0, Math.min(255, Math.round(val * 255)));
   }
 

--- a/packages/nukebg-core/src/cv/alpha-refine.ts
+++ b/packages/nukebg-core/src/cv/alpha-refine.ts
@@ -19,14 +19,14 @@ export function alphaRefine(mask: Uint8Array, width: number, height: number): Ui
 
   // Step 3: Multiply by 2 and clamp (like np.clip(alpha_arr * 2, 0, 255))
   for (let i = 0; i < afterGauss.length; i++) {
-    afterGauss[i] = Math.min(afterGauss[i] * 2, 255);
+    afterGauss[i] = Math.min(afterGauss[i]! * 2, 255);
   }
 
   // Step 4: Threshold
   for (let i = 0; i < afterGauss.length; i++) {
-    if (afterGauss[i] > ALPHA_PARAMS.THRESHOLD_HIGH) {
+    if (afterGauss[i]! > ALPHA_PARAMS.THRESHOLD_HIGH) {
       afterGauss[i] = 255;
-    } else if (afterGauss[i] < ALPHA_PARAMS.THRESHOLD_LOW) {
+    } else if (afterGauss[i]! < ALPHA_PARAMS.THRESHOLD_LOW) {
       afterGauss[i] = 0;
     }
   }
@@ -47,13 +47,13 @@ function medianFilter(data: Uint8Array, width: number, height: number, kernel: n
         for (let kx = -half; kx <= half; kx++) {
           const ny = Math.min(Math.max(y + ky, 0), height - 1);
           const nx = Math.min(Math.max(x + kx, 0), width - 1);
-          values[count++] = data[ny * width + nx];
+          values[count++] = data[ny * width + nx]!;
         }
       }
       // Sort the neighborhood values and pick median
       const slice = values.slice(0, count);
       slice.sort((a, b) => a - b);
-      result[y * width + x] = slice[Math.floor(count / 2)];
+      result[y * width + x] = slice[Math.floor(count / 2)]!;
     }
   }
 
@@ -77,7 +77,7 @@ function gaussianBlur(data: Uint8Array, width: number, height: number, sigma: nu
   }
   // Normalize
   for (let i = 0; i < kernel.length; i++) {
-    kernel[i] /= sum;
+    kernel[i] = kernel[i]! / sum;
   }
 
   for (let y = 0; y < height; y++) {
@@ -88,7 +88,7 @@ function gaussianBlur(data: Uint8Array, width: number, height: number, sigma: nu
         for (let kx = -1; kx <= 1; kx++) {
           const ny = Math.min(Math.max(y + ky, 0), height - 1);
           const nx = Math.min(Math.max(x + kx, 0), width - 1);
-          val += data[ny * width + nx] * kernel[ki++];
+          val += data[ny * width + nx]! * kernel[ki++]!;
         }
       }
       result[y * width + x] = Math.round(val);

--- a/packages/nukebg-core/src/cv/classify-image.ts
+++ b/packages/nukebg-core/src/cv/classify-image.ts
@@ -42,9 +42,9 @@ export function extractImageFeatures(
 
   for (let i = 0; i < totalPixels; i++) {
     const off = i * 4;
-    const r = pixels[off];
-    const g = pixels[off + 1];
-    const b = pixels[off + 2];
+    const r = pixels[off]!;
+    const g = pixels[off + 1]!;
+    const b = pixels[off + 2]!;
 
     // Brightness (luminance approximation)
     const brightness = 0.299 * r + 0.587 * g + 0.114 * b;

--- a/packages/nukebg-core/src/cv/detect-bg-colors.ts
+++ b/packages/nukebg-core/src/cv/detect-bg-colors.ts
@@ -32,9 +32,9 @@ export function detectBgColors(
     for (let y = y0; y < y1; y++) {
       for (let x = x0; x < x1; x++) {
         const idx = (y * width + x) * 4;
-        const r = pixels[idx];
-        const g = pixels[idx + 1];
-        const b = pixels[idx + 2];
+        const r = pixels[idx]!;
+        const g = pixels[idx + 1]!;
+        const b = pixels[idx + 2]!;
         allR.push(r);
         allG.push(g);
         allB.push(b);
@@ -68,14 +68,14 @@ export function detectBgColors(
   const lightB: number[] = [];
 
   for (let i = 0; i < brightness.length; i++) {
-    if (brightness[i] <= medianB) {
-      darkR.push(allR[i]);
-      darkG.push(allG[i]);
-      darkB.push(allB[i]);
+    if (brightness[i]! <= medianB) {
+      darkR.push(allR[i]!);
+      darkG.push(allG[i]!);
+      darkB.push(allB[i]!);
     } else {
-      lightR.push(allR[i]);
-      lightG.push(allG[i]);
-      lightB.push(allB[i]);
+      lightR.push(allR[i]!);
+      lightG.push(allG[i]!);
+      lightB.push(allB[i]!);
     }
   }
 

--- a/packages/nukebg-core/src/cv/detect-checker-grid.ts
+++ b/packages/nukebg-core/src/cv/detect-checker-grid.ts
@@ -14,8 +14,8 @@ export function detectCheckerGrid(
   colorLight: number[],
 ): GridResult {
   const midBrightness =
-    ((colorDark[0] + colorDark[1] + colorDark[2]) / 3 +
-      (colorLight[0] + colorLight[1] + colorLight[2]) / 3) /
+    ((colorDark[0]! + colorDark[1]! + colorDark[2]!) / 3 +
+      (colorLight[0]! + colorLight[1]! + colorLight[2]!) / 3) /
     2;
 
   const gridSizes: number[] = [];
@@ -27,7 +27,7 @@ export function detectCheckerGrid(
 
     for (let x = 0; x < width; x++) {
       const idx = (rowIdx * width + x) * 4;
-      const b = (pixels[idx] + pixels[idx + 1] + pixels[idx + 2]) / 3;
+      const b = (pixels[idx]! + pixels[idx + 1]! + pixels[idx + 2]!) / 3;
       const above = b > midBrightness;
 
       if (x > 0 && above !== prevAbove) {
@@ -39,7 +39,7 @@ export function detectCheckerGrid(
     if (transitions.length >= 4) {
       const gaps: number[] = [];
       for (let i = 1; i < transitions.length; i++) {
-        const gap = transitions[i] - transitions[i - 1];
+        const gap = transitions[i]! - transitions[i - 1]!;
         if (gap > 5) {
           gaps.push(gap);
         }
@@ -66,7 +66,7 @@ export function detectCheckerGrid(
 
   if (centerY < height && centerX < width) {
     const idx = (centerY * width + centerX) * 4;
-    const sampleB = (pixels[idx] + pixels[idx + 1] + pixels[idx + 2]) / 3;
+    const sampleB = (pixels[idx]! + pixels[idx + 1]! + pixels[idx + 2]!) / 3;
     phase = sampleB < midBrightness ? 0 : 1;
   }
 

--- a/packages/nukebg-core/src/cv/foreground-estimation.ts
+++ b/packages/nukebg-core/src/cv/foreground-estimation.ts
@@ -64,7 +64,7 @@ export function estimateForeground(
   const pyramid = buildPyramid(observed, alpha, width, height);
 
   // Initialize F = B = I at the coarsest level.
-  const coarsest = pyramid[pyramid.length - 1];
+  const coarsest = pyramid[pyramid.length - 1]!;
   let F: Float32Array = new Float32Array(coarsest.width * coarsest.height * 3);
   let B: Float32Array = new Float32Array(coarsest.width * coarsest.height * 3);
   initializeFromImage(coarsest.image, F);
@@ -72,7 +72,7 @@ export function estimateForeground(
 
   // Coarse-to-fine solve.
   for (let level = pyramid.length - 1; level >= 0; level--) {
-    const { image, alpha: a, width: w, height: h } = pyramid[level];
+    const { image, alpha: a, width: w, height: h } = pyramid[level]!;
 
     // Precompute α-weight buffers (opaque pixels should dominate F̄; transparent
     // pixels should dominate B̄). Without this weighting, F gets dragged toward
@@ -81,7 +81,7 @@ export function estimateForeground(
     const wF = new Float32Array(w * h);
     const wB = new Float32Array(w * h);
     for (let i = 0; i < w * h; i++) {
-      const an = a[i] / 255;
+      const an = a[i]! / 255;
       wF[i] = an;
       wB[i] = 1 - an;
     }
@@ -94,7 +94,7 @@ export function estimateForeground(
 
     // Upsample F and B to the next finer level (bilinear), unless we're at L0.
     if (level > 0) {
-      const next = pyramid[level - 1];
+      const next = pyramid[level - 1]!;
       F = new Float32Array(upsample3(F, w, h, next.width, next.height));
       B = new Float32Array(upsample3(B, w, h, next.width, next.height));
     }
@@ -104,18 +104,18 @@ export function estimateForeground(
   // (no floating-point round-trip). Transparent pixels output zero RGB.
   const out = new Uint8ClampedArray(width * height * 4);
   for (let i = 0; i < width * height; i++) {
-    const a = alpha[i];
+    const a = alpha[i]!;
     out[i * 4 + 3] = a;
     if (a >= 254) {
-      out[i * 4] = observed[i * 4];
-      out[i * 4 + 1] = observed[i * 4 + 1];
-      out[i * 4 + 2] = observed[i * 4 + 2];
+      out[i * 4] = observed[i * 4]!;
+      out[i * 4 + 1] = observed[i * 4 + 1]!;
+      out[i * 4 + 2] = observed[i * 4 + 2]!;
     } else if (a <= 1) {
       // Invisible — leave RGB at zero.
     } else {
-      out[i * 4] = Math.max(0, Math.min(255, Math.round(F[i * 3])));
-      out[i * 4 + 1] = Math.max(0, Math.min(255, Math.round(F[i * 3 + 1])));
-      out[i * 4 + 2] = Math.max(0, Math.min(255, Math.round(F[i * 3 + 2])));
+      out[i * 4] = Math.max(0, Math.min(255, Math.round(F[i * 3]!)));
+      out[i * 4 + 1] = Math.max(0, Math.min(255, Math.round(F[i * 3 + 1]!)));
+      out[i * 4 + 2] = Math.max(0, Math.min(255, Math.round(F[i * 3 + 2]!)));
     }
   }
   return out;
@@ -140,7 +140,7 @@ function buildPyramid(
   while (Math.min(w, h) >= MIN_LEVEL_DIM * 2) {
     const nw = Math.max(1, w >> 1);
     const nh = Math.max(1, h >> 1);
-    const parent = levels[levels.length - 1];
+    const parent = levels[levels.length - 1]!;
     const nextImage = downsample2xRGBA(parent.image, parent.width, parent.height, nw, nh);
     const nextAlpha = downsample2xU8(parent.alpha, parent.width, parent.height, nw, nh);
     levels.push({ image: nextImage, alpha: nextAlpha, width: nw, height: nh });
@@ -153,9 +153,9 @@ function buildPyramid(
 function initializeFromImage(image: Uint8ClampedArray, out: Float32Array): void {
   const n = out.length / 3;
   for (let i = 0; i < n; i++) {
-    out[i * 3] = image[i * 4];
-    out[i * 3 + 1] = image[i * 4 + 1];
-    out[i * 3 + 2] = image[i * 4 + 2];
+    out[i * 3] = image[i * 4]!;
+    out[i * 3 + 1] = image[i * 4 + 1]!;
+    out[i * 3 + 2] = image[i * 4 + 2]!;
   }
 }
 
@@ -176,7 +176,7 @@ function solveIteration(
 ): void {
   const n = width * height;
   for (let i = 0; i < n; i++) {
-    const aN = alpha[i] / 255;
+    const aN = alpha[i]! / 255;
     const inv = 1 - aN;
 
     const a11 = aN * aN + lambda;
@@ -186,9 +186,9 @@ function solveIteration(
     if (det < 1e-6) continue; // degenerate; skip this pixel
 
     for (let ch = 0; ch < 3; ch++) {
-      const ii = image[i * 4 + ch];
-      const rf = aN * ii + lambda * Favg[i * 3 + ch];
-      const rb = inv * ii + lambda * Bavg[i * 3 + ch];
+      const ii = image[i * 4 + ch]!;
+      const rf = aN * ii + lambda * Favg[i * 3 + ch]!;
+      const rb = inv * ii + lambda * Bavg[i * 3 + ch]!;
       const newF = (rf * a22 - rb * a12) / det;
       const newB = (rb * a11 - rf * a12) / det;
       F[i * 3 + ch] = newF;
@@ -222,12 +222,12 @@ function weightedBoxBlur3(
         for (let dx = -r; dx <= r; dx++) {
           const xi = Math.min(Math.max(x + dx, 0), width - 1);
           const ni = yi * width + xi;
-          const wv = weights[ni];
+          const wv = weights[ni]!;
           if (wv === 0) continue;
           wsum += wv;
-          sr += wv * src[ni * 3];
-          sg += wv * src[ni * 3 + 1];
-          sb += wv * src[ni * 3 + 2];
+          sr += wv * src[ni * 3]!;
+          sg += wv * src[ni * 3 + 1]!;
+          sb += wv * src[ni * 3 + 2]!;
         }
       }
       const oi = y * width + x;
@@ -236,9 +236,9 @@ function weightedBoxBlur3(
         out[oi * 3 + 1] = sg / wsum;
         out[oi * 3 + 2] = sb / wsum;
       } else {
-        out[oi * 3] = src[oi * 3];
-        out[oi * 3 + 1] = src[oi * 3 + 1];
-        out[oi * 3 + 2] = src[oi * 3 + 2];
+        out[oi * 3] = src[oi * 3]!;
+        out[oi * 3 + 1] = src[oi * 3 + 1]!;
+        out[oi * 3 + 2] = src[oi * 3 + 2]!;
       }
     }
   }
@@ -270,10 +270,10 @@ function upsample3(
       const dx = sx - x0;
 
       for (let ch = 0; ch < 3; ch++) {
-        const a = src[(y0 * srcW + x0) * 3 + ch];
-        const b = src[(y0 * srcW + x1) * 3 + ch];
-        const c = src[(y1 * srcW + x0) * 3 + ch];
-        const d = src[(y1 * srcW + x1) * 3 + ch];
+        const a = src[(y0 * srcW + x0) * 3 + ch]!;
+        const b = src[(y0 * srcW + x1) * 3 + ch]!;
+        const c = src[(y1 * srcW + x0) * 3 + ch]!;
+        const d = src[(y1 * srcW + x1) * 3 + ch]!;
         const top = a + (b - a) * dx;
         const bot = c + (d - c) * dx;
         dst[(y * dstW + x) * 3 + ch] = top + (bot - top) * dy;
@@ -301,10 +301,10 @@ function downsample2xRGBA(
       const x1 = Math.min(x0 + 1, srcW - 1);
       for (let ch = 0; ch < 3; ch++) {
         const s =
-          src[(y0 * srcW + x0) * 4 + ch] +
-          src[(y0 * srcW + x1) * 4 + ch] +
-          src[(y1 * srcW + x0) * 4 + ch] +
-          src[(y1 * srcW + x1) * 4 + ch];
+          src[(y0 * srcW + x0) * 4 + ch]! +
+          src[(y0 * srcW + x1) * 4 + ch]! +
+          src[(y1 * srcW + x0) * 4 + ch]! +
+          src[(y1 * srcW + x1) * 4 + ch]!;
         dst[(y * dstW + x) * 4 + ch] = (s + 2) >> 2;
       }
       dst[(y * dstW + x) * 4 + 3] = 255;
@@ -329,7 +329,7 @@ function downsample2xU8(
       const x0 = Math.min(x * 2, srcW - 1);
       const x1 = Math.min(x0 + 1, srcW - 1);
       const s =
-        src[y0 * srcW + x0] + src[y0 * srcW + x1] + src[y1 * srcW + x0] + src[y1 * srcW + x1];
+        src[y0 * srcW + x0]! + src[y0 * srcW + x1]! + src[y1 * srcW + x0]! + src[y1 * srcW + x1]!;
       dst[y * dstW + x] = (s + 2) >> 2;
     }
   }

--- a/packages/nukebg-core/src/cv/grid-flood-fill.ts
+++ b/packages/nukebg-core/src/cv/grid-flood-fill.ts
@@ -80,8 +80,8 @@ export function gridFloodFill(
   while (!queue.empty) {
     const [y, x] = queue.pop();
     for (let d = 0; d < 4; d++) {
-      const ny = y + dy[d];
-      const nx = x + dx[d];
+      const ny = y + dy[d]!;
+      const nx = x + dx[d]!;
       if (ny >= 0 && ny < height && nx >= 0 && nx < width) {
         const npos = ny * width + nx;
         if (!visited[npos]) {

--- a/packages/nukebg-core/src/cv/inpaint-blend.ts
+++ b/packages/nukebg-core/src/cv/inpaint-blend.ts
@@ -46,7 +46,7 @@ export function dilateMask(
       const row = y * width;
       for (let x = 0; x < width; x++) {
         const i = row + x;
-        let v = src[i];
+        let v = src[i]!;
         if (x > 0 && src[i - 1]) v = 1;
         if (x < width - 1 && src[i + 1]) v = 1;
         dst[i] = v;
@@ -57,7 +57,7 @@ export function dilateMask(
       const row = y * width;
       for (let x = 0; x < width; x++) {
         const i = row + x;
-        let v = dst[i];
+        let v = dst[i]!;
         if (y > 0 && dst[i - width]) v = 1;
         if (y < height - 1 && dst[i + width]) v = 1;
         src[i] = v;
@@ -130,12 +130,12 @@ export function compositeWithFeather(
 
   // Composite with alpha + noise inside the core.
   for (let i = 0, p = 0; i < alphaMap.length; i++, p += 4) {
-    const a = alphaMap[i];
+    const a = alphaMap[i]!;
     if (a === 0) continue; // unchanged from original
 
-    let ir = inpainted[p];
-    let ig = inpainted[p + 1];
-    let ib = inpainted[p + 2];
+    let ir = inpainted[p]!;
+    let ig = inpainted[p + 1]!;
+    let ib = inpainted[p + 2]!;
 
     if (noiseSigma > 0 && coreMask[i]) {
       ir = ir + gauss() * noiseSigma;
@@ -148,9 +148,9 @@ export function compositeWithFeather(
     // but writing it out documents intent and traps a NaN before it
     // becomes a silent 0 (would happen only if upstream math drifts —
     // gauss() is currently NaN-safe via Math.max(u1, 1e-12)).
-    out[p] = clamp255((ir * a + original[p] * inv) / 255);
-    out[p + 1] = clamp255((ig * a + original[p + 1] * inv) / 255);
-    out[p + 2] = clamp255((ib * a + original[p + 2] * inv) / 255);
+    out[p] = clamp255((ir * a + original[p]! * inv) / 255);
+    out[p + 1] = clamp255((ig * a + original[p + 1]! * inv) / 255);
+    out[p + 2] = clamp255((ib * a + original[p + 2]! * inv) / 255);
     // Alpha channel: always 255 (opaque). Inpaint output may have garbage
     // here; the original is guaranteed opaque for loaded images.
     out[p + 3] = 255;

--- a/packages/nukebg-core/src/cv/inpaint-telea.ts
+++ b/packages/nukebg-core/src/cv/inpaint-telea.ts
@@ -29,9 +29,9 @@ class MinHeap {
     let pos = this.data.length - 1;
     while (pos > 0) {
       const parent = (pos - 1) >>> 1;
-      if (this.data[pos][0] < this.data[parent][0]) {
-        const tmp = this.data[parent];
-        this.data[parent] = this.data[pos];
+      if (this.data[pos]![0] < this.data[parent]![0]) {
+        const tmp = this.data[parent]!;
+        this.data[parent] = this.data[pos]!;
         this.data[pos] = tmp;
         pos = parent;
       } else {
@@ -41,7 +41,7 @@ class MinHeap {
   }
 
   pop(): HeapEntry {
-    const ret = this.data[0];
+    const ret = this.data[0]!;
     const last = this.data.pop()!;
     if (this.data.length > 0) {
       this.data[0] = last;
@@ -51,11 +51,11 @@ class MinHeap {
         const left = (pos << 1) + 1;
         const right = left + 1;
         let min = pos;
-        if (left <= end && this.data[left][0] < this.data[min][0]) min = left;
-        if (right <= end && this.data[right][0] < this.data[min][0]) min = right;
+        if (left <= end && this.data[left]![0] < this.data[min]![0]) min = left;
+        if (right <= end && this.data[right]![0] < this.data[min]![0]) min = right;
         if (min !== pos) {
-          const tmp = this.data[min];
-          this.data[min] = this.data[pos];
+          const tmp = this.data[min]!;
+          this.data[min] = this.data[pos]!;
           this.data[pos] = tmp;
           pos = min;
         } else {
@@ -102,7 +102,7 @@ export function inpaintTelea(
   for (let c = 0; c < 3; c++) {
     const ch = new Float32Array(size);
     for (let i = 0; i < size; i++) {
-      ch[i] = pixels[i * 4 + c];
+      ch[i] = pixels[i * 4 + c]!;
     }
     channels.push(ch);
   }
@@ -157,7 +157,7 @@ export function inpaintTelea(
   const heap = new MinHeap();
   for (let i = 0; i < size; i++) {
     if (flag[i] === BAND) {
-      heap.push([u[i], i]);
+      heap.push([u[i]!, i]);
     }
   }
 
@@ -173,8 +173,8 @@ export function inpaintTelea(
   // Funciones auxiliares del FMM
   function eikonal(n1: number, n2: number): number {
     let uOut = LARGE_VALUE;
-    const u1 = u[n1];
-    const u2 = u[n2];
+    const u1 = u[n1]!;
+    const u2 = u[n2]!;
     if (flag[n1] === KNOWN) {
       if (flag[n2] === KNOWN) {
         const diff = u1 - u2;
@@ -200,12 +200,12 @@ export function inpaintTelea(
   function gradFunc(array: Float32Array, n: number, step: number): number {
     if (flag[n + step] !== UNKNOWN) {
       if (flag[n - step] !== UNKNOWN) {
-        return (array[n + step] - array[n - step]) * 0.5;
+        return (array[n + step]! - array[n - step]!) * 0.5;
       }
-      return array[n + step] - array[n];
+      return array[n + step]! - array[n]!;
     }
     if (flag[n - step] !== UNKNOWN) {
-      return array[n] - array[n - step];
+      return array[n]! - array[n - step]!;
     }
     return 0;
   }
@@ -219,7 +219,7 @@ export function inpaintTelea(
     const iy = Math.floor(n / width);
 
     for (let k = 0; k < offsets.length; k++) {
-      const nb = n + offsets[k];
+      const nb = n + offsets[k]!;
       if (nb < 0 || nb >= size) continue;
 
       const nbx = nb % width;
@@ -239,11 +239,11 @@ export function inpaintTelea(
       if (dst2 === 0) continue;
 
       const geometricDst = 1 / (dst2 * Math.sqrt(dst2));
-      const levelsetDst = 1 / (1 + Math.abs(u[nb] - u[n]));
+      const levelsetDst = 1 / (1 + Math.abs(u[nb]! - u[n]!));
       const direction = Math.abs(rx * gradxU + ry * gradyU);
       const weight = geometricDst * levelsetDst * direction + SMALL_VALUE;
 
-      Ia += weight * channel[nb];
+      Ia += weight * channel[nb]!;
       norm += weight;
     }
 
@@ -266,7 +266,7 @@ export function inpaintTelea(
     // Cardinal neighbors
     const neighbors = [n - width, n - 1, n + width, n + 1];
     for (let k = 0; k < 4; k++) {
-      const nb = neighbors[k];
+      const nb = neighbors[k]!;
       if (nb < 0 || nb >= size) continue;
       if (flag[nb] === KNOWN) continue;
 
@@ -279,10 +279,10 @@ export function inpaintTelea(
 
       if (flag[nb] === UNKNOWN) {
         flag[nb] = BAND;
-        heap.push([u[nb], nb]);
+        heap.push([u[nb]!, nb]);
         // Inpaint all 3 channels at this point
         for (let c = 0; c < 3; c++) {
-          inpaintPoint(nb, channels[c]);
+          inpaintPoint(nb, channels[c]!);
         }
       }
     }
@@ -291,9 +291,9 @@ export function inpaintTelea(
   // Step 6: write processed channels back to RGBA
   for (let i = 0; i < size; i++) {
     if (!mask[i]) continue; // Only touch mask pixels
-    result[i * 4] = Math.round(Math.max(0, Math.min(255, channels[0][i])));
-    result[i * 4 + 1] = Math.round(Math.max(0, Math.min(255, channels[1][i])));
-    result[i * 4 + 2] = Math.round(Math.max(0, Math.min(255, channels[2][i])));
+    result[i * 4] = Math.round(Math.max(0, Math.min(255, channels[0]![i]!)));
+    result[i * 4 + 1] = Math.round(Math.max(0, Math.min(255, channels[1]![i]!)));
+    result[i * 4 + 2] = Math.round(Math.max(0, Math.min(255, channels[2]![i]!)));
     result[i * 4 + 3] = 255; // Opaque
   }
 

--- a/packages/nukebg-core/src/cv/lama-crop.ts
+++ b/packages/nukebg-core/src/cv/lama-crop.ts
@@ -95,8 +95,8 @@ export function bilinearResizeRGBA(
       const di = (ty * targetSize + tx) * 4;
 
       for (let c = 0; c < 4; c++) {
-        const top = src[i00 + c] * (1 - fx) + src[i01 + c] * fx;
-        const bot = src[i10 + c] * (1 - fx) + src[i11 + c] * fx;
+        const top = src[i00 + c]! * (1 - fx) + src[i01 + c]! * fx;
+        const bot = src[i10 + c]! * (1 - fx) + src[i11 + c]! * fx;
         dst[di + c] = top * (1 - fy) + bot * fy;
       }
     }
@@ -173,8 +173,8 @@ export function spliceLamaOutput(
       const di = (dy * baseWidth + dx) * 4;
 
       for (let c = 0; c < 3; c++) {
-        const top = lamaOutput[i00 + c] * (1 - fx) + lamaOutput[i01 + c] * fx;
-        const bot = lamaOutput[i10 + c] * (1 - fx) + lamaOutput[i11 + c] * fx;
+        const top = lamaOutput[i00 + c]! * (1 - fx) + lamaOutput[i01 + c]! * fx;
+        const bot = lamaOutput[i10 + c]! * (1 - fx) + lamaOutput[i11 + c]! * fx;
         // Explicit clamp + round (#194). Uint8ClampedArray clamps and
         // rounds on assign, but stating it makes the intent visible and
         // traps NaN before it becomes a silent 0.

--- a/packages/nukebg-core/src/cv/lama-router.ts
+++ b/packages/nukebg-core/src/cv/lama-router.ts
@@ -82,7 +82,7 @@ function expandedMaskBbox(
 }
 
 function luminance(pixels: Uint8ClampedArray, idx: number): number {
-  return pixels[idx] * 0.299 + pixels[idx + 1] * 0.587 + pixels[idx + 2] * 0.114;
+  return pixels[idx]! * 0.299 + pixels[idx + 1]! * 0.587 + pixels[idx + 2]! * 0.114;
 }
 
 function luminanceVariance(

--- a/packages/nukebg-core/src/cv/patchmatch-inpaint.ts
+++ b/packages/nukebg-core/src/cv/patchmatch-inpaint.ts
@@ -87,9 +87,9 @@ export function patchDistance(
     for (let dx = -patchRadius; dx <= patchRadius; dx++) {
       const ai = ((ay + dy) * aw + (ax + dx)) * 4;
       const bi = ((by + dy) * aw + (bx + dx)) * 4;
-      const dr = a[ai] - b[bi];
-      const dg = a[ai + 1] - b[bi + 1];
-      const db = a[ai + 2] - b[bi + 2];
+      const dr = a[ai]! - b[bi]!;
+      const dg = a[ai + 1]! - b[bi + 1]!;
+      const db = a[ai + 2]! - b[bi + 2]!;
       sum += dr * dr + dg * dg + db * db;
     }
   }
@@ -203,10 +203,10 @@ export function patchMatchInpaint(
   for (let i = 0; i < mask.length; i++) {
     if (mask[i]) continue;
     const p = i * 4;
-    work[p] = src[p];
-    work[p + 1] = src[p + 1];
-    work[p + 2] = src[p + 2];
-    work[p + 3] = src[p + 3];
+    work[p] = src[p]!;
+    work[p + 1] = src[p + 1]!;
+    work[p + 2] = src[p + 2]!;
+    work[p + 3] = src[p + 3]!;
   }
   return work;
 }
@@ -251,9 +251,9 @@ function seedMaskedWithLocalMean(
     for (let x = rx0; x <= rx1; x++) {
       if (mask[y * width + x]) continue;
       const i = (y * width + x) * 4;
-      r += img[i];
-      g += img[i + 1];
-      b += img[i + 2];
+      r += img[i]!;
+      g += img[i + 1]!;
+      b += img[i + 2]!;
       n++;
     }
   }
@@ -291,8 +291,8 @@ function computeInitialDistances(
         dist[idx] = Infinity;
         continue;
       }
-      const sx = nnf[idx * 2],
-        sy = nnf[idx * 2 + 1];
+      const sx = nnf[idx * 2]!,
+        sy = nnf[idx * 2 + 1]!;
       dist[idx] = patchDistance(work, work, width, height, x, y, sx, sy, patchRadius);
     }
   }
@@ -312,8 +312,8 @@ function recomputeMaskedDistances(
       const idx = y * width + x;
       if (!mask[idx]) continue;
       if (!fits(x, y, width, height, patchRadius)) continue;
-      const sx = nnf[idx * 2],
-        sy = nnf[idx * 2 + 1];
+      const sx = nnf[idx * 2]!,
+        sy = nnf[idx * 2 + 1]!;
       dist[idx] = patchDistance(work, work, width, height, x, y, sx, sy, patchRadius);
     }
   }
@@ -356,16 +356,16 @@ function patchMatchPass(
       if (!mask[idx]) continue;
       if (!fits(x, y, width, height, patchRadius)) continue;
 
-      let bestSx = nnf[idx * 2];
-      let bestSy = nnf[idx * 2 + 1];
-      let bestD = dist[idx];
+      let bestSx = nnf[idx * 2]!;
+      let bestSy = nnf[idx * 2 + 1]!;
+      let bestD = dist[idx]!;
 
       // ── Propagation from horizontal neighbour ──
       const nx = x + off;
       if (nx >= 0 && nx < width) {
         const nidx = y * width + nx;
-        const candX = nnf[nidx * 2] - off;
-        const candY = nnf[nidx * 2 + 1];
+        const candX = nnf[nidx * 2]! - off;
+        const candY = nnf[nidx * 2 + 1]!;
         if (isValidSource(candX, candY, width, height, mask, patchRadius, searchRegion)) {
           const d = patchDistance(work, work, width, height, x, y, candX, candY, patchRadius);
           if (d < bestD) {
@@ -379,8 +379,8 @@ function patchMatchPass(
       const ny = y + off;
       if (ny >= 0 && ny < height) {
         const nidx = ny * width + x;
-        const candX = nnf[nidx * 2];
-        const candY = nnf[nidx * 2 + 1] - off;
+        const candX = nnf[nidx * 2]!;
+        const candY = nnf[nidx * 2 + 1]! - off;
         if (isValidSource(candX, candY, width, height, mask, patchRadius, searchRegion)) {
           const d = patchDistance(work, work, width, height, x, y, candX, candY, patchRadius);
           if (d < bestD) {
@@ -455,8 +455,8 @@ function voteReconstruct(
       const idx = y * width + x;
       if (!mask[idx]) continue;
       if (!fits(x, y, width, height, patchRadius)) continue;
-      const sx = nnf[idx * 2];
-      const sy = nnf[idx * 2 + 1];
+      const sx = nnf[idx * 2]!;
+      const sy = nnf[idx * 2 + 1]!;
       // Each NNF entry implies that the target patch at (x,y) should look
       // like the source patch at (sx,sy). Accumulate every offset so the
       // contribution averages over all overlapping source patches.
@@ -468,10 +468,10 @@ function voteReconstruct(
           const tIdx = ty * width + tx;
           if (!mask[tIdx]) continue; // only write masked pixels
           const sIdx = ((sy + dy) * width + (sx + dx)) * 4;
-          accR[tIdx] += src[sIdx];
-          accG[tIdx] += src[sIdx + 1];
-          accB[tIdx] += src[sIdx + 2];
-          accN[tIdx] += 1;
+          accR[tIdx] = accR[tIdx]! + src[sIdx]!;
+          accG[tIdx] = accG[tIdx]! + src[sIdx + 1]!;
+          accB[tIdx] = accB[tIdx]! + src[sIdx + 2]!;
+          accN[tIdx] = accN[tIdx]! + 1;
         }
       }
     }
@@ -481,9 +481,9 @@ function voteReconstruct(
     if (!mask[i]) continue;
     if (accN[i] === 0) continue;
     const p = i * 4;
-    work[p] = Math.round(accR[i] / accN[i]);
-    work[p + 1] = Math.round(accG[i] / accN[i]);
-    work[p + 2] = Math.round(accB[i] / accN[i]);
+    work[p] = Math.round(accR[i]! / accN[i]!);
+    work[p + 1] = Math.round(accG[i]! / accN[i]!);
+    work[p + 2] = Math.round(accB[i]! / accN[i]!);
     work[p + 3] = 255;
   }
 }

--- a/packages/nukebg-core/src/cv/shadow-cleanup.ts
+++ b/packages/nukebg-core/src/cv/shadow-cleanup.ts
@@ -23,9 +23,9 @@ export function shadowCleanup(
       if (result[pos]) continue; // already background
 
       const idx = pixelIndex(x, y, width);
-      const r = pixels[idx];
-      const g = pixels[idx + 1];
-      const b = pixels[idx + 2];
+      const r = pixels[idx]!;
+      const g = pixels[idx + 1]!;
+      const b = pixels[idx + 2]!;
 
       const mx = Math.max(r, g, b);
       const mn = Math.min(r, g, b);

--- a/packages/nukebg-core/src/cv/signature-threshold.ts
+++ b/packages/nukebg-core/src/cv/signature-threshold.ts
@@ -22,7 +22,7 @@ export function signatureThreshold(
   const gray = new Float32Array(totalPixels);
   for (let i = 0; i < totalPixels; i++) {
     const off = i * 4;
-    gray[i] = 0.299 * pixels[off] + 0.587 * pixels[off + 1] + 0.114 * pixels[off + 2];
+    gray[i] = 0.299 * pixels[off]! + 0.587 * pixels[off + 1]! + 0.114 * pixels[off + 2]!;
   }
 
   // Always use Sauvola adaptive threshold - better for all signature types
@@ -32,8 +32,8 @@ export function signatureThreshold(
   // Apply threshold with anti-aliasing transition band
   const halfBand = P.AA_BAND_SIZE / 2;
   for (let i = 0; i < totalPixels; i++) {
-    const t = thresholdMap[i];
-    const g = gray[i];
+    const t = thresholdMap[i]!;
+    const g = gray[i]!;
     const diff = t - g; // positive = pixel is darker than threshold = foreground
 
     if (diff > halfBand) {
@@ -59,13 +59,14 @@ export function signatureThreshold(
 export function computeOtsu(gray: Float32Array): number {
   const histogram = new Float64Array(256);
   for (let i = 0; i < gray.length; i++) {
-    histogram[Math.round(Math.min(255, Math.max(0, gray[i])))]++;
+    const bin = Math.round(Math.min(255, Math.max(0, gray[i]!)));
+    histogram[bin] = histogram[bin]! + 1;
   }
 
   const total = gray.length;
   let sumAll = 0;
   for (let i = 0; i < 256; i++) {
-    sumAll += i * histogram[i];
+    sumAll += i * histogram[i]!;
   }
 
   let sumBg = 0;
@@ -75,13 +76,13 @@ export function computeOtsu(gray: Float32Array): number {
   let lastBest = 0;
 
   for (let t = 0; t < 256; t++) {
-    weightBg += histogram[t];
+    weightBg += histogram[t]!;
     if (weightBg === 0) continue;
 
     const weightFg = total - weightBg;
     if (weightFg === 0) break;
 
-    sumBg += t * histogram[t];
+    sumBg += t * histogram[t]!;
     const meanBg = sumBg / weightBg;
     const meanFg = (sumAll - sumBg) / weightFg;
     const meanDiff = meanBg - meanFg;
@@ -126,12 +127,12 @@ function computeSauvola(
     let rowSum = 0;
     let rowSqSum = 0;
     for (let x = 0; x < width; x++) {
-      const g = gray[y * width + x];
+      const g = gray[y * width + x]!;
       rowSum += g;
       rowSqSum += g * g;
       const idx = (y + 1) * (width + 1) + (x + 1);
-      integralSum[idx] = rowSum + integralSum[y * (width + 1) + (x + 1)];
-      integralSqSum[idx] = rowSqSum + integralSqSum[y * (width + 1) + (x + 1)];
+      integralSum[idx] = rowSum + integralSum[y * (width + 1) + (x + 1)]!;
+      integralSqSum[idx] = rowSqSum + integralSqSum[y * (width + 1) + (x + 1)]!;
     }
   }
 
@@ -149,16 +150,16 @@ function computeSauvola(
 
       // Sum in rectangle using integral image
       const sum =
-        integralSum[(y2 + 1) * stride + (x2 + 1)] -
-        integralSum[y1 * stride + (x2 + 1)] -
-        integralSum[(y2 + 1) * stride + x1] +
-        integralSum[y1 * stride + x1];
+        integralSum[(y2 + 1) * stride + (x2 + 1)]! -
+        integralSum[y1 * stride + (x2 + 1)]! -
+        integralSum[(y2 + 1) * stride + x1]! +
+        integralSum[y1 * stride + x1]!;
 
       const sqSum =
-        integralSqSum[(y2 + 1) * stride + (x2 + 1)] -
-        integralSqSum[y1 * stride + (x2 + 1)] -
-        integralSqSum[(y2 + 1) * stride + x1] +
-        integralSqSum[y1 * stride + x1];
+        integralSqSum[(y2 + 1) * stride + (x2 + 1)]! -
+        integralSqSum[y1 * stride + (x2 + 1)]! -
+        integralSqSum[(y2 + 1) * stride + x1]! +
+        integralSqSum[y1 * stride + x1]!;
 
       const localMean = sum / count;
       const localVariance = sqSum / count - localMean * localMean;
@@ -195,7 +196,7 @@ export function morphologicalClose(
         for (let dx = -radius; dx <= radius; dx++) {
           const nx = x + dx;
           if (nx < 0 || nx >= width) continue;
-          const val = alpha[ny * width + nx];
+          const val = alpha[ny * width + nx]!;
           if (val > maxVal) maxVal = val;
         }
       }
@@ -213,7 +214,7 @@ export function morphologicalClose(
         for (let dx = -radius; dx <= radius; dx++) {
           const nx = x + dx;
           if (nx < 0 || nx >= width) continue;
-          const val = temp[ny * width + nx];
+          const val = temp[ny * width + nx]!;
           if (val < minVal) minVal = val;
         }
       }

--- a/packages/nukebg-core/src/cv/simple-flood-fill.ts
+++ b/packages/nukebg-core/src/cv/simple-flood-fill.ts
@@ -61,8 +61,8 @@ export function simpleFloodFill(
   while (!queue.empty) {
     const [y, x] = queue.pop();
     for (let d = 0; d < 4; d++) {
-      const ny = y + dy[d];
-      const nx = x + dx[d];
+      const ny = y + dy[d]!;
+      const nx = x + dx[d]!;
       if (ny >= 0 && ny < height && nx >= 0 && nx < width) {
         const npos = ny * width + nx;
         if (!visited[npos]) {

--- a/packages/nukebg-core/src/cv/sparkle-detect.ts
+++ b/packages/nukebg-core/src/cv/sparkle-detect.ts
@@ -47,20 +47,20 @@ export function sparkleDetect(
   if (scales.length === 0) {
     return { detected: false, mask: null };
   }
-  const maxScale = scales[scales.length - 1];
+  const maxScale = scales[scales.length - 1]!;
 
   // Pre-compute luminance grid (Rec. 601)
   const lum = new Uint8ClampedArray(width * height);
   for (let i = 0, j = 0; i < pixels.length; i += 4, j++) {
-    lum[j] = (pixels[i] * 299 + pixels[i + 1] * 587 + pixels[i + 2] * 114) / 1000;
+    lum[j] = (pixels[i]! * 299 + pixels[i + 1]! * 587 + pixels[i + 2]! * 114) / 1000;
   }
 
   // Scan area: bottom-right corner. Inset by the smallest scale's outer ring;
   // per-candidate we filter scales that don't fit at that position.
-  const minScale = scales[0];
+  const minScale = scales[0]!;
   const minMargin = Math.ceil(minScale * 1.6);
-  const scanW = Math.max(maxScale * 2, Math.floor(width * SPARKLE_PARAMS.SCAN_WIDTH_FRACTION));
-  const scanH = Math.max(maxScale * 2, Math.floor(height * SPARKLE_PARAMS.SCAN_HEIGHT_FRACTION));
+  const scanW = Math.max(maxScale! * 2, Math.floor(width * SPARKLE_PARAMS.SCAN_WIDTH_FRACTION));
+  const scanH = Math.max(maxScale! * 2, Math.floor(height * SPARKLE_PARAMS.SCAN_HEIGHT_FRACTION));
   const xStart = Math.max(minMargin, width - scanW);
   const xEnd = width - minMargin;
   const yStart = Math.max(minMargin, height - scanH);
@@ -131,24 +131,24 @@ export function sparkleDetect(
 
   for (let cy = yStart; cy < yEnd; cy += stride) {
     for (let cx = xStart; cx < xEnd; cx += stride) {
-      const c = lum[cy * width + cx];
+      const c = lum[cy * width + cx]!;
 
       for (let si = 0; si < scales.length; si++) {
-        const m = scaleMargins[si];
+        const m = scaleMargins[si]!;
         if (cy - m < 0 || cy + m >= height || cx - m < 0 || cx + m >= width) continue;
-        const off = offsetsByScale[si];
+        const off = offsetsByScale[si]!;
 
         // Sample cardinals individually (4-fold symmetry check)
-        const a0 = lum[(cy + off.arm[0][0]) * width + (cx + off.arm[0][1])];
-        const a1 = lum[(cy + off.arm[1][0]) * width + (cx + off.arm[1][1])];
-        const a2 = lum[(cy + off.arm[2][0]) * width + (cx + off.arm[2][1])];
-        const a3 = lum[(cy + off.arm[3][0]) * width + (cx + off.arm[3][1])];
+        const a0 = lum[(cy + off.arm[0]![0]!) * width + (cx + off.arm[0]![1]!)]!;
+        const a1 = lum[(cy + off.arm[1]![0]!) * width + (cx + off.arm[1]![1]!)]!;
+        const a2 = lum[(cy + off.arm[2]![0]!) * width + (cx + off.arm[2]![1]!)]!;
+        const a3 = lum[(cy + off.arm[3]![0]!) * width + (cx + off.arm[3]![1]!)]!;
 
         // Sample diagonals individually
-        const d0 = lum[(cy + off.gap[0][0]) * width + (cx + off.gap[0][1])];
-        const d1 = lum[(cy + off.gap[1][0]) * width + (cx + off.gap[1][1])];
-        const d2 = lum[(cy + off.gap[2][0]) * width + (cx + off.gap[2][1])];
-        const d3 = lum[(cy + off.gap[3][0]) * width + (cx + off.gap[3][1])];
+        const d0 = lum[(cy + off.gap[0]![0]!) * width + (cx + off.gap[0]![1]!)]!;
+        const d1 = lum[(cy + off.gap[1]![0]!) * width + (cx + off.gap[1]![1]!)]!;
+        const d2 = lum[(cy + off.gap[2]![0]!) * width + (cx + off.gap[2]![1]!)]!;
+        const d3 = lum[(cy + off.gap[3]![0]!) * width + (cx + off.gap[3]![1]!)]!;
 
         // G1: min(arms) > max(gaps) + margin
         const minA = Math.min(a0, a1, a2, a3);
@@ -173,7 +173,7 @@ export function sparkleDetect(
         // G4: contrast vs outer ring
         let oSum = 0;
         for (const [dy, dx] of off.outer) {
-          oSum += lum[(cy + dy) * width + (cx + dx)];
+          oSum += lum[(cy + dy) * width + (cx + dx)]!;
         }
         const meanO = oSum / 8;
         const cMinusO = c - meanO;
@@ -186,7 +186,7 @@ export function sparkleDetect(
         // wide solid regions with bright neighboring pixels.
         let maxPerp = 0;
         for (const [dy, dx] of off.perp) {
-          const v = lum[(cy + dy) * width + (cx + dx)];
+          const v = lum[(cy + dy) * width + (cx + dx)]!;
           if (v > maxPerp) maxPerp = v;
         }
         if (maxPerp > meanA * SPARKLE_PARAMS.MAX_PERP_ARM_RATIO) continue;
@@ -198,7 +198,7 @@ export function sparkleDetect(
           bestScore = score;
           bestY = cy;
           bestX = cx;
-          bestR = scales[si];
+          bestR = scales[si]!;
         }
       }
     }

--- a/packages/nukebg-core/src/cv/subject-exclusion.ts
+++ b/packages/nukebg-core/src/cv/subject-exclusion.ts
@@ -30,9 +30,9 @@ export function subjectExclusion(
   for (let y = 0; y < height; y++) {
     for (let x = 0; x < width; x++) {
       const idx = pixelIndex(x, y, width);
-      const r = pixels[idx];
-      const g = pixels[idx + 1];
-      const b = pixels[idx + 2];
+      const r = pixels[idx]!;
+      const g = pixels[idx + 1]!;
+      const b = pixels[idx + 2]!;
 
       const mx = Math.max(r, g, b);
       const mn = Math.min(r, g, b);

--- a/packages/nukebg-core/src/cv/utils.ts
+++ b/packages/nukebg-core/src/cv/utils.ts
@@ -27,8 +27,8 @@ export class RingBuffer {
 
   pop(): [number, number] {
     const idx = this.head * 2;
-    const y = this.buffer[idx];
-    const x = this.buffer[idx + 1];
+    const y = this.buffer[idx]!;
+    const x = this.buffer[idx + 1]!;
     this.head = (this.head + 1) % this.capacity;
     this.count--;
     return [y, x];
@@ -48,8 +48,8 @@ export class RingBuffer {
     for (let i = 0; i < this.count; i++) {
       const srcIdx = ((this.head + i) % this.capacity) * 2;
       const dstIdx = i * 2;
-      newBuf[dstIdx] = this.buffer[srcIdx];
-      newBuf[dstIdx + 1] = this.buffer[srcIdx + 1];
+      newBuf[dstIdx] = this.buffer[srcIdx]!;
+      newBuf[dstIdx + 1] = this.buffer[srcIdx + 1]!;
     }
     this.buffer = newBuf;
     this.head = 0;
@@ -66,9 +66,9 @@ export function pixelIndex(x: number, y: number, width: number): number {
 /** Max channel difference between pixel at (x,y) and an RGB color */
 export function maxChannelDiff(pixels: Uint8ClampedArray, idx: number, color: number[]): number {
   return Math.max(
-    Math.abs(pixels[idx] - color[0]),
-    Math.abs(pixels[idx + 1] - color[1]),
-    Math.abs(pixels[idx + 2] - color[2]),
+    Math.abs(pixels[idx]! - color[0]!),
+    Math.abs(pixels[idx + 1]! - color[1]!),
+    Math.abs(pixels[idx + 2]! - color[2]!),
   );
 }
 
@@ -76,7 +76,7 @@ export function maxChannelDiff(pixels: Uint8ClampedArray, idx: number, color: nu
 export function mean(arr: number[]): number {
   if (arr.length === 0) return 0;
   let sum = 0;
-  for (let i = 0; i < arr.length; i++) sum += arr[i];
+  for (let i = 0; i < arr.length; i++) sum += arr[i]!;
   return sum / arr.length;
 }
 
@@ -86,7 +86,7 @@ export function std(arr: number[]): number {
   const m = mean(arr);
   let sumSq = 0;
   for (let i = 0; i < arr.length; i++) {
-    const d = arr[i] - m;
+    const d = arr[i]! - m;
     sumSq += d * d;
   }
   return Math.sqrt(sumSq / arr.length);
@@ -97,5 +97,5 @@ export function median(arr: number[]): number {
   if (arr.length === 0) return 0;
   const sorted = arr.slice().sort((a, b) => a - b);
   const mid = Math.floor(sorted.length / 2);
-  return sorted.length % 2 !== 0 ? sorted[mid] : (sorted[mid - 1] + sorted[mid]) / 2;
+  return sorted.length % 2 !== 0 ? sorted[mid]! : (sorted[mid - 1]! + sorted[mid]!) / 2;
 }

--- a/packages/nukebg-core/src/cv/watermark-dalle.ts
+++ b/packages/nukebg-core/src/cv/watermark-dalle.ts
@@ -32,9 +32,9 @@ export function watermarkDetectDalle(
 
     for (let x = width - scanW; x < width; x++) {
       const idx = pixelIndex(x, y, width);
-      const r = pixels[idx];
-      const g = pixels[idx + 1];
-      const b = pixels[idx + 2];
+      const r = pixels[idx]!;
+      const g = pixels[idx + 1]!;
+      const b = pixels[idx + 2]!;
       // Cuantizar a bloques de 16 para agrupar colores cercanos
       const quantized = ((r >> 4) << 8) | ((g >> 4) << 4) | (b >> 4);
       colors.add(quantized);
@@ -54,9 +54,9 @@ export function watermarkDetectDalle(
     const refColors = new Set<number>();
     for (let x = width - scanW; x < width; x++) {
       const idx = pixelIndex(x, refY, width);
-      const r = pixels[idx];
-      const g = pixels[idx + 1];
-      const b = pixels[idx + 2];
+      const r = pixels[idx]!;
+      const g = pixels[idx + 1]!;
+      const b = pixels[idx + 2]!;
       const quantized = ((r >> 4) << 8) | ((g >> 4) << 4) | (b >> 4);
       refColors.add(quantized);
     }
@@ -73,9 +73,9 @@ export function watermarkDetectDalle(
       maxB = 0;
     for (let x = width - scanW; x < width; x++) {
       const idx = pixelIndex(x, y, width);
-      const r = pixels[idx];
-      const g = pixels[idx + 1];
-      const b = pixels[idx + 2];
+      const r = pixels[idx]!;
+      const g = pixels[idx + 1]!;
+      const b = pixels[idx + 2]!;
       minR = Math.min(minR, r);
       maxR = Math.max(maxR, r);
       minG = Math.min(minG, g);

--- a/packages/nukebg-core/src/cv/watermark-detect.ts
+++ b/packages/nukebg-core/src/cv/watermark-detect.ts
@@ -58,19 +58,19 @@ export function watermarkDetect(
       for (let lx = 0; lx < scanSize; lx++) {
         const x = width - scanSize + lx;
         const idx = pixelIndex(x, y, width);
-        const r = pixels[idx];
-        const g = pixels[idx + 1];
-        const b = pixels[idx + 2];
+        const r = pixels[idx]!;
+        const g = pixels[idx + 1]!;
+        const b = pixels[idx + 2]!;
 
         const diffA = Math.max(
-          Math.abs(r - colorA[0]),
-          Math.abs(g - colorA[1]),
-          Math.abs(b - colorA[2]),
+          Math.abs(r - colorA[0]!),
+          Math.abs(g - colorA[1]!),
+          Math.abs(b - colorA[2]!),
         );
         const diffB = Math.max(
-          Math.abs(r - colorB[0]),
-          Math.abs(g - colorB[1]),
-          Math.abs(b - colorB[2]),
+          Math.abs(r - colorB[0]!),
+          Math.abs(g - colorB[1]!),
+          Math.abs(b - colorB[2]!),
         );
         const deviation = Math.min(diffA, diffB);
 
@@ -111,7 +111,7 @@ export function watermarkDetect(
     distances.push(Math.sqrt((ly - cyLocal) ** 2 + (lx - cxLocal) ** 2));
   }
   distances.sort((a, b) => a - b);
-  const medianDist = distances[Math.floor(distances.length / 2)];
+  const medianDist = distances[Math.floor(distances.length / 2)]!;
 
   if (medianDist > scanSize * WATERMARK_PARAMS.MAX_MEDIAN_DISTANCE_RATIO) {
     return { detected: false, mask: null };
@@ -146,18 +146,18 @@ export function watermarkDetect(
       } else if (dist <= radius * WATERMARK_PARAMS.HALO_RADIUS_MULTIPLIER) {
         // Check for halo anomaly
         const idx = pixelIndex(x, y, width);
-        const r = pixels[idx];
-        const g = pixels[idx + 1];
-        const b = pixels[idx + 2];
+        const r = pixels[idx]!;
+        const g = pixels[idx + 1]!;
+        const b = pixels[idx + 2]!;
         const diffA = Math.max(
-          Math.abs(r - colorA[0]),
-          Math.abs(g - colorA[1]),
-          Math.abs(b - colorA[2]),
+          Math.abs(r - colorA[0]!),
+          Math.abs(g - colorA[1]!),
+          Math.abs(b - colorA[2]!),
         );
         const diffB = Math.max(
-          Math.abs(r - colorB[0]),
-          Math.abs(g - colorB[1]),
-          Math.abs(b - colorB[2]),
+          Math.abs(r - colorB[0]!),
+          Math.abs(g - colorB[1]!),
+          Math.abs(b - colorB[2]!),
         );
         const dev = Math.min(diffA, diffB);
         if (dev > WATERMARK_PARAMS.HALO_DEVIATION_THRESHOLD && isGeminiSparkleColor(r, g, b)) {

--- a/packages/nukebg-core/src/pipeline/run-pipeline.ts
+++ b/packages/nukebg-core/src/pipeline/run-pipeline.ts
@@ -240,7 +240,7 @@ export async function runPipeline(
     status: 'running' | 'done' | 'skipped' | 'error',
     message?: string,
   ): void => {
-    onStage?.({ stage, status, message });
+    onStage?.(message !== undefined ? { stage, status, message } : { stage, status });
   };
 
   // Check abort at each major boundary
@@ -348,7 +348,7 @@ export async function runPipeline(
           inpainted = await runners.lama.inpaint(
             createImageDataLike(originalPixels, width, height),
             dilated,
-            { signal },
+            signal !== undefined ? { signal } : {},
           );
         } catch (err: unknown) {
           if (err instanceof PipelineAbortError) throw err;
@@ -419,7 +419,7 @@ export async function runPipeline(
           clusterRatio: profile.clusterRatio,
           minClusterSize: profile.minClusterSize,
         },
-        signal,
+        ...(signal !== undefined ? { signal } : {}),
         onProgress: (pct) =>
           emit('ml-segmentation', 'running', `Loading AI model... ${pct}%`),
       },

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,6 @@
 {
   "files": [],
   "references": [
-    { "path": "./packages/nukebg-core" },
-    { "path": "./packages/nukebg-cli" }
+    { "path": "./packages/nukebg-core" }
   ]
 }


### PR DESCRIPTION
## Summary

Node image decode/encode via sharp, satisfying the core ImageCodec interface.

## Chain Context

| Field | Value |
|-------|-------|
| Chain | extract-core-cli |
| Tracker PR | `feat/extract-core-cli` → `dev` (opens once PR 1 of 15 merges into the tracker; GitHub rejects a zero-diff PR) |
| Position | 9 of 15 |
| Base | `feat/extract-core-cli-phase-10` |
| Depends on | `feat/extract-core-cli-phase-10` |
| Follow-up | `feat/extract-core-cli-phase-12-14` |
| Review budget | 1399 (1147 additions + 252 deletions) / 400 |
| Starts at | `feat/extract-core-cli-phase-10` |
| Ends with | Node image decode/encode via sharp, satisfying the core ImageCodec interface. |

### Chain Overview

```text
dev
 └── feat/extract-core-cli  (tracker, draft/no-merge)
      └── feat/extract-core-cli-phase-3
           └── feat/extract-core-cli-phase-4
                └── feat/extract-core-cli-phase-5
                     └── feat/extract-core-cli-phase-6
                     └── feat/extract-core-cli-phase-7
                     └── feat/extract-core-cli-phase-8
                     └── feat/extract-core-cli-phase-9
                     └── feat/extract-core-cli-phase-10
                     └── 📍 feat/extract-core-cli-phase-11
                     └── feat/extract-core-cli-phase-12-14
                     └── … (5 more)
```

### Scope

- **Includes:** Node image decode/encode via sharp, satisfying the core ImageCodec interface.
- **Excludes:** ONNX runners (phases 12-14).

> **Review budget note.** This slice is 1399 changed lines, over the 400 guideline. It is not split further because the remaining boundaries are within single work units — separating an implementation module from the test file that verifies it would make review harder, not easier. Requesting `size:exception` for this slice.

### Autonomy

- [x] CI is expected to pass for this PR branch
- [x] This PR has one deliverable scope
- [x] This PR can be rolled back without unrelated changes
- [x] Tests, docs, or manual verification cover this unit

### Verification

Full gate green on the chain tip: `npm run typecheck`, `npm run lint`, `npm test` (737 app + 78 cli + 336 core, 1 expected parity skip), and `npm run build`.
