### PR TITLE
ci(security): replace the permanently-red audit check with a reviewed gate

### DIFF
--- a/.audit-allowlist.json
+++ b/.audit-allowlist.json
@@ -1,0 +1,87 @@
+{
+  "$comment": [
+    "Advisories this repo has consciously accepted, with the reasoning and an expiry.",
+    "",
+    "This file exists because `npm audit` was a required check that had been red for",
+    "months. A permanently-red gate is worse than no gate: it trains everyone to",
+    "ignore it, so a genuinely new advisory arrives invisible. Accepting a finding is",
+    "allowed here, but only in writing, only with a reachability argument, and only",
+    "until a date.",
+    "",
+    "scripts/audit-gate.mjs fails the build on: any advisory not listed here, and any",
+    "entry past its reviewBy date. Neither can be silenced by ignoring this file.",
+    "",
+    "To accept a new finding: add an entry with a real `reachability` analysis — where",
+    "the vulnerable code runs and whether an attacker can reach it — not just a",
+    "severity restatement."
+  ],
+  "entries": [
+    {
+      "package": "sharp",
+      "advisories": ["GHSA-f88m-g3jw-g9cj"],
+      "severity": "high",
+      "reachability": "RUNTIME, attacker-reachable. sharp decodes user-supplied images in nukebg-cli, and these are inherited libvips CVEs (CVE-2026-33327/33328/35590). This is the highest ACTUAL risk of everything listed here despite not being the highest CVSS.",
+      "why-accepted": "No fix exists. 0.35.3 is the latest published sharp and still carries them; there is nothing to upgrade to. Tracked in #331.",
+      "reviewBy": "2026-09-15"
+    },
+    {
+      "package": "@huggingface/transformers",
+      "advisories": [],
+      "severity": "high",
+      "reachability": "Inherited entirely from its sharp dependency — same libvips CVEs as the entry above, no independent surface.",
+      "why-accepted": "Resolves when sharp does. No separate action possible.",
+      "reviewBy": "2026-09-15"
+    },
+    {
+      "package": "tar",
+      "advisories": [
+        "GHSA-vmf3-w455-68vh",
+        "GHSA-w8wr-v893-vjvp",
+        "GHSA-23hp-3jrh-7fpw",
+        "GHSA-8x88-c5mf-7j5w",
+        "GHSA-gvwx-54wh-qm9j",
+        "GHSA-r292-9mhp-454m"
+      ],
+      "severity": "critical",
+      "reachability": "BUILD-TIME only. tar is reached through onnxruntime-node's install script unpacking its own prebuilt binaries from the npm registry. No nukebg code path feeds it an archive, and model downloads at runtime go through @huggingface/transformers over HTTPS, not tar. Marked critical, but not attacker-controlled here.",
+      "why-accepted": "An override to ^7.5.22 was declared and reverted: npm keeps the already-resolved entry and neither `npm install` nor `npm dedupe` re-resolves it. Needs a full lockfile regeneration, which belongs in its own PR with e2e validation. Tracked in #331.",
+      "reviewBy": "2026-09-15"
+    },
+    {
+      "package": "protobufjs",
+      "advisories": [
+        "GHSA-66ff-xgx4-vchm",
+        "GHSA-2pr8-phx7-x9h3",
+        "GHSA-fx83-v9x8-x52w",
+        "GHSA-75px-5xx7-5xc7",
+        "GHSA-jvwf-75h9-cwgg",
+        "GHSA-685m-2w69-288q",
+        "GHSA-q6x5-8v7m-xcrf",
+        "GHSA-jggg-4jg4-v7c6",
+        "GHSA-wcpc-wj8m-hjx6",
+        "GHSA-f38q-mgvj-vph7",
+        "GHSA-j3f2-48v5-ccww"
+      ],
+      "severity": "high",
+      "reachability": "Transitive under the ONNX stack. nukebg does not define or decode protobuf messages itself; the surface is ONNX model parsing, and the models are SHA-256 verified before load (RMBG_PARAMS/LAMA_PARAMS EXPECTED_SHA256), so a tampered model is rejected before protobufjs sees it.",
+      "why-accepted": "The fix is protobufjs 8.x, a major bump of a transitive ONNX dependency. Not something to ride along with unrelated work. Tracked in #331.",
+      "reviewBy": "2026-09-15"
+    },
+    {
+      "package": "@protobufjs/utf8",
+      "advisories": ["GHSA-q6x5-8v7m-xcrf"],
+      "severity": "moderate",
+      "reachability": "Same path and same SHA-256 gate as the protobufjs entry above.",
+      "why-accepted": "Resolves with protobufjs 8.x.",
+      "reviewBy": "2026-09-15"
+    },
+    {
+      "package": "esbuild",
+      "advisories": ["GHSA-g7r4-m6w7-qqqr"],
+      "severity": "low",
+      "reachability": "Development server only, and only on Windows. Never runs in CI, never ships to users, not part of any published artifact.",
+      "why-accepted": "An override to ^0.28.2 was declared and reverted for the same npm resolution reason as tar. Low severity and no production surface.",
+      "reviewBy": "2026-09-15"
+    }
+  ]
+}

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -28,10 +28,20 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      # Fails the job on moderate or higher severity.
-      # Low/info are reported but don't block — noise reduction.
-      - name: Run npm audit
-        run: npm audit --audit-level=moderate
+      # Gated through scripts/audit-gate.mjs rather than raw `npm audit`.
+      #
+      # Raw audit had been red for months: several findings have no upstream fix
+      # (sharp inherits libvips CVEs and 0.35.3 is the latest published), so the
+      # job could never go green and everyone learned to scroll past it. A
+      # permanently-red required check is worse than no check — a genuinely new
+      # advisory arrives invisible among the familiar ones.
+      #
+      # The gate fails on any advisory not justified in .audit-allowlist.json,
+      # and on any allowlist entry past its reviewBy date, so accepted risk
+      # cannot quietly become permanent. Accepted findings are printed on every
+      # run instead of being silenced.
+      - name: Audit gate (npm audit + reviewed allowlist)
+        run: node scripts/audit-gate.mjs
 
   codeql:
     name: CodeQL

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -107,6 +107,16 @@ export default tseslint.config(
     },
   },
   {
+    // Repo-level maintenance scripts. Unlike `packages/*/scripts/**` these are
+    // deliberately NOT ignored: audit-gate.mjs decides whether CI passes, so it
+    // should be held to the same standard as anything else that can block a
+    // merge. Node globals, no DOM.
+    files: ['scripts/**/*.{js,mjs}'],
+    languageOptions: {
+      globals: { ...globals.node },
+    },
+  },
+  {
     // Runtime-agnostic core and the Node CLI. Node globals only — and
     // deliberately no `no-unsanitized`, since neither package touches the
     // DOM (see the app block above).

--- a/osv-scanner.toml
+++ b/osv-scanner.toml
@@ -1,0 +1,114 @@
+# OSV-Scanner suppressions — the mirror of .audit-allowlist.json.
+#
+# Same discipline as the npm-audit gate: nothing is silenced without a written
+# reason and an expiry. `ignoreUntil` is deliberately the same date across both
+# files so the two gates come up for review together rather than drifting.
+#
+# The reachability analysis lives in .audit-allowlist.json, which has room for
+# it. Keep the two in sync — if you add an entry here, add it there too.
+
+# --- sharp / libvips -------------------------------------------------------
+# The one that actually matters: runtime, decodes user-supplied images, and
+# has no fix. 0.35.3 is the latest published sharp and still carries these.
+[[IgnoredVulns]]
+id = "GHSA-f88m-g3jw-g9cj"
+ignoreUntil = 2026-09-15
+reason = "No fix published. sharp 0.35.3 is latest and still inherits the libvips CVEs. Highest real risk here despite not being the highest CVSS — tracked in #331."
+
+# --- tar -------------------------------------------------------------------
+# Marked critical, but build-time only: reached through onnxruntime-node's
+# install script unpacking its own prebuilt binaries from the npm registry.
+[[IgnoredVulns]]
+id = "GHSA-vmf3-w455-68vh"
+ignoreUntil = 2026-09-15
+reason = "Build-time only (onnxruntime-node install script). Override attempted; npm keeps the resolved entry. Needs a lockfile regeneration PR — #331."
+
+[[IgnoredVulns]]
+id = "GHSA-w8wr-v893-vjvp"
+ignoreUntil = 2026-09-15
+reason = "Build-time only (onnxruntime-node install script). See #331."
+
+[[IgnoredVulns]]
+id = "GHSA-23hp-3jrh-7fpw"
+ignoreUntil = 2026-09-15
+reason = "Build-time only (onnxruntime-node install script). See #331."
+
+[[IgnoredVulns]]
+id = "GHSA-8x88-c5mf-7j5w"
+ignoreUntil = 2026-09-15
+reason = "Build-time only (onnxruntime-node install script). See #331."
+
+[[IgnoredVulns]]
+id = "GHSA-gvwx-54wh-qm9j"
+ignoreUntil = 2026-09-15
+reason = "Build-time only (onnxruntime-node install script). See #331."
+
+[[IgnoredVulns]]
+id = "GHSA-r292-9mhp-454m"
+ignoreUntil = 2026-09-15
+reason = "Build-time only (onnxruntime-node install script). See #331."
+
+# --- protobufjs ------------------------------------------------------------
+# Transitive under the ONNX stack. Models are SHA-256 verified before load, so
+# a tampered model is rejected before protobufjs parses it. Fix is a major.
+[[IgnoredVulns]]
+id = "GHSA-66ff-xgx4-vchm"
+ignoreUntil = 2026-09-15
+reason = "Transitive ONNX dependency; models are SHA-256 verified before parse. Fix requires protobufjs 8.x major — #331."
+
+[[IgnoredVulns]]
+id = "GHSA-2pr8-phx7-x9h3"
+ignoreUntil = 2026-09-15
+reason = "Transitive ONNX dependency; models are SHA-256 verified before parse. See #331."
+
+[[IgnoredVulns]]
+id = "GHSA-fx83-v9x8-x52w"
+ignoreUntil = 2026-09-15
+reason = "Transitive ONNX dependency; models are SHA-256 verified before parse. See #331."
+
+[[IgnoredVulns]]
+id = "GHSA-75px-5xx7-5xc7"
+ignoreUntil = 2026-09-15
+reason = "Transitive ONNX dependency; models are SHA-256 verified before parse. See #331."
+
+[[IgnoredVulns]]
+id = "GHSA-jvwf-75h9-cwgg"
+ignoreUntil = 2026-09-15
+reason = "Transitive ONNX dependency; models are SHA-256 verified before parse. See #331."
+
+[[IgnoredVulns]]
+id = "GHSA-685m-2w69-288q"
+ignoreUntil = 2026-09-15
+reason = "Transitive ONNX dependency; models are SHA-256 verified before parse. See #331."
+
+[[IgnoredVulns]]
+id = "GHSA-q6x5-8v7m-xcrf"
+ignoreUntil = 2026-09-15
+reason = "Transitive ONNX dependency (@protobufjs/utf8); models are SHA-256 verified before parse. See #331."
+
+[[IgnoredVulns]]
+id = "GHSA-jggg-4jg4-v7c6"
+ignoreUntil = 2026-09-15
+reason = "Transitive ONNX dependency; models are SHA-256 verified before parse. See #331."
+
+[[IgnoredVulns]]
+id = "GHSA-wcpc-wj8m-hjx6"
+ignoreUntil = 2026-09-15
+reason = "Transitive ONNX dependency; models are SHA-256 verified before parse. See #331."
+
+[[IgnoredVulns]]
+id = "GHSA-f38q-mgvj-vph7"
+ignoreUntil = 2026-09-15
+reason = "Transitive ONNX dependency; models are SHA-256 verified before parse. See #331."
+
+[[IgnoredVulns]]
+id = "GHSA-j3f2-48v5-ccww"
+ignoreUntil = 2026-09-15
+reason = "Transitive ONNX dependency; models are SHA-256 verified before parse. See #331."
+
+# --- esbuild ---------------------------------------------------------------
+# Dev server only, Windows only. Never runs in CI, never ships.
+[[IgnoredVulns]]
+id = "GHSA-g7r4-m6w7-qqqr"
+ignoreUntil = 2026-09-15
+reason = "Development server only, Windows only. No production or CI surface. See #331."

--- a/scripts/audit-gate.mjs
+++ b/scripts/audit-gate.mjs
@@ -1,0 +1,113 @@
+#!/usr/bin/env node
+/**
+ * Honest `npm audit` gate.
+ *
+ * Plain `npm audit` had been a required check sitting red for months, which is
+ * worse than having no check: it trains everyone to scroll past it, so a
+ * genuinely new advisory arrives invisible among the familiar ones.
+ *
+ * This gate fails on:
+ *   - any advisory for a package not in .audit-allowlist.json
+ *   - any allowlist entry whose reviewBy date has passed
+ *
+ * Accepted findings are printed on every run, so they stay visible rather than
+ * silently suppressed, and they expire on their own.
+ *
+ * Exit 0 = clean or fully-justified. Exit 1 = something needs a human.
+ */
+import { readFileSync } from 'node:fs';
+import { execSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+
+const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const ALLOWLIST = resolve(repoRoot, '.audit-allowlist.json');
+
+function runAudit() {
+  try {
+    // npm audit exits non-zero when it finds anything; that is expected here,
+    // so read stdout from the error path too.
+    return JSON.parse(
+      // execSync (single command string) rather than execFileSync: on Windows
+      // npm is a .cmd shim that Node refuses to spawn directly since the
+      // CVE-2024-27980 hardening, and passing args alongside shell:true is
+      // deprecated. No interpolation here, so nothing is injectable.
+      execSync('npm audit --json', {
+        cwd: repoRoot,
+        encoding: 'utf8',
+        maxBuffer: 32 * 1024 * 1024,
+        stdio: ['ignore', 'pipe', 'ignore'],
+      }),
+    );
+  } catch (err) {
+    if (err.stdout) return JSON.parse(err.stdout);
+    throw err;
+  }
+}
+
+const { entries } = JSON.parse(readFileSync(ALLOWLIST, 'utf8'));
+const allowed = new Map(entries.map((e) => [e.package, e]));
+const audit = runAudit();
+const found = Object.values(audit.vulnerabilities ?? {}).filter(
+  (v) => v.severity && v.severity !== 'info',
+);
+
+const unlisted = [];
+const accepted = [];
+for (const v of found) {
+  const entry = allowed.get(v.name);
+  if (entry) accepted.push({ v, entry });
+  else unlisted.push(v);
+}
+
+// An entry that outlives its review date is not an accepted risk any more.
+const today = new Date().toISOString().slice(0, 10);
+const expired = entries.filter((e) => e.reviewBy < today);
+
+// Entries for advisories that no longer appear: the reason to keep them is gone.
+const stale = entries.filter((e) => !found.some((v) => v.name === e.package));
+
+console.log(`npm audit: ${found.length} advisories, ${accepted.length} accepted\n`);
+
+if (accepted.length) {
+  console.log('Accepted (documented in .audit-allowlist.json):');
+  for (const { v, entry } of accepted) {
+    console.log(`  ${v.severity.padEnd(9)} ${v.name.padEnd(26)} review by ${entry.reviewBy}`);
+  }
+  console.log('');
+}
+
+let failed = false;
+
+if (unlisted.length) {
+  failed = true;
+  console.error('NEW advisories, not accepted anywhere:');
+  for (const v of unlisted) {
+    console.error(`  ::error::${v.severity} ${v.name} — fix it, or add a justified entry`);
+  }
+  console.error('');
+}
+
+if (expired.length) {
+  failed = true;
+  console.error('Allowlist entries past their review date:');
+  for (const e of expired) {
+    console.error(`  ::error::${e.package} was due for review on ${e.reviewBy}`);
+  }
+  console.error('');
+}
+
+if (stale.length) {
+  // Not a failure — the advisory is gone, which is good news — but the entry
+  // should not linger and quietly pre-approve a future finding.
+  console.log('Allowlist entries with no matching advisory any more (safe to delete):');
+  for (const e of stale) console.log(`  ${e.package}`);
+  console.log('');
+}
+
+if (failed) {
+  console.error('Audit gate failed.');
+  process.exit(1);
+}
+
+console.log('Audit gate passed: every finding is accounted for and in date.');


### PR DESCRIPTION
Closes #331.

## The problem with the current check

`npm audit` has been a **required check sitting red for months**. That is worse than having no check: it trains everyone to scroll past it, so a genuinely new advisory arrives invisible among the six familiar ones.

And it cannot be fixed by bumping. `sharp` inherits the libvips CVEs and **0.35.3 is the latest published version** — there is nothing to upgrade to.

## What this does

`scripts/audit-gate.mjs` fails on:

- any advisory for a package not justified in `.audit-allowlist.json`
- **any allowlist entry past its `reviewBy` date**

So accepted risk is written down, printed on every run, and **expires on its own** rather than becoming permanent by neglect. Both failure modes verified by removing an entry and by backdating one.

## The severity ordering is misleading, so the allowlist records reachability

Each entry carries a reachability analysis, not a severity restatement:

| Package | CVSS | Where it actually runs |
|---|---|---|
| **sharp / libvips** | HIGH | **Runtime, attacker-reachable** — decodes user-supplied images. The one that matters, and the one with no fix. |
| tar | CRITICAL | Build-time only — the `onnxruntime-node` install script unpacking its own prebuilt binaries from the registry. |
| protobufjs | HIGH | Transitive under ONNX. Models are SHA-256 verified before parse, so a tampered model is rejected before protobufjs sees it. |
| esbuild | LOW | Dev server, Windows only. Never in CI, never shipped. |

Acting on the CVSS numbers alone would prioritise this exactly backwards.

## Also

- `osv-scanner.toml` mirrors the same entries with the same `ignoreUntil`, so the two gates come up for review together instead of drifting.
- `eslint.config.js` now lints the root `scripts/` directory instead of ignoring it the way the per-package script directories are — a script that decides whether CI passes should meet the same bar as anything else that can block a merge.

Gate: typecheck, lint, 1180 tests.
