### PR TITLE
chore(security): dedupe brace-expansion, and record why the rest cannot follow

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2519,16 +2519,16 @@
       "license": "MIT"
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/buffer-image-size": {
@@ -3916,6 +3916,26 @@
         "tar": "^7.0.1"
       }
     },
+    "node_modules/onnxruntime-web": {
+      "version": "1.24.3",
+      "resolved": "https://registry.npmjs.org/onnxruntime-web/-/onnxruntime-web-1.24.3.tgz",
+      "integrity": "sha512-41dDq7fxtTm0XzGE7N0d6m8FcOY8EWtUA65GkOixJPB/G7DGzBmiDAnVVXHznRw9bgUZpb+4/1lQK/PNxGpbrQ==",
+      "license": "MIT",
+      "dependencies": {
+        "flatbuffers": "^25.1.24",
+        "guid-typescript": "^1.0.9",
+        "long": "^5.2.3",
+        "onnxruntime-common": "1.24.3",
+        "platform": "^1.3.6",
+        "protobufjs": "^7.2.4"
+      }
+    },
+    "node_modules/onnxruntime-web/node_modules/onnxruntime-common": {
+      "version": "1.24.3",
+      "resolved": "https://registry.npmjs.org/onnxruntime-common/-/onnxruntime-common-1.24.3.tgz",
+      "integrity": "sha512-GeuPZO6U/LBJXvwdaqHbuUmoXiEdeCjWi/EG7Y1HNnDwJYuk6WUbNXpF6luSUY8yASul3cmUlLGrCCL1ZgVXqA==",
+      "license": "MIT"
+    },
     "node_modules/optionator": {
       "version": "0.9.4",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
@@ -4624,9 +4644,9 @@
       }
     },
     "node_modules/tinyglobby": {
-      "version": "0.2.16",
-      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
-      "integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5420,23 +5440,6 @@
         }
       }
     },
-    "node_modules/vite/node_modules/tinyglobby": {
-      "version": "0.2.17",
-      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
-      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "fdir": "^6.5.0",
-        "picomatch": "^4.0.4"
-      },
-      "engines": {
-        "node": ">=12.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/SuperchupuDev"
-      }
-    },
     "node_modules/vitest": {
       "version": "4.1.10",
       "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.10.tgz",
@@ -6153,26 +6156,6 @@
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
-      }
-    },
-    "packages/nukebg-app/node_modules/onnxruntime-common": {
-      "version": "1.24.3",
-      "resolved": "https://registry.npmjs.org/onnxruntime-common/-/onnxruntime-common-1.24.3.tgz",
-      "integrity": "sha512-GeuPZO6U/LBJXvwdaqHbuUmoXiEdeCjWi/EG7Y1HNnDwJYuk6WUbNXpF6luSUY8yASul3cmUlLGrCCL1ZgVXqA==",
-      "license": "MIT"
-    },
-    "packages/nukebg-app/node_modules/onnxruntime-web": {
-      "version": "1.24.3",
-      "resolved": "https://registry.npmjs.org/onnxruntime-web/-/onnxruntime-web-1.24.3.tgz",
-      "integrity": "sha512-41dDq7fxtTm0XzGE7N0d6m8FcOY8EWtUA65GkOixJPB/G7DGzBmiDAnVVXHznRw9bgUZpb+4/1lQK/PNxGpbrQ==",
-      "license": "MIT",
-      "dependencies": {
-        "flatbuffers": "^25.1.24",
-        "guid-typescript": "^1.0.9",
-        "long": "^5.2.3",
-        "onnxruntime-common": "1.24.3",
-        "platform": "^1.3.6",
-        "protobufjs": "^7.2.4"
       }
     },
     "packages/nukebg-app/node_modules/sharp": {

--- a/package.json
+++ b/package.json
@@ -31,7 +31,8 @@
     "typescript-eslint": "^8.65.0"
   },
   "overrides": {
-    "protobufjs": "^7.5.5"
+    "protobufjs": "^7.5.5",
+    "brace-expansion": "^5.0.9"
   },
   "engines": {
     "node": ">=20.0.0"


### PR DESCRIPTION
Partial progress on #331: **7 findings -> 6**. The interesting part is what could *not* be fixed and why.

## Fixed

`brace-expansion` overridden to `^5.0.9`, resolving a high-severity DoS.

## Attempted and reverted — not left as dead config

| Package | Why not |
|---|---|
| `tar` (CRITICAL), `esbuild` (LOW) | Overrides declared, npm ignored them. It keeps the already-resolved entry; neither `npm install` nor `npm dedupe` re-resolves. tar stayed 7.5.13, esbuild 0.27.7 **with the override in place**. Same behaviour that made the onnxruntime-node dedupe need its own pass. |
| `sharp` (HIGH), `@huggingface/transformers` (HIGH, via sharp) | **No fix exists.** 0.35.3 is the latest published sharp and still carries the libvips CVEs. Nothing to bump to. |
| `protobufjs` (HIGH), `@protobufjs/utf8` (MODERATE) | Fix is a major (8.x) for a transitive dep of the ONNX stack. Not a rider on an unrelated change. |

## The severity ordering is misleading

Worth stating plainly, because acting on the CVSS numbers alone would prioritise this backwards:

- **`sharp`/libvips is the one that matters.** It decodes user-supplied images at runtime, so it is attacker-reachable — and it is exactly the one with no available fix.
- **`tar` is marked CRITICAL but is build-time.** It is only exercised by `onnxruntime-node`'s install script unpacking its own prebuilt binaries from the npm registry. Not attacker-controlled.

## Recommendation for the rest of #331

A permanently-red required check trains everyone to ignore it, which is worse than no check. Either make `npm audit` non-blocking with an explicit, reviewed allowlist for the unfixable entries, or schedule a dedicated dependency-refresh PR that regenerates the lockfile from scratch and validates with the full e2e suite. Not both, and not silently.

Gate: typecheck, lint, 1180 tests.