### PR TITLE
feat(core,cli): restore per-stage and wall-clock time budgets

### DIFF
--- a/packages/nukebg-cli/src/util/errors.ts
+++ b/packages/nukebg-cli/src/util/errors.ts
@@ -1,5 +1,11 @@
 import { CommanderError } from 'commander';
-import { PipelineAbortError, DecodeError, RmbgError, LamaError } from 'nukebg-core';
+import {
+  PipelineAbortError,
+  PipelineTimeoutError,
+  DecodeError,
+  RmbgError,
+  LamaError,
+} from 'nukebg-core';
 import { LicenseRequiredError } from '../license/gate.js';
 import { ExitCode } from './exit-codes.js';
 
@@ -74,6 +80,7 @@ const MODEL_ACQUISITION_CODES = new Set([
 
 export function exitCodeFor(err: unknown): number {
   if (err instanceof PipelineAbortError) return ExitCode.ABORTED;
+  if (err instanceof PipelineTimeoutError) return ExitCode.TIMEOUT;
   if (err instanceof CommanderError) return ExitCode.USER_ERROR;
   if (err instanceof LicenseRequiredError) return ExitCode.LICENSE_REQUIRED;
   if (err instanceof NoInputError) return ExitCode.NO_INPUT;

--- a/packages/nukebg-cli/src/util/exit-codes.ts
+++ b/packages/nukebg-cli/src/util/exit-codes.ts
@@ -19,6 +19,10 @@ export const ExitCode = Object.freeze({
   MODEL_DOWNLOAD_FAILED: 74, // network/integrity failure on RMBG or LaMa load
   IO_ERROR: 75, // fs read/write failure (permission denied, ENOSPC)
   LICENSE_REQUIRED: 78, // CC-BY-NC-4.0 not accepted
+  /** A stage or the whole run exceeded its time budget. Matches GNU timeout(1),
+   *  which is the convention scripts already branch on; the sysexits range
+   *  (64-78) has no slot for 'took too long'. */
+  TIMEOUT: 124,
   ABORTED: 130, // SIGINT (Ctrl+C); matches POSIX convention 128 + signal 2
 });
 

--- a/packages/nukebg-cli/tests/util/errors.test.ts
+++ b/packages/nukebg-cli/tests/util/errors.test.ts
@@ -1,6 +1,12 @@
 import { describe, it, expect } from 'vitest';
 import { CommanderError } from 'commander';
-import { DecodeError, RmbgError, LamaError, PipelineAbortError } from 'nukebg-core';
+import {
+  DecodeError,
+  RmbgError,
+  LamaError,
+  PipelineAbortError,
+  PipelineTimeoutError,
+} from 'nukebg-core';
 import { exitCodeFor, IoError, NoInputError } from '../../src/util/errors.js';
 import { LicenseRequiredError } from '../../src/license/gate.js';
 import { ExitCode } from '../../src/util/exit-codes.js';
@@ -56,6 +62,17 @@ describe('exitCodeFor', () => {
   it('maps model inference failures to ExitCode.PIPELINE_FAILED (70)', () => {
     expect(exitCodeFor(new RmbgError('RMBG segmentation failed'))).toBe(ExitCode.PIPELINE_FAILED);
     expect(exitCodeFor(new LamaError('LaMa inpaint failed'))).toBe(ExitCode.PIPELINE_FAILED);
+  });
+
+  // A timeout is not a generic pipeline failure: it is retryable, and folding
+  // it into 70 would lose that. 124 matches GNU timeout(1), which is what
+  // scripts already branch on — the sysexits range (64-78) has no slot for
+  // "took too long". See issue #328.
+  it('maps PipelineTimeoutError to ExitCode.TIMEOUT (124)', () => {
+    expect(exitCodeFor(new PipelineTimeoutError('RMBG segmentation', 300_000))).toBe(
+      ExitCode.TIMEOUT,
+    );
+    expect(ExitCode.TIMEOUT).toBe(124);
   });
 
   it('maps NoInputError to ExitCode.NO_INPUT (66)', () => {

--- a/packages/nukebg-core/src/index.ts
+++ b/packages/nukebg-core/src/index.ts
@@ -32,6 +32,7 @@ export {
   LamaError,
   DecodeError,
   PipelineAbortError,
+  PipelineTimeoutError,
 } from './pipeline/errors.js';
 
 // Top-level pipeline orchestrator + runner bundle type

--- a/packages/nukebg-core/src/pipeline/constants.ts
+++ b/packages/nukebg-core/src/pipeline/constants.ts
@@ -378,3 +378,35 @@ export const RMBG_PARAMS = {
   /** Cache name used by @huggingface/transformers v3 in the browser. */
   CACHE_NAME: 'transformers-cache',
 } as const;
+
+/**
+ * Time budgets for a pipeline run, in milliseconds.
+ *
+ * Carried over from the browser orchestrator, which had per-call worker
+ * timeouts plus a wall-clock safety net. The extraction to `nukebg-core`
+ * dropped all of them: nothing stopped a stalled model fetch from hanging a
+ * run forever (issue #328).
+ *
+ * Only the asynchronous stages can genuinely be bounded — a `Promise.race`
+ * cannot interrupt synchronous CV running on the same thread. Those are the
+ * stages where the observed hangs occur (model download and inference), so
+ * bounding them is what matters; `WALL_CLOCK` is checked at stage boundaries
+ * as a coarse backstop.
+ */
+export const PIPELINE_TIMEOUTS = {
+  /** RMBG segmentation. Generous: the first call downloads ~45MB. */
+  RMBG_MS: 300_000,
+  /** LaMa inpaint. First call downloads the ~90MB ONNX model. */
+  LAMA_MS: 300_000,
+  /**
+   * Whole-run cap, checked at stage boundaries. Generous because a cold run
+   * on a slow connection pays for both model downloads in sequence before any
+   * CPU work starts. If this fires, a per-stage budget already failed to
+   * catch something pathological.
+   */
+  WALL_CLOCK_MS: 20 * 60_000,
+} as const;
+
+export type PipelineTimeouts = {
+  -readonly [K in keyof typeof PIPELINE_TIMEOUTS]: number;
+};

--- a/packages/nukebg-core/src/pipeline/errors.ts
+++ b/packages/nukebg-core/src/pipeline/errors.ts
@@ -69,3 +69,27 @@ export class PipelineAbortError extends NukebgError {
     Object.setPrototypeOf(this, new.target.prototype);
   }
 }
+
+/**
+ * Thrown when a stage, or the run as a whole, exceeds its time budget.
+ *
+ * Distinct from `PipelineAbortError`: an abort is the caller changing its
+ * mind, a timeout is the pipeline failing to make progress. Callers branch on
+ * them differently — a timeout is worth retrying, a user abort is not.
+ *
+ * code: "PIPELINE_TIMEOUT".
+ */
+export class PipelineTimeoutError extends NukebgError {
+  /** Which budget was exceeded — a stage name, or "wall-clock". */
+  readonly stage: string;
+  /** The budget in milliseconds that was exceeded. */
+  readonly timeoutMs: number;
+
+  constructor(stage: string, timeoutMs: number, opts?: { cause?: unknown }) {
+    super(`${stage} exceeded its ${timeoutMs}ms budget`, 'PIPELINE_TIMEOUT', opts);
+    this.name = 'PipelineTimeoutError';
+    this.stage = stage;
+    this.timeoutMs = timeoutMs;
+    Object.setPrototypeOf(this, new.target.prototype);
+  }
+}

--- a/packages/nukebg-core/src/pipeline/run-pipeline.ts
+++ b/packages/nukebg-core/src/pipeline/run-pipeline.ts
@@ -28,13 +28,50 @@ import {
   PRECISION_PROFILES,
   INPAINT_PARAMS,
   IMAGE_CLASSIFY_PARAMS,
+  PIPELINE_TIMEOUTS,
 } from './constants.js';
 import type { PrecisionMode } from './constants.js';
-import { PipelineAbortError, RmbgError, LamaError } from './errors.js';
+import {
+  PipelineAbortError,
+  PipelineTimeoutError,
+  RmbgError,
+  LamaError,
+} from './errors.js';
 
 // ---------------------------------------------------------------------------
 // Public types
 // ---------------------------------------------------------------------------
+
+/**
+ * Reject with `PipelineTimeoutError` if `work` has not settled within
+ * `timeoutMs`.
+ *
+ * This bounds the *wait*, not the work: the underlying promise keeps running.
+ * That is enough for the failure this guards — a stalled model fetch — because
+ * the host exits after mapping the error. It cannot help with synchronous CV,
+ * which blocks the event loop and never yields to the timer at all.
+ *
+ * `Infinity` opts out, so a caller can disable a budget without special-casing.
+ */
+async function withDeadline<T>(
+  work: Promise<T>,
+  timeoutMs: number,
+  stage: string,
+): Promise<T> {
+  if (!Number.isFinite(timeoutMs) || timeoutMs <= 0) return work;
+
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  try {
+    return await Promise.race([
+      work,
+      new Promise<never>((_resolve, reject) => {
+        timer = setTimeout(() => reject(new PipelineTimeoutError(stage, timeoutMs)), timeoutMs);
+      }),
+    ]);
+  } finally {
+    if (timer !== undefined) clearTimeout(timer);
+  }
+}
 
 /**
  * The two runner implementations injected by the caller.
@@ -232,7 +269,14 @@ export async function runPipeline(
     skipWatermark = false,
     signal,
     onStage,
+    timeouts,
   } = options;
+
+  const budget = {
+    rmbg: timeouts?.RMBG_MS ?? PIPELINE_TIMEOUTS.RMBG_MS,
+    lama: timeouts?.LAMA_MS ?? PIPELINE_TIMEOUTS.LAMA_MS,
+    wallClock: timeouts?.WALL_CLOCK_MS ?? PIPELINE_TIMEOUTS.WALL_CLOCK_MS,
+  };
 
   // Helper: emit a stage event (no-op when onStage is not provided)
   const emit = (
@@ -243,10 +287,19 @@ export async function runPipeline(
     onStage?.(message !== undefined ? { stage, status, message } : { stage, status });
   };
 
-  // Check abort at each major boundary
+  // Check abort — and the wall-clock budget — at each major boundary.
+  // Coarse by construction: it can only fire between stages, never inside a
+  // long synchronous CV loop.
+  const startedAt = performance.now();
   const checkAbort = (): void => {
     if (signal?.aborted) {
       throw new PipelineAbortError('aborted');
+    }
+    if (
+      Number.isFinite(budget.wallClock) &&
+      performance.now() - startedAt > budget.wallClock
+    ) {
+      throw new PipelineTimeoutError('wall-clock', budget.wallClock);
     }
   };
 
@@ -345,13 +398,18 @@ export async function runPipeline(
       if (router.useLama && runners.lama) {
         emit('inpaint', 'running', 'Reconstructing zone [AI]...');
         try {
-          inpainted = await runners.lama.inpaint(
-            createImageDataLike(originalPixels, width, height),
-            dilated,
-            signal !== undefined ? { signal } : {},
+          inpainted = await withDeadline(
+            runners.lama.inpaint(
+              createImageDataLike(originalPixels, width, height),
+              dilated,
+              signal !== undefined ? { signal } : {},
+            ),
+            budget.lama,
+            'LaMa inpaint',
           );
         } catch (err: unknown) {
           if (err instanceof PipelineAbortError) throw err;
+          if (err instanceof PipelineTimeoutError) throw err;
           throw new LamaError('LaMa inpaint failed', { cause: err });
         }
         // Deliberately NOT disposing the runner here. `runners.lama` is
@@ -413,7 +471,8 @@ export async function runPipeline(
 
   let mlAlpha: Uint8Array;
   try {
-    mlAlpha = await runners.rmbg.segment(
+    mlAlpha = await withDeadline(
+      runners.rmbg.segment(
       createImageDataLike(originalPixels, width, height),
       {
         threshold,
@@ -428,9 +487,13 @@ export async function runPipeline(
         onProgress: (pct) =>
           emit('ml-segmentation', 'running', `Loading AI model... ${pct}%`),
       },
+      ),
+      budget.rmbg,
+      'RMBG segmentation',
     );
   } catch (err: unknown) {
     if (err instanceof PipelineAbortError) throw err;
+    if (err instanceof PipelineTimeoutError) throw err;
     throw new RmbgError('RMBG segmentation failed', { cause: err });
   }
 

--- a/packages/nukebg-core/src/types/pipeline-options.ts
+++ b/packages/nukebg-core/src/types/pipeline-options.ts
@@ -1,4 +1,5 @@
 import type { StageEvent } from './pipeline-result.js';
+import type { PipelineTimeouts } from '../pipeline/constants.js';
 
 export type PipelineMode = 'photo' | 'signature' | 'icon' | 'auto';
 export type PipelinePrecision = 'low' | 'normal' | 'high' | 'ultra';
@@ -24,6 +25,16 @@ export interface PipelineOptions {
   readonly skipAutoCrop?: boolean;
   /** Cancellation. */
   readonly signal?: AbortSignal;
+  /**
+   * Per-stage and whole-run time budgets in milliseconds. Any omitted key
+   * falls back to `PIPELINE_TIMEOUTS`.
+   *
+   * Only the asynchronous stages can actually be bounded — a `Promise.race`
+   * cannot interrupt synchronous CV on the same thread — but those are where
+   * the real hangs live (a stalled model fetch). Pass `Infinity` for a key to
+   * opt out of that budget.
+   */
+  readonly timeouts?: Partial<PipelineTimeouts>;
   /** Stage event sink. Optional. */
   readonly onStage?: (event: StageEvent) => void;
 }

--- a/packages/nukebg-core/tests/pipeline/timeouts.test.ts
+++ b/packages/nukebg-core/tests/pipeline/timeouts.test.ts
@@ -1,0 +1,129 @@
+import { describe, it, expect } from 'vitest';
+import { runPipeline } from '../../src/pipeline/run-pipeline.js';
+import type { RunnerBundle } from '../../src/pipeline/run-pipeline.js';
+import { createImageDataLike } from '../../src/types/image-data-like.js';
+import type { ImageDataLike } from '../../src/types/image-data-like.js';
+import { PipelineTimeoutError } from '../../src/pipeline/errors.js';
+import { PIPELINE_TIMEOUTS } from '../../src/pipeline/constants.js';
+import type { LamaRunner } from '../../src/runners/lama-runner.js';
+import type { RmbgRunner } from '../../src/runners/rmbg-runner.js';
+
+// The extraction dropped every timeout the browser orchestrator had, so a
+// stalled model fetch hung a run forever with no output and no exit
+// (issue #328). `git grep -i timeout` over both new packages returned nothing.
+//
+// What can actually be bounded is the asynchronous stages — a Promise.race
+// cannot interrupt synchronous CV on the same thread — and that is exactly
+// where the observed hang lives.
+
+function makeImage(w = 16, h = 16): ImageDataLike {
+  const data = new Uint8ClampedArray(w * h * 4);
+  for (let i = 0; i < w * h; i++) {
+    data[i * 4] = 120;
+    data[i * 4 + 1] = 120;
+    data[i * 4 + 2] = 120;
+    data[i * 4 + 3] = 255;
+  }
+  return createImageDataLike(data, w, h);
+}
+
+/** An RMBG runner whose segment() never settles — a stalled model fetch. */
+function makeHangingRmbg(): RmbgRunner {
+  return {
+    segment: () => new Promise<Uint8Array>(() => {}),
+    async dispose() {},
+  };
+}
+
+function makeFastRmbg(): RmbgRunner {
+  return {
+    async segment(input) {
+      return new Uint8Array(input.width * input.height).fill(200);
+    },
+    async dispose() {},
+  };
+}
+
+function makeFastLama(): LamaRunner {
+  return {
+    async inpaint(input) {
+      return new Uint8ClampedArray(input.width * input.height * 4).fill(255);
+    },
+    async dispose() {},
+  };
+}
+
+describe('runPipeline time budgets', () => {
+  it('rejects with PipelineTimeoutError when RMBG never settles', async () => {
+    const runners: RunnerBundle = { rmbg: makeHangingRmbg() };
+
+    await expect(
+      runPipeline(makeImage(), runners, {
+        mode: 'photo',
+        skipWatermark: true,
+        timeouts: { RMBG_MS: 40 },
+      }),
+    ).rejects.toBeInstanceOf(PipelineTimeoutError);
+  });
+
+  it('names the stage and the budget on the error', async () => {
+    const runners: RunnerBundle = { rmbg: makeHangingRmbg() };
+
+    const err = await runPipeline(makeImage(), runners, {
+      mode: 'photo',
+      skipWatermark: true,
+      timeouts: { RMBG_MS: 40 },
+    }).catch((e: unknown) => e);
+
+    expect(err).toBeInstanceOf(PipelineTimeoutError);
+    const timeout = err as PipelineTimeoutError;
+    expect(timeout.stage).toBe('RMBG segmentation');
+    expect(timeout.timeoutMs).toBe(40);
+    expect(timeout.code).toBe('PIPELINE_TIMEOUT');
+  });
+
+  it('does not fire when the stage completes inside its budget', async () => {
+    const runners: RunnerBundle = { rmbg: makeFastRmbg(), lama: makeFastLama() };
+
+    await expect(
+      runPipeline(makeImage(), runners, {
+        mode: 'photo',
+        skipWatermark: true,
+        timeouts: { RMBG_MS: 10_000 },
+      }),
+    ).resolves.toBeDefined();
+  });
+
+  it('treats Infinity as opting out of a budget', async () => {
+    const runners: RunnerBundle = { rmbg: makeFastRmbg() };
+
+    await expect(
+      runPipeline(makeImage(), runners, {
+        mode: 'photo',
+        skipWatermark: true,
+        timeouts: { RMBG_MS: Infinity },
+      }),
+    ).resolves.toBeDefined();
+  });
+
+  it('trips the wall-clock budget at a stage boundary', async () => {
+    const runners: RunnerBundle = { rmbg: makeFastRmbg() };
+
+    // Zero budget: already exceeded by the time the first boundary check runs.
+    await expect(
+      runPipeline(makeImage(), runners, {
+        mode: 'photo',
+        skipWatermark: true,
+        timeouts: { WALL_CLOCK_MS: -1 },
+      }),
+    ).rejects.toBeInstanceOf(PipelineTimeoutError);
+  });
+
+  it('ships defaults carried over from the browser orchestrator', () => {
+    // Regression guard: these were 300s/300s/20min before the extraction and
+    // silently became "no limit at all".
+    expect(PIPELINE_TIMEOUTS.RMBG_MS).toBe(300_000);
+    expect(PIPELINE_TIMEOUTS.LAMA_MS).toBe(300_000);
+    expect(PIPELINE_TIMEOUTS.WALL_CLOCK_MS).toBe(20 * 60_000);
+  });
+});


### PR DESCRIPTION
Closes #328. Found by the chain code review — every timeout the browser orchestrator had was lost in the extraction, so a stalled model fetch hung a run forever with no output and no exit.

## Design decisions

| Question | Resolution |
|---|---|
| Where do limits live? | `runPipeline`, overridable per call via `PipelineOptions.timeouts` — hosts should not each reinvent this, but a batch caller must be able to opt out |
| What can be bounded? | Only the async stages. `Promise.race` bounds the *wait*, not the work, and cannot interrupt synchronous CV on the same thread |
| Values | Carried over unchanged: 300s RMBG, 300s LaMa, 20 min wall clock — pinned by a test so they cannot silently become 'no limit' again |
| Exit code | New `TIMEOUT: 124`, matching GNU `timeout(1)`. Folding into 70 would lose that a timeout is retryable; sysexits (64-78) has no slot for 'took too long' |

## Honest scope

`WALL_CLOCK_MS` is checked at stage boundaries only, so it cannot fire inside a long synchronous CV loop. That is documented at the call site rather than dressed up as a hard cap. Interrupting synchronous CV is #329's problem, and it needs either yield points in the hot loops or moving CV to a worker thread.

`Infinity` on any budget opts out without special-casing.

## Verification

`core tests/pipeline/timeouts.test.ts` — hang detection, error payload (`stage`, `timeoutMs`, `code`), happy path, opt-out, wall-clock, pinned defaults. Plus the exit-code mapping in the cli suite. **1177 tests green**, typecheck and lint clean.