### PR TITLE
feat(cli): restore cancellation at asynchronous boundaries

### DIFF
--- a/packages/nukebg-cli/src/cli.ts
+++ b/packages/nukebg-cli/src/cli.ts
@@ -88,7 +88,11 @@ function buildProcessOptions(
   };
 }
 
-export async function runCli(argv: string[], deps: RunCliDeps = {}): Promise<number> {
+export async function runCli(
+  argv: string[],
+  deps: RunCliDeps = {},
+  signal?: AbortSignal,
+): Promise<number> {
   const stdoutWrite =
     deps.stdoutWrite ??
     ((text: string) => {
@@ -145,7 +149,10 @@ export async function runCli(argv: string[], deps: RunCliDeps = {}): Promise<num
     .option('-q, --quiet', 'suppress non-error stderr output')
     .option('-v, --verbose', 'extra timings on stderr')
     .action(async (input: string, raw: RawProcessOptions) => {
-      exitCode = await runProcessCommand(buildProcessOptions(input, raw, cliVersion));
+      const opts = buildProcessOptions(input, raw, cliVersion);
+      exitCode = await runProcessCommand(
+        signal !== undefined ? { ...opts, signal } : opts,
+      );
     });
 
   program
@@ -189,15 +196,38 @@ function isMainModule(): boolean {
 }
 
 async function main(): Promise<void> {
+  const controller = new AbortController();
+  let interrupted = false;
+
   process.on('SIGINT', () => {
-    process.exit(ExitCode.ABORTED);
+    if (interrupted) {
+      // Second Ctrl+C: the graceful path did not get us out. Drop the
+      // listener so SIGINT stops being handled in JS, and re-raise — the
+      // user always gets a way out.
+      process.removeAllListeners('SIGINT');
+      process.kill(process.pid, 'SIGINT');
+      return;
+    }
+    interrupted = true;
+    // Abort rather than exit. Exiting here would leave the run's own
+    // cleanup unrun and, worse, could fire mid-write; aborting unwinds
+    // through the pipeline's checkpoints and returns exit 130 the normal
+    // way, which is also what makes that code reachable at all.
+    controller.abort();
+    process.stderr.write('\nInterrupted — finishing the current step...\n');
   });
+
+  // Honest limit (issue #329): this cancels at asynchronous boundaries —
+  // model download, RMBG segmentation, LaMa inpaint, and each stage
+  // checkpoint. Synchronous CV (PatchMatch, sparkle detection) blocks the
+  // event loop, so the handler above cannot even run until that loop
+  // finishes. Interrupting those needs them off the main thread.
   // Last-resort net. `runCli` maps everything it can, but anything thrown
   // before or around that mapping must still leave through the documented
   // exit-code table rather than as an unhandled rejection.
   let code: number;
   try {
-    code = await runCli(process.argv.slice(2));
+    code = await runCli(process.argv.slice(2), {}, controller.signal);
   } catch (err) {
     process.stderr.write(`${err instanceof Error ? err.message : String(err)}\n`);
     code = exitCodeFor(err);

--- a/packages/nukebg-cli/src/commands/process.ts
+++ b/packages/nukebg-cli/src/commands/process.ts
@@ -10,7 +10,11 @@ import type {
   PipelineRunner,
   RmbgRunner,
 } from 'nukebg-core';
-import { autoCropToSubject, finalizePipelineResult } from 'nukebg-core';
+import {
+  autoCropToSubject,
+  finalizePipelineResult,
+  PipelineAbortError,
+} from 'nukebg-core';
 import { SharpImageCodec } from '../codecs/sharp-codec.js';
 import { OnnxNodeLamaRunner } from '../runners/onnx-node-lama.js';
 import { OnnxNodeRmbgRunner } from '../runners/onnx-node-rmbg.js';
@@ -49,6 +53,13 @@ export interface ProcessCommandOptions {
   readonly quiet?: boolean;
   readonly verbose?: boolean;
   readonly cliVersion?: string;
+  /**
+   * Cancellation. Honoured at every asynchronous boundary — model download,
+   * RMBG segmentation, LaMa inpaint and each stage checkpoint in
+   * `runPipeline`. Synchronous CV (PatchMatch, sparkle detection) cannot be
+   * interrupted mid-loop; see issue #329.
+   */
+  readonly signal?: AbortSignal;
 }
 
 export interface ProcessCommandDeps {
@@ -177,6 +188,7 @@ export class ProcessCommand {
       const pipelineOptions: PipelineOptions = {
         skipWatermark: noWatermark,
         skipAutoCrop: options.noAutoCrop ?? false,
+        ...(options.signal !== undefined ? { signal: options.signal } : {}),
         ...(options.mode !== undefined ? { mode: options.mode } : {}),
         ...(options.precision !== undefined ? { precision: options.precision } : {}),
       };
@@ -197,6 +209,10 @@ export class ProcessCommand {
       // holes unfilled — and made `--no-auto-crop` an inert flag.
       const finalized = finalizePipelineResult(result, decoded.image);
       const exported = options.noAutoCrop === true ? finalized : autoCropToSubject(finalized);
+
+      if (options.signal?.aborted) {
+        throw new PipelineAbortError('aborted before encoding output');
+      }
 
       log('Encoding output...\n');
       const encoded = await this.deps.codec.encode(exported, format);

--- a/packages/nukebg-cli/tests/commands/cancellation.test.ts
+++ b/packages/nukebg-cli/tests/commands/cancellation.test.ts
@@ -1,0 +1,131 @@
+import { describe, it, expect, vi } from 'vitest';
+import { PipelineAbortError } from 'nukebg-core';
+import type { PipelineResult } from 'nukebg-core';
+import { ProcessCommand } from '../../src/commands/process.js';
+import { ExitCode } from '../../src/util/exit-codes.js';
+
+// Cancellation was removed end-to-end in the extraction (issue #329):
+// ProcessCommand never built an AbortController and never passed `signal`, so
+// runPipeline's checkAbort() could not fire and the
+// PipelineAbortError -> ExitCode.ABORTED (130) mapping was dead code.
+//
+// Scope note: this covers cancellation at asynchronous boundaries, which is
+// where the long waits are (model download, inference). Synchronous CV still
+// blocks the event loop and cannot be interrupted — that needs CV off the
+// main thread and is deliberately out of scope here.
+
+function fakeResult(w = 2, h = 2): PipelineResult {
+  return {
+    output: { data: new Uint8ClampedArray(w * h * 4), width: w, height: h },
+    resolvedMode: 'photo',
+    durationMs: 1,
+    stageTimings: { watermark: 0, rmbg: 1, inpaint: 0, finalize: 0 },
+    watermarkRemoved: false,
+    watermarkMask: null,
+    workingPixels: new Uint8ClampedArray(w * h * 4),
+    workingAlpha: new Uint8Array(w * h),
+    workingWidth: w,
+    workingHeight: h,
+    nukedPct: 0,
+    contentType: 'PHOTO',
+  } as PipelineResult;
+}
+
+function makeDeps(overrides: { run?: () => Promise<PipelineResult> } = {}) {
+  const writeFileImpl = vi.fn(async () => undefined);
+  // `| undefined` is explicit because the package runs with
+  // exactOptionalPropertyTypes: recording "the signal arrived as undefined"
+  // is exactly what this fixture needs to be able to express.
+  const seen: { signal?: AbortSignal | undefined } = {};
+  return {
+    writeFileImpl,
+    seen,
+    deps: {
+      readFileImpl: vi.fn(async () => Buffer.from([0x89, 0x50, 0x4e, 0x47])),
+      writeFileImpl,
+      stderrWrite: vi.fn(),
+      stdoutWrite: vi.fn(),
+      assertAccepted: vi.fn(async () => undefined),
+      codec: {
+        decode: vi.fn(async () => ({
+          image: { data: new Uint8ClampedArray(16), width: 2, height: 2 },
+          originalWidth: 2,
+          originalHeight: 2,
+          wasDownsampled: false,
+        })),
+        encode: vi.fn(async () => new Uint8Array([1, 2, 3])),
+      },
+      createRmbgRunner: vi.fn(() => ({
+        segment: vi.fn(),
+        dispose: vi.fn(async () => undefined),
+      })),
+      createLamaRunner: vi.fn(() => ({
+        inpaint: vi.fn(),
+        dispose: vi.fn(async () => undefined),
+      })),
+      createPipelineRunner: vi.fn(() => ({
+        preload: vi.fn(async () => undefined),
+        run: overrides.run
+          ? overrides.run
+          : vi.fn(async (_input: unknown, opts: { signal?: AbortSignal }) => {
+              seen.signal = opts.signal;
+              return fakeResult();
+            }),
+        dispose: vi.fn(async () => undefined),
+      })),
+    },
+  };
+}
+
+describe('ProcessCommand cancellation', () => {
+  it('forwards the caller signal into the pipeline options', async () => {
+    const { deps, seen } = makeDeps();
+    const controller = new AbortController();
+
+    await new ProcessCommand(deps as never).execute({
+      input: 'in.png',
+      acceptNonCommercial: true,
+      signal: controller.signal,
+    });
+
+    // The whole defect was that this arrived undefined.
+    expect(seen.signal).toBe(controller.signal);
+  });
+
+  it('exits ABORTED (130) when the pipeline reports an abort', async () => {
+    const { deps } = makeDeps({
+      run: async () => {
+        throw new PipelineAbortError('aborted');
+      },
+    });
+
+    const code = await new ProcessCommand(deps as never).execute({
+      input: 'in.png',
+      acceptNonCommercial: true,
+    });
+
+    expect(code).toBe(ExitCode.ABORTED);
+    expect(code).toBe(130);
+  });
+
+  it('writes no output file when cancelled before encoding', async () => {
+    const controller = new AbortController();
+    const { deps, writeFileImpl } = makeDeps({
+      run: async () => {
+        // Cancelled while the pipeline was running.
+        controller.abort();
+        return fakeResult();
+      },
+    });
+
+    const code = await new ProcessCommand(deps as never).execute({
+      input: 'in.png',
+      acceptNonCommercial: true,
+      signal: controller.signal,
+    });
+
+    expect(code).toBe(ExitCode.ABORTED);
+    // A partially-processed run must not leave a file behind.
+    expect(writeFileImpl).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
Addresses #329 **in part**, deliberately — the scope note below is the point, not a caveat.

## What was broken

`ProcessCommand` never built an `AbortController` and never passed `signal`, so `runPipeline`'s `checkAbort()` could not fire and the `PipelineAbortError -> ExitCode.ABORTED (130)` mapping was unreachable code.

## What changed

- `ProcessCommandOptions` accepts a `signal`, forwarded into `PipelineOptions`; the run is re-checked before encoding so a cancelled run leaves **no output file** behind.
- `runCli` threads a signal through to the process action.
- `main()` owns the controller. **SIGINT now aborts instead of calling `process.exit`** — exiting there skipped the pipeline's own unwinding, could fire mid-write, and is why 130 was never produced through the normal path. A second Ctrl+C drops the listener and re-raises, so the user always has a way out.

## Scope — what this does not fix

Cancellation works at **asynchronous** boundaries: model download, RMBG segmentation, LaMa inpaint, and each stage checkpoint. That is where the multi-minute waits actually are.

**Synchronous CV is still uninterruptible.** PatchMatch and sparkle detection block the event loop, so the SIGINT handler cannot run until the loop frees — no amount of signal plumbing changes that. Fixing it means moving CV to a `worker_thread` (what the browser does with Web Workers) or adding yield points to the hot loops, each with real costs. #329 stays open for that decision.

## Verification

`cli tests/commands/cancellation.test.ts` — signal propagation, exit 130 reachable, no file written when cancelled. Verified by removing the forwarding line and watching the first assertion fail. Full gate green: typecheck, lint, **1180 tests**.