### PR TITLE
feat(cli): run the pipeline on a worker thread so Ctrl+C works

### DIFF
--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -66,18 +66,18 @@ jobs:
       - name: Typecheck nukebg-cli
         run: npm run typecheck -w nukebg-cli
 
-      # NOTE (Phase 18 -> Phase 19 handoff): `npm run build -w nukebg-cli`
-      # is intentionally NOT wired in yet. nukebg-cli's package.json has no
-      # `build` script today, and `tsup.config.ts` for nukebg-cli does not
-      # exist until Phase 19 (CLI packaging & distribution) — running it
-      # now would fail the whole matrix with "Missing script: build" on
-      # every OS leg. Once Phase 19 lands the tsup config + `build` script,
-      # uncomment the step below (it must run before the test step so
-      # `dist/cli.js` exists for any test that shells out to the built
-      # binary, if such a test is added):
+      # Build both packages before testing. This is no longer optional: tsup
+      # externalises nukebg-core, so the emitted worker imports
+      # nukebg-core/dist/index.js at RUNTIME. Without core built the pipeline
+      # worker dies with ERR_MODULE_NOT_FOUND, and tests/runners/worker-bundle.test.ts
+      # exists precisely to catch that — it did, on all three legs.
       #
-      # - name: Build nukebg-cli (tsup)
-      #   run: npm run build -w nukebg-cli
+      # Order matters: core first, then the CLI bundle that depends on it.
+      - name: Build nukebg-core
+        run: npm run build -w nukebg-core
+
+      - name: Build nukebg-cli (tsup)
+        run: npm run build -w nukebg-cli
 
       # Parity placeholder (tasks.md X.6): the browser<->Node pixel parity
       # test (packages/nukebg-core/tests/parity/parity.test.ts, REQ-PARITY-1

--- a/packages/nukebg-cli/src/commands/process.ts
+++ b/packages/nukebg-cli/src/commands/process.ts
@@ -19,6 +19,7 @@ import { SharpImageCodec } from '../codecs/sharp-codec.js';
 import { OnnxNodeLamaRunner } from '../runners/onnx-node-lama.js';
 import { OnnxNodeRmbgRunner } from '../runners/onnx-node-rmbg.js';
 import { NodePipelineRunner } from '../runners/node-pipeline-runner.js';
+import { WorkerPipelineRunner } from '../runners/worker-pipeline-runner.js';
 import { assertAccepted as defaultAssertAccepted } from '../license/gate.js';
 import type { GateOptions } from '../license/gate.js';
 import { ExitCode } from '../util/exit-codes.js';
@@ -134,9 +135,15 @@ function resolveDeps(deps: ProcessCommandDeps): ResolvedDeps {
 
 export class ProcessCommand {
   private readonly deps: ResolvedDeps;
+  /**
+   * True when the caller injected its own pipeline runner. Tests do; the real
+   * CLI does not, and takes the worker path instead.
+   */
+  private readonly runnerInjected: boolean;
 
   constructor(deps: ProcessCommandDeps = {}) {
     this.deps = resolveDeps(deps);
+    this.runnerInjected = deps.createPipelineRunner !== undefined;
   }
 
   async execute(options: ProcessCommandOptions): Promise<number> {
@@ -169,17 +176,33 @@ export class ProcessCommand {
       const outputPath = resolveOutputPath(options.input, options.output, format);
 
       const noWatermark = options.noWatermark ?? false;
-      const rmbgRunner = this.deps.createRmbgRunner(
-        options.cacheDir !== undefined ? { cacheDir: options.cacheDir } : {},
-      );
-      const lamaRunner = noWatermark
-        ? undefined
-        : this.deps.createLamaRunner(
-            options.cacheDir !== undefined ? { cacheDir: options.cacheDir } : {},
-          );
-      const runner = this.deps.createPipelineRunner(
-        lamaRunner ? { rmbgRunner, lamaRunner } : { rmbgRunner },
-      );
+
+      // Default path: the whole pipeline runs on a worker thread, and the ONNX
+      // runners are constructed inside it. Building them here too would mean
+      // two copies of every model. See issue #329 — synchronous CV
+      // (patchMatchInpaint, ~2.3s at 720p and ~14.4s at 6MP) blocks the event
+      // loop, so on the main thread SIGINT cannot be answered at all.
+      //
+      // When a caller injects its own runner it wins, which is how the unit
+      // tests drive this without spawning threads.
+      const runner: PipelineRunner = this.runnerInjected
+        ? this.deps.createPipelineRunner(
+            (() => {
+              const rmbgRunner = this.deps.createRmbgRunner(
+                options.cacheDir !== undefined ? { cacheDir: options.cacheDir } : {},
+              );
+              const lamaRunner = noWatermark
+                ? undefined
+                : this.deps.createLamaRunner(
+                    options.cacheDir !== undefined ? { cacheDir: options.cacheDir } : {},
+                  );
+              return lamaRunner ? { rmbgRunner, lamaRunner } : { rmbgRunner };
+            })(),
+          )
+        : new WorkerPipelineRunner({
+            noWatermark,
+            ...(options.cacheDir !== undefined ? { cacheDir: options.cacheDir } : {}),
+          });
 
       log('Loading models...\n');
       await runner.preload?.();

--- a/packages/nukebg-cli/src/runners/pipeline.worker.ts
+++ b/packages/nukebg-cli/src/runners/pipeline.worker.ts
@@ -1,0 +1,132 @@
+/**
+ * Pipeline worker thread.
+ *
+ * Everything expensive runs here — decode-side pixels in, finished
+ * `PipelineResult` out — so the main thread stays free to answer SIGINT.
+ *
+ * This mirrors what the browser already does. `patchMatchInpaint` costs
+ * ~2.3 s at 720p, ~4.8 s at 1080p and ~14.4 s on a 6 MP image (measured for
+ * issue #329), and it runs synchronously. On the main thread that window is
+ * simply uninterruptible: the SIGINT handler cannot run because the event
+ * loop is blocked, so no amount of AbortSignal plumbing helps. In the browser
+ * the same function already runs inside a Web Worker (`inpaint.worker.ts`),
+ * which is why the browser never had this problem.
+ *
+ * Cancellation here is `worker.terminate()` — immediate, not cooperative.
+ *
+ * The ONNX runners are constructed inside the worker rather than on the main
+ * thread. Splitting them would mean shuttling masks back and forth across the
+ * boundary mid-pipeline; keeping the whole run on one side costs nothing
+ * extra, because the worker is spawned per run anyway.
+ */
+import { parentPort, workerData } from 'node:worker_threads';
+import type { ImageDataLike, PipelineOptions, PipelineResult, StageEvent } from 'nukebg-core';
+import { OnnxNodeRmbgRunner } from './onnx-node-rmbg.js';
+import { OnnxNodeLamaRunner } from './onnx-node-lama.js';
+import { NodePipelineRunner } from './node-pipeline-runner.js';
+
+/** What the main thread sends when it spawns us. */
+export interface PipelineWorkerInput {
+  readonly pixels: Uint8ClampedArray;
+  readonly width: number;
+  readonly height: number;
+  /** `PipelineOptions` minus the things that cannot cross a thread boundary. */
+  readonly options: Omit<PipelineOptions, 'signal' | 'onStage'>;
+  readonly cacheDir?: string;
+  /** Omit the LaMa runner entirely, mirroring ProcessCommand's own policy. */
+  readonly noWatermark: boolean;
+}
+
+/** What we send back. Stage events stream; the result or error arrives once. */
+export type PipelineWorkerMessage =
+  | { readonly kind: 'stage'; readonly event: StageEvent }
+  | { readonly kind: 'result'; readonly result: SerializablePipelineResult }
+  | { readonly kind: 'error'; readonly name: string; readonly message: string; readonly code?: string };
+
+/**
+ * `PipelineResult` as it survives structured clone.
+ *
+ * `runPipeline` freezes its result and the typed arrays clone fine, but the
+ * object is rebuilt on the other side, so this documents exactly what crosses.
+ */
+export interface SerializablePipelineResult {
+  readonly output: { data: Uint8ClampedArray; width: number; height: number };
+  readonly resolvedMode: PipelineResult['resolvedMode'];
+  readonly durationMs: number;
+  readonly stageTimings: PipelineResult['stageTimings'];
+  readonly watermarkRemoved: boolean;
+  readonly watermarkMask: Uint8Array | null;
+  readonly workingPixels: Uint8ClampedArray;
+  readonly workingAlpha: Uint8Array;
+  readonly workingWidth: number;
+  readonly workingHeight: number;
+  readonly nukedPct: number;
+  readonly contentType: PipelineResult['contentType'];
+}
+
+async function main(): Promise<void> {
+  const port = parentPort;
+  if (!port) throw new Error('pipeline.worker must be run as a worker thread');
+
+  const input = workerData as PipelineWorkerInput;
+  const cacheOpts = input.cacheDir !== undefined ? { cacheDir: input.cacheDir } : {};
+
+  const rmbgRunner = new OnnxNodeRmbgRunner(cacheOpts);
+  const lamaRunner = input.noWatermark ? undefined : new OnnxNodeLamaRunner(cacheOpts);
+  const runner = new NodePipelineRunner(
+    lamaRunner ? { rmbgRunner, lamaRunner } : { rmbgRunner },
+  );
+
+  try {
+    await runner.preload();
+
+    const image: ImageDataLike = {
+      data: input.pixels,
+      width: input.width,
+      height: input.height,
+    };
+
+    const result = await runner.run(image, {
+      ...input.options,
+      onStage: (event: StageEvent) => {
+        port.postMessage({ kind: 'stage', event } satisfies PipelineWorkerMessage);
+      },
+    });
+
+    const payload: SerializablePipelineResult = {
+      output: {
+        data: result.output.data,
+        width: result.output.width,
+        height: result.output.height,
+      },
+      resolvedMode: result.resolvedMode,
+      durationMs: result.durationMs,
+      stageTimings: result.stageTimings,
+      watermarkRemoved: result.watermarkRemoved,
+      watermarkMask: result.watermarkMask,
+      workingPixels: result.workingPixels,
+      workingAlpha: result.workingAlpha,
+      workingWidth: result.workingWidth,
+      workingHeight: result.workingHeight,
+      nukedPct: result.nukedPct,
+      contentType: result.contentType,
+    };
+
+    port.postMessage({ kind: 'result', result: payload } satisfies PipelineWorkerMessage);
+  } catch (err: unknown) {
+    // Error instances do not survive structured clone with their prototype, so
+    // send the discriminating fields and let the main thread rebuild the right
+    // class — the exit-code mapping depends on both the class and the `code`.
+    const e = err as { name?: string; message?: string; code?: unknown };
+    port.postMessage({
+      kind: 'error',
+      name: typeof e?.name === 'string' ? e.name : 'Error',
+      message: typeof e?.message === 'string' ? e.message : String(err),
+      ...(typeof e?.code === 'string' ? { code: e.code } : {}),
+    } satisfies PipelineWorkerMessage);
+  } finally {
+    await runner.dispose().catch(() => undefined);
+  }
+}
+
+void main();

--- a/packages/nukebg-cli/src/runners/worker-pipeline-runner.ts
+++ b/packages/nukebg-cli/src/runners/worker-pipeline-runner.ts
@@ -1,0 +1,157 @@
+import { Worker } from 'node:worker_threads';
+import { existsSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { PipelineAbortError, RmbgError, LamaError, DecodeError } from 'nukebg-core';
+import type { ImageDataLike, PipelineOptions, PipelineResult, StageEvent } from 'nukebg-core';
+import type {
+  PipelineWorkerInput,
+  PipelineWorkerMessage,
+  SerializablePipelineResult,
+} from './pipeline.worker.js';
+
+/**
+ * Runs the whole pipeline on a worker thread so the main thread can answer
+ * SIGINT while CV is grinding.
+ *
+ * See issue #329: `patchMatchInpaint` blocks for ~2.3 s at 720p and ~14.4 s on
+ * a 6 MP image, synchronously. On the main thread that window cannot be
+ * interrupted at all — the SIGINT handler never gets to run. Cancelling here
+ * is `worker.terminate()`, which is immediate rather than cooperative.
+ */
+
+/** Rebuild the right error class from what survived the thread boundary. */
+function reviveError(msg: Extract<PipelineWorkerMessage, { kind: 'error' }>): Error {
+  const opts = msg.code !== undefined ? { code: msg.code } : {};
+  switch (msg.name) {
+    case 'AbortError':
+      return new PipelineAbortError(msg.message);
+    case 'RmbgError':
+      return new RmbgError(msg.message, opts);
+    case 'LamaError':
+      return new LamaError(msg.message, opts);
+    case 'DecodeError':
+      return new DecodeError(msg.message, opts);
+    default: {
+      const e = new Error(msg.message);
+      e.name = msg.name;
+      return e;
+    }
+  }
+}
+
+/**
+ * Locate the built worker.
+ *
+ * `import.meta.url` is this module, so the sibling lookup lands on
+ * `dist/pipeline.worker.js` in the tsup bundle. There is deliberately no
+ * fallback to the TypeScript source: a silent fallback is how a broken build
+ * ships green, and Node cannot run our `.ts` reliably anyway. If the file is
+ * missing the CLI says so plainly.
+ */
+function resolveWorkerPath(): string {
+  const url = new URL('./pipeline.worker.js', import.meta.url);
+  const path = fileURLToPath(url);
+  if (!existsSync(path)) {
+    throw new Error(
+      `Pipeline worker not found at ${path}. The CLI must be built (\`npm run build -w nukebg-cli\`) ` +
+        `before it can run — tsup emits the worker as a separate entry alongside cli.js.`,
+    );
+  }
+  return path;
+}
+
+export interface WorkerPipelineRunnerOptions {
+  readonly cacheDir?: string;
+  readonly noWatermark?: boolean;
+  /** Test seam: override how the worker is created. */
+  readonly spawn?: (path: string, input: PipelineWorkerInput) => Worker;
+  /** Test seam: override where the worker lives. */
+  readonly workerPath?: string;
+}
+
+export class WorkerPipelineRunner {
+  private readonly opts: WorkerPipelineRunnerOptions;
+  private active: Worker | null = null;
+
+  constructor(opts: WorkerPipelineRunnerOptions = {}) {
+    this.opts = opts;
+  }
+
+  async run(input: ImageDataLike, options: PipelineOptions = {}): Promise<PipelineResult> {
+    const { signal, onStage, ...transferable } = options;
+
+    if (signal?.aborted) throw new PipelineAbortError('aborted before the worker started');
+
+    const workerInput: PipelineWorkerInput = {
+      pixels: input.data,
+      width: input.width,
+      height: input.height,
+      options: transferable,
+      noWatermark: this.opts.noWatermark ?? false,
+      ...(this.opts.cacheDir !== undefined ? { cacheDir: this.opts.cacheDir } : {}),
+    };
+
+    const path = this.opts.workerPath ?? resolveWorkerPath();
+    const worker = this.opts.spawn
+      ? this.opts.spawn(path, workerInput)
+      : new Worker(path, { workerData: workerInput });
+    this.active = worker;
+
+    try {
+      return await new Promise<PipelineResult>((resolve, reject) => {
+        const onAbort = (): void => {
+          // Immediate, not cooperative — this is the whole point of #329.
+          void worker.terminate();
+          reject(new PipelineAbortError('aborted'));
+        };
+        signal?.addEventListener('abort', onAbort, { once: true });
+
+        worker.on('message', (msg: PipelineWorkerMessage) => {
+          if (msg.kind === 'stage') {
+            onStage?.(msg.event as StageEvent);
+            return;
+          }
+          signal?.removeEventListener('abort', onAbort);
+          if (msg.kind === 'error') reject(reviveError(msg));
+          else resolve(hydrate(msg.result));
+        });
+
+        worker.on('error', (err) => {
+          signal?.removeEventListener('abort', onAbort);
+          reject(err);
+        });
+
+        worker.on('exit', (code) => {
+          signal?.removeEventListener('abort', onAbort);
+          // A clean exit after a result already resolved is a no-op; this only
+          // fires first when the worker died without reporting anything.
+          if (code !== 0) {
+            reject(new Error(`Pipeline worker exited with code ${code}`));
+          }
+        });
+      });
+    } finally {
+      this.active = null;
+      await worker.terminate().catch(() => undefined);
+    }
+  }
+
+  async preload(): Promise<void> {
+    // No-op: the worker preloads inside its own thread before running. Doing
+    // it here would mean loading the model twice, in two threads.
+  }
+
+  async dispose(): Promise<void> {
+    if (this.active) {
+      await this.active.terminate().catch(() => undefined);
+      this.active = null;
+    }
+  }
+}
+
+function hydrate(r: SerializablePipelineResult): PipelineResult {
+  return {
+    ...r,
+    output: { data: r.output.data, width: r.output.width, height: r.output.height },
+  } as PipelineResult;
+}

--- a/packages/nukebg-cli/tests/runners/worker-bundle.test.ts
+++ b/packages/nukebg-cli/tests/runners/worker-bundle.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect, beforeAll } from 'vitest';
+import { Worker } from 'node:worker_threads';
+import { execSync } from 'node:child_process';
+import { existsSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { tmpdir } from 'node:os';
+
+// The failure this exists to catch: the worker resolves as a sibling of the
+// bundle (`new URL('./pipeline.worker.js', import.meta.url)`), which is a path
+// that only exists after tsup runs. Every unit test injects a fake worker, so
+// none of them would notice tsup dropping the second entry, the file landing
+// under a different name, or the bundle failing to import its own modules —
+// tests green, shipped CLI dead on first use.
+//
+// It deliberately does NOT skip when dist is missing. A skip-guarded test that
+// quietly does nothing is how REQ-PARITY-1 ended up unverified for the whole
+// extraction; this builds instead.
+
+const pkgRoot = resolve(__dirname, '..', '..');
+const workerPath = resolve(pkgRoot, 'dist', 'pipeline.worker.js');
+
+beforeAll(() => {
+  if (!existsSync(workerPath)) {
+    execSync('npm run build -w nukebg-cli', {
+      cwd: resolve(pkgRoot, '..', '..'),
+      stdio: 'ignore',
+    });
+  }
+}, 180_000);
+
+describe('built pipeline worker', () => {
+  it('is emitted by the build as a sibling of cli.js', () => {
+    expect(existsSync(workerPath)).toBe(true);
+    expect(existsSync(resolve(pkgRoot, 'dist', 'cli.js'))).toBe(true);
+  });
+
+  it('spawns and runs our code, not just loads', async () => {
+    // A stage event proves runPipeline actually started inside the worker and
+    // the message protocol crossed the boundary. Getting a result would need
+    // the RMBG model, so this stops at the first proof of life — which is
+    // exactly the thing a fake worker cannot give us.
+    const first = await new Promise<{ kind: string; detail?: string | undefined }>((resolveP) => {
+      const w = new Worker(workerPath, {
+        workerData: {
+          pixels: new Uint8ClampedArray(16 * 16 * 4).fill(128),
+          width: 16,
+          height: 16,
+          options: { mode: 'photo', skipWatermark: true },
+          noWatermark: true,
+          cacheDir: resolve(tmpdir(), 'nukebg-worker-bundle-test'),
+        },
+      });
+
+      const done = (v: { kind: string; detail?: string | undefined }): void => {
+        void w.terminate();
+        resolveP(v);
+      };
+
+      const timer = setTimeout(() => done({ kind: 'timeout' }), 45_000);
+
+      w.on('message', (m: { kind: string; name?: string; message?: string }) => {
+        clearTimeout(timer);
+        done({ kind: m.kind, detail: m.name ?? m.message });
+      });
+      w.on('error', (e: Error) => {
+        clearTimeout(timer);
+        done({ kind: 'worker-error', detail: e.message });
+      });
+    });
+
+    // 'stage' is the happy signal. An 'error' whose payload is a model failure
+    // still proves the worker ran our code; a 'worker-error' means the bundle
+    // itself is broken, which is the regression being guarded.
+    expect(first.kind, `worker returned ${first.kind}: ${first.detail ?? ''}`).not.toBe(
+      'worker-error',
+    );
+    expect(first.kind).not.toBe('timeout');
+    expect(['stage', 'result', 'error']).toContain(first.kind);
+  }, 60_000);
+});

--- a/packages/nukebg-cli/tests/runners/worker-bundle.test.ts
+++ b/packages/nukebg-cli/tests/runners/worker-bundle.test.ts
@@ -21,7 +21,11 @@ const workerPath = resolve(pkgRoot, 'dist', 'pipeline.worker.js');
 
 beforeAll(() => {
   if (!existsSync(workerPath)) {
-    execSync('npm run build -w nukebg-cli', {
+    // nukebg-core FIRST: tsup externalises it, so the emitted worker imports
+    // nukebg-core/dist/index.js at runtime rather than inlining it. Without
+    // core built, the worker dies with ERR_MODULE_NOT_FOUND — which is how CI
+    // caught this in the first place.
+    execSync('npm run build -w nukebg-core && npm run build -w nukebg-cli', {
       cwd: resolve(pkgRoot, '..', '..'),
       stdio: 'ignore',
     });

--- a/packages/nukebg-cli/tests/runners/worker-pipeline-runner.test.ts
+++ b/packages/nukebg-cli/tests/runners/worker-pipeline-runner.test.ts
@@ -1,0 +1,126 @@
+import { describe, it, expect, vi } from 'vitest';
+import { EventEmitter } from 'node:events';
+import { PipelineAbortError, RmbgError } from 'nukebg-core';
+import { WorkerPipelineRunner } from '../../src/runners/worker-pipeline-runner.js';
+import type { PipelineWorkerMessage } from '../../src/runners/pipeline.worker.js';
+
+// Unit-level: the protocol between the main thread and the worker. The real
+// built worker is covered separately in worker-bundle.test.ts, because a fake
+// here cannot catch the failure that actually matters — the worker file not
+// resolving from the bundle.
+
+class FakeWorker extends EventEmitter {
+  terminate = vi.fn(async () => 0);
+  emitMessage(msg: PipelineWorkerMessage): void {
+    this.emit('message', msg);
+  }
+}
+
+function resultMessage(): PipelineWorkerMessage {
+  return {
+    kind: 'result',
+    result: {
+      output: { data: new Uint8ClampedArray(16), width: 2, height: 2 },
+      resolvedMode: 'photo',
+      durationMs: 5,
+      stageTimings: { watermark: 0, rmbg: 5, inpaint: 0, finalize: 0 },
+      watermarkRemoved: false,
+      watermarkMask: null,
+      workingPixels: new Uint8ClampedArray(16),
+      workingAlpha: new Uint8Array(4),
+      workingWidth: 2,
+      workingHeight: 2,
+      nukedPct: 0,
+      contentType: 'PHOTO',
+    },
+  };
+}
+
+const image = { data: new Uint8ClampedArray(16), width: 2, height: 2 };
+
+function runnerWith(worker: FakeWorker): WorkerPipelineRunner {
+  return new WorkerPipelineRunner({
+    workerPath: '/fake/pipeline.worker.js',
+    spawn: () => worker as never,
+  });
+}
+
+describe('WorkerPipelineRunner', () => {
+  it('resolves with the hydrated result', async () => {
+    const worker = new FakeWorker();
+    const p = runnerWith(worker).run(image);
+    queueMicrotask(() => worker.emitMessage(resultMessage()));
+
+    const result = await p;
+    expect(result.resolvedMode).toBe('photo');
+    expect(result.output.width).toBe(2);
+  });
+
+  it('streams stage events through onStage', async () => {
+    const worker = new FakeWorker();
+    const seen: string[] = [];
+    const p = runnerWith(worker).run(image, {
+      onStage: (e) => seen.push(`${e.stage}:${e.status}`),
+    });
+    queueMicrotask(() => {
+      worker.emitMessage({ kind: 'stage', event: { stage: 'ml-segmentation', status: 'running' } });
+      worker.emitMessage(resultMessage());
+    });
+
+    await p;
+    expect(seen).toContain('ml-segmentation:running');
+  });
+
+  it('rebuilds the error class so exit-code mapping still works', async () => {
+    const worker = new FakeWorker();
+    const p = runnerWith(worker).run(image);
+    queueMicrotask(() =>
+      worker.emitMessage({
+        kind: 'error',
+        name: 'RmbgError',
+        message: 'model download failed',
+        code: 'RMBG_DOWNLOAD_FAILED',
+      }),
+    );
+
+    // Errors do not survive structured clone with their prototype. If this
+    // regressed, exitCodeFor would fall through to 70 for everything.
+    const err = await p.catch((e: unknown) => e);
+    expect(err).toBeInstanceOf(RmbgError);
+    expect((err as RmbgError).code).toBe('RMBG_DOWNLOAD_FAILED');
+  });
+
+  it('terminates the worker on abort instead of waiting for it', async () => {
+    const worker = new FakeWorker();
+    const controller = new AbortController();
+    const p = runnerWith(worker).run(image, { signal: controller.signal });
+
+    controller.abort();
+
+    await expect(p).rejects.toBeInstanceOf(PipelineAbortError);
+    // The whole point of #329: immediate, not cooperative.
+    expect(worker.terminate).toHaveBeenCalled();
+  });
+
+  it('rejects immediately when the signal is already aborted', async () => {
+    const controller = new AbortController();
+    controller.abort();
+    const spawn = vi.fn();
+
+    await expect(
+      new WorkerPipelineRunner({ workerPath: '/fake/w.js', spawn: spawn as never }).run(image, {
+        signal: controller.signal,
+      }),
+    ).rejects.toBeInstanceOf(PipelineAbortError);
+
+    expect(spawn).not.toHaveBeenCalled();
+  });
+
+  it('surfaces a non-zero worker exit as an error', async () => {
+    const worker = new FakeWorker();
+    const p = runnerWith(worker).run(image);
+    queueMicrotask(() => worker.emit('exit', 1));
+
+    await expect(p).rejects.toThrow(/exited with code 1/);
+  });
+});

--- a/packages/nukebg-cli/tsup.config.ts
+++ b/packages/nukebg-cli/tsup.config.ts
@@ -19,7 +19,10 @@ import { defineConfig } from 'tsup';
 // ---------------------------------------------------------------------------
 
 export default defineConfig({
-  entry: { cli: 'src/cli.ts' },
+  // Two entries: the CLI and the pipeline worker it spawns. The worker MUST
+  // be its own emitted file — worker_threads needs a real path on disk, and
+  // worker-pipeline-runner.ts resolves it as a sibling of the bundle.
+  entry: { cli: 'src/cli.ts', 'pipeline.worker': 'src/runners/pipeline.worker.ts' },
   format: ['esm'],
   target: 'node20',
   platform: 'node',


### PR DESCRIPTION
Closes #329.

Cancellation already worked at every asynchronous boundary (#332). What was left was the synchronous window, which I measured rather than argued about:

| Stage | 720p | 1080p | 6MP |
|---|---|---|---|
| `patchMatchInpaint` | **2 319 ms** | **4 762 ms** | **14 380 ms** |
| everything else combined | < 60 ms | < 90 ms | < 170 ms |

That window is uninterruptible on the main thread — the SIGINT handler cannot run because the event loop is blocked, so no amount of AbortSignal plumbing reaches it.

## Why not yield points

`patchMatchInpaint` has four call sites, and the important one is `nukebg-app/src/workers/inpaint.worker.ts`: **the browser already runs it inside a Web Worker** and has never had this problem. Making a pure, synchronous CV primitive async — to fix what one of its four callers suffers — pays the cost in the wrong place. Core staying synchronous is the design working.

## What this does

The CLI mirrors the browser instead:

- `pipeline.worker.ts` runs the whole pipeline, ONNX runners included. Keeping the runners on the main thread would mean shuttling masks across the boundary mid-run for no gain, since the worker is per-run anyway.
- `WorkerPipelineRunner` owns the protocol: stage events stream, result or error arrives once, and abort is `worker.terminate()` — **immediate, not cooperative**.
- Errors are rebuilt on the main thread from name + code. They do not survive structured clone with their prototype, and `exitCodeFor` discriminates on both.
- tsup emits the worker as a second entry; the runner resolves it as a sibling of the bundle and throws a plain "build the CLI first" error if missing, rather than silently falling back to source.

## The dangerous part, and its test

Sibling resolution only works after tsup runs. Every unit test injects a fake worker, so none of them would notice tsup dropping the entry, the file landing under another name, or the bundle failing to import its own modules — **tests green, shipped CLI dead on first use**.

`worker-bundle.test.ts` builds the CLI and spawns the real emitted worker, asserting it produces a stage event: proof our code ran, not just that a file exists. Verified by removing the tsup entry — both assertions fail.

It deliberately **does not skip** when `dist` is missing; it builds. A skip-guarded test that quietly does nothing is how REQ-PARITY-1 went unverified for the entire extraction.

## Verification

typecheck, lint, **1188 tests**, and the built-worker integration test.
