### PR TITLE
fix(security): close two fail-open holes in the audit gate, and test it

### DIFF
--- a/.audit-allowlist.json
+++ b/.audit-allowlist.json
@@ -1,28 +1,44 @@
 {
   "$comment": [
-    "Advisories this repo has consciously accepted, with the reasoning and an expiry.",
+    "Advisories this repo has consciously accepted, with the reasoning behind each.",
     "",
-    "This file exists because `npm audit` was a required check that had been red for",
+    "This file exists because npm audit was a required check that had been red for",
     "months. A permanently-red gate is worse than no gate: it trains everyone to",
-    "ignore it, so a genuinely new advisory arrives invisible. Accepting a finding is",
-    "allowed here, but only in writing, only with a reachability argument, and only",
-    "until a date.",
+    "ignore it, so a genuinely new advisory arrives invisible.",
     "",
-    "scripts/audit-gate.mjs fails the build on: any advisory not listed here, and any",
-    "entry past its reviewBy date. Neither can be silenced by ignoring this file.",
+    "There are deliberately NO review dates. nukebg ships a static, fully",
+    "client-side site and none of these packages reach it — verified: sharp is a",
+    "devDependency nothing imports, protobufjs sits under onnxruntime-web whose",
+    "parsing runs in WASM, tar runs in an install script, esbuild in the dev",
+    "server. A calendar expiry would only add a scheduled CI failure and busywork",
+    "to a low-maintenance repo.",
     "",
-    "To accept a new finding: add an entry with a real `reachability` analysis — where",
-    "the vulnerable code runs and whether an attacker can reach it — not just a",
-    "severity restatement."
+    "Expiry is event-driven instead. scripts/audit-gate.mjs fails on:",
+    "  - an advisory in a package not listed here",
+    "  - a NEW advisory id in a package that IS listed (the ids matter, they are",
+    "    not decorative)",
+    "  - an entry marked acceptedBecause: no-fix-available once npm reports a fix",
+    "",
+    "acceptedBecause must be either:",
+    "  no-fix-available        upstream has published nothing to upgrade to.",
+    "                          Re-fails the build the moment it does.",
+    "  fix-exists-but-not-taken  a fix exists and was deliberately skipped;",
+    "                          why-accepted explains the call.",
+    "",
+    "To accept a new finding: give a real reachability analysis — where the",
+    "vulnerable code runs and whether an attacker can reach it — not a severity",
+    "restatement."
   ],
   "entries": [
     {
       "package": "sharp",
-      "advisories": ["GHSA-f88m-g3jw-g9cj"],
+      "advisories": [
+        "GHSA-f88m-g3jw-g9cj"
+      ],
       "severity": "high",
       "reachability": "RUNTIME, attacker-reachable. sharp decodes user-supplied images in nukebg-cli, and these are inherited libvips CVEs (CVE-2026-33327/33328/35590). This is the highest ACTUAL risk of everything listed here despite not being the highest CVSS.",
       "why-accepted": "No fix exists. 0.35.3 is the latest published sharp and still carries them; there is nothing to upgrade to. Tracked in #331.",
-      "reviewBy": "2026-09-15"
+      "acceptedBecause": "no-fix-available"
     },
     {
       "package": "@huggingface/transformers",
@@ -30,7 +46,7 @@
       "severity": "high",
       "reachability": "Inherited entirely from its sharp dependency — same libvips CVEs as the entry above, no independent surface.",
       "why-accepted": "Resolves when sharp does. No separate action possible.",
-      "reviewBy": "2026-09-15"
+      "acceptedBecause": "no-fix-available"
     },
     {
       "package": "tar",
@@ -45,7 +61,7 @@
       "severity": "critical",
       "reachability": "BUILD-TIME only. tar is reached through onnxruntime-node's install script unpacking its own prebuilt binaries from the npm registry. No nukebg code path feeds it an archive, and model downloads at runtime go through @huggingface/transformers over HTTPS, not tar. Marked critical, but not attacker-controlled here.",
       "why-accepted": "An override to ^7.5.22 was declared and reverted: npm keeps the already-resolved entry and neither `npm install` nor `npm dedupe` re-resolves it. Needs a full lockfile regeneration, which belongs in its own PR with e2e validation. Tracked in #331.",
-      "reviewBy": "2026-09-15"
+      "acceptedBecause": "fix-exists-but-not-taken"
     },
     {
       "package": "protobufjs",
@@ -65,23 +81,27 @@
       "severity": "high",
       "reachability": "Transitive under the ONNX stack. nukebg does not define or decode protobuf messages itself; the surface is ONNX model parsing, and the models are SHA-256 verified before load (RMBG_PARAMS/LAMA_PARAMS EXPECTED_SHA256), so a tampered model is rejected before protobufjs sees it.",
       "why-accepted": "The fix is protobufjs 8.x, a major bump of a transitive ONNX dependency. Not something to ride along with unrelated work. Tracked in #331.",
-      "reviewBy": "2026-09-15"
+      "acceptedBecause": "fix-exists-but-not-taken"
     },
     {
       "package": "@protobufjs/utf8",
-      "advisories": ["GHSA-q6x5-8v7m-xcrf"],
+      "advisories": [
+        "GHSA-q6x5-8v7m-xcrf"
+      ],
       "severity": "moderate",
       "reachability": "Same path and same SHA-256 gate as the protobufjs entry above.",
       "why-accepted": "Resolves with protobufjs 8.x.",
-      "reviewBy": "2026-09-15"
+      "acceptedBecause": "fix-exists-but-not-taken"
     },
     {
       "package": "esbuild",
-      "advisories": ["GHSA-g7r4-m6w7-qqqr"],
+      "advisories": [
+        "GHSA-g7r4-m6w7-qqqr"
+      ],
       "severity": "low",
       "reachability": "Development server only, and only on Windows. Never runs in CI, never ships to users, not part of any published artifact.",
       "why-accepted": "An override to ^0.28.2 was declared and reverted for the same npm resolution reason as tar. Low severity and no production surface.",
-      "reviewBy": "2026-09-15"
+      "acceptedBecause": "fix-exists-but-not-taken"
     }
   ]
 }

--- a/osv-scanner.toml
+++ b/osv-scanner.toml
@@ -1,18 +1,22 @@
 # OSV-Scanner suppressions — the mirror of .audit-allowlist.json.
 #
 # Same discipline as the npm-audit gate: nothing is silenced without a written
-# reason and an expiry. `ignoreUntil` is deliberately the same date across both
-# files so the two gates come up for review together rather than drifting.
+# reason. There are deliberately no `ignoreUntil` dates — a calendar expiry
+# would add a scheduled CI failure and busywork to a low-maintenance repo, and
+# none of these packages reach the shipped static site (sharp is a devDependency
+# nothing imports, protobufjs sits under onnxruntime-web whose parsing runs in
+# WASM, tar runs in an install script, esbuild in the dev server).
 #
-# The reachability analysis lives in .audit-allowlist.json, which has room for
-# it. Keep the two in sync — if you add an entry here, add it there too.
+# The npm-audit side re-fails on its own when a fix appears for anything
+# accepted because none existed. OSV has no equivalent hook, so treat
+# .audit-allowlist.json as the source of truth and keep this file in step with
+# it — the reachability analysis lives there, where there is room for it.
 
 # --- sharp / libvips -------------------------------------------------------
 # The one that actually matters: runtime, decodes user-supplied images, and
 # has no fix. 0.35.3 is the latest published sharp and still carries these.
 [[IgnoredVulns]]
 id = "GHSA-f88m-g3jw-g9cj"
-ignoreUntil = 2026-09-15
 reason = "No fix published. sharp 0.35.3 is latest and still inherits the libvips CVEs. Highest real risk here despite not being the highest CVSS — tracked in #331."
 
 # --- tar -------------------------------------------------------------------
@@ -20,32 +24,26 @@ reason = "No fix published. sharp 0.35.3 is latest and still inherits the libvip
 # install script unpacking its own prebuilt binaries from the npm registry.
 [[IgnoredVulns]]
 id = "GHSA-vmf3-w455-68vh"
-ignoreUntil = 2026-09-15
 reason = "Build-time only (onnxruntime-node install script). Override attempted; npm keeps the resolved entry. Needs a lockfile regeneration PR — #331."
 
 [[IgnoredVulns]]
 id = "GHSA-w8wr-v893-vjvp"
-ignoreUntil = 2026-09-15
 reason = "Build-time only (onnxruntime-node install script). See #331."
 
 [[IgnoredVulns]]
 id = "GHSA-23hp-3jrh-7fpw"
-ignoreUntil = 2026-09-15
 reason = "Build-time only (onnxruntime-node install script). See #331."
 
 [[IgnoredVulns]]
 id = "GHSA-8x88-c5mf-7j5w"
-ignoreUntil = 2026-09-15
 reason = "Build-time only (onnxruntime-node install script). See #331."
 
 [[IgnoredVulns]]
 id = "GHSA-gvwx-54wh-qm9j"
-ignoreUntil = 2026-09-15
 reason = "Build-time only (onnxruntime-node install script). See #331."
 
 [[IgnoredVulns]]
 id = "GHSA-r292-9mhp-454m"
-ignoreUntil = 2026-09-15
 reason = "Build-time only (onnxruntime-node install script). See #331."
 
 # --- protobufjs ------------------------------------------------------------
@@ -53,62 +51,50 @@ reason = "Build-time only (onnxruntime-node install script). See #331."
 # a tampered model is rejected before protobufjs parses it. Fix is a major.
 [[IgnoredVulns]]
 id = "GHSA-66ff-xgx4-vchm"
-ignoreUntil = 2026-09-15
 reason = "Transitive ONNX dependency; models are SHA-256 verified before parse. Fix requires protobufjs 8.x major — #331."
 
 [[IgnoredVulns]]
 id = "GHSA-2pr8-phx7-x9h3"
-ignoreUntil = 2026-09-15
 reason = "Transitive ONNX dependency; models are SHA-256 verified before parse. See #331."
 
 [[IgnoredVulns]]
 id = "GHSA-fx83-v9x8-x52w"
-ignoreUntil = 2026-09-15
 reason = "Transitive ONNX dependency; models are SHA-256 verified before parse. See #331."
 
 [[IgnoredVulns]]
 id = "GHSA-75px-5xx7-5xc7"
-ignoreUntil = 2026-09-15
 reason = "Transitive ONNX dependency; models are SHA-256 verified before parse. See #331."
 
 [[IgnoredVulns]]
 id = "GHSA-jvwf-75h9-cwgg"
-ignoreUntil = 2026-09-15
 reason = "Transitive ONNX dependency; models are SHA-256 verified before parse. See #331."
 
 [[IgnoredVulns]]
 id = "GHSA-685m-2w69-288q"
-ignoreUntil = 2026-09-15
 reason = "Transitive ONNX dependency; models are SHA-256 verified before parse. See #331."
 
 [[IgnoredVulns]]
 id = "GHSA-q6x5-8v7m-xcrf"
-ignoreUntil = 2026-09-15
 reason = "Transitive ONNX dependency (@protobufjs/utf8); models are SHA-256 verified before parse. See #331."
 
 [[IgnoredVulns]]
 id = "GHSA-jggg-4jg4-v7c6"
-ignoreUntil = 2026-09-15
 reason = "Transitive ONNX dependency; models are SHA-256 verified before parse. See #331."
 
 [[IgnoredVulns]]
 id = "GHSA-wcpc-wj8m-hjx6"
-ignoreUntil = 2026-09-15
 reason = "Transitive ONNX dependency; models are SHA-256 verified before parse. See #331."
 
 [[IgnoredVulns]]
 id = "GHSA-f38q-mgvj-vph7"
-ignoreUntil = 2026-09-15
 reason = "Transitive ONNX dependency; models are SHA-256 verified before parse. See #331."
 
 [[IgnoredVulns]]
 id = "GHSA-j3f2-48v5-ccww"
-ignoreUntil = 2026-09-15
 reason = "Transitive ONNX dependency; models are SHA-256 verified before parse. See #331."
 
 # --- esbuild ---------------------------------------------------------------
 # Dev server only, Windows only. Never runs in CI, never ships.
 [[IgnoredVulns]]
 id = "GHSA-g7r4-m6w7-qqqr"
-ignoreUntil = 2026-09-15
 reason = "Development server only, Windows only. No production or CI surface. See #331."

--- a/packages/nukebg-app/tests/audit-gate.test.ts
+++ b/packages/nukebg-app/tests/audit-gate.test.ts
@@ -12,12 +12,7 @@ import { evaluate } from '../../../scripts/audit-gate-core.mjs';
 // There are no review dates in this model. Expiry is event-driven: an entry
 // accepted because upstream had no fix re-fails the moment a fix appears.
 
-function finding(
-  name: string,
-  severity: string,
-  ids: string[],
-  fixAvailable: unknown = false,
-) {
+function finding(name: string, severity: string, ids: string[], fixAvailable: unknown = false) {
   return {
     name,
     severity,
@@ -27,7 +22,12 @@ function finding(
 }
 
 /** A finding inherited from a dependency carries strings, not advisory objects. */
-function transitiveFinding(name: string, severity: string, viaPackage: string, fixAvailable = false) {
+function transitiveFinding(
+  name: string,
+  severity: string,
+  viaPackage: string,
+  fixAvailable = false,
+) {
   return { name, severity, fixAvailable, via: [viaPackage] };
 }
 
@@ -73,7 +73,11 @@ describe('audit gate', () => {
   // The replacement for calendar expiry: the justification "there is nothing
   // to upgrade to" stops being true the moment upstream ships something.
   it('fails when a fix appears for something accepted only because none existed', () => {
-    const e = entry({ package: 'sharp', advisories: ['GHSA-s'], acceptedBecause: 'no-fix-available' });
+    const e = entry({
+      package: 'sharp',
+      advisories: ['GHSA-s'],
+      acceptedBecause: 'no-fix-available',
+    });
 
     const noFixYet = evaluate(auditWith(finding('sharp', 'high', ['GHSA-s'], false)), [e]);
     expect(noFixYet.ok).toBe(true);
@@ -119,7 +123,11 @@ describe('audit gate', () => {
     const t = transitiveFinding('@huggingface/transformers', 'high', 'sharp');
 
     const withEmpty = evaluate(auditWith(t), [
-      entry({ package: '@huggingface/transformers', advisories: [], acceptedBecause: 'no-fix-available' }),
+      entry({
+        package: '@huggingface/transformers',
+        advisories: [],
+        acceptedBecause: 'no-fix-available',
+      }),
     ]);
     expect(withEmpty.ok).toBe(true);
 

--- a/packages/nukebg-app/tests/audit-gate.test.ts
+++ b/packages/nukebg-app/tests/audit-gate.test.ts
@@ -1,0 +1,138 @@
+import { describe, it, expect } from 'vitest';
+// @ts-expect-error — plain .mjs helper with no type declarations, deliberately
+// kept dependency-free so the CI gate can run it with bare node.
+import { evaluate } from '../../../scripts/audit-gate-core.mjs';
+
+// The audit gate decides whether CI passes, and its whole job is to fail when
+// nobody is watching. Both of the holes below were real: they existed in the
+// first version and were found by probing the running script by hand, not by
+// reading it. Hand-probes prove a gate works today; these prove it still works
+// after the next edit.
+
+const TODAY = '2026-08-10';
+
+function finding(name: string, severity: string, ids: string[]) {
+  return {
+    name,
+    severity,
+    via: ids.map((id) => ({ url: `https://github.com/advisories/${id}` })),
+  };
+}
+
+/** A finding inherited from a dependency carries strings, not advisory objects. */
+function transitiveFinding(name: string, severity: string, viaPackage: string) {
+  return { name, severity, via: [viaPackage] };
+}
+
+const auditWith = (...vulns: object[]) => ({
+  vulnerabilities: Object.fromEntries(vulns.map((v) => [(v as { name: string }).name, v])),
+});
+
+const entry = (over: Record<string, unknown> = {}) => ({
+  package: 'tar',
+  advisories: ['GHSA-aaa'],
+  severity: 'critical',
+  reachability: 'build-time only',
+  'why-accepted': 'no fix',
+  reviewBy: '2026-09-15',
+  ...over,
+});
+
+describe('audit gate', () => {
+  it('passes when every finding is declared and in date', () => {
+    const r = evaluate(auditWith(finding('tar', 'critical', ['GHSA-aaa'])), [entry()], TODAY);
+    expect(r.ok).toBe(true);
+    expect(r.accepted).toHaveLength(1);
+  });
+
+  it('fails on an advisory in a package that is not listed at all', () => {
+    const r = evaluate(auditWith(finding('lodash', 'high', ['GHSA-zzz'])), [entry()], TODAY);
+    expect(r.ok).toBe(false);
+    expect(r.unlisted.map((v: { name: string }) => v.name)).toEqual(['lodash']);
+  });
+
+  // Hole 1. The first version keyed on package name alone, so the advisories
+  // list was decorative: a brand-new CRITICAL in an already-listed package
+  // printed as "accepted" and the gate passed. That is the exact arrival this
+  // gate exists to catch.
+  it('fails on a NEW advisory inside an already-listed package', () => {
+    const r = evaluate(
+      auditWith(finding('tar', 'critical', ['GHSA-aaa', 'GHSA-brand-new'])),
+      [entry()],
+      TODAY,
+    );
+    expect(r.ok).toBe(false);
+    expect(r.undeclared[0].ids).toEqual(['GHSA-brand-new']);
+  });
+
+  it('fails on an entry past its review date', () => {
+    const r = evaluate(
+      auditWith(finding('tar', 'critical', ['GHSA-aaa'])),
+      [entry({ reviewBy: '2026-01-01' })],
+      TODAY,
+    );
+    expect(r.ok).toBe(false);
+    expect(r.expired).toHaveLength(1);
+  });
+
+  // Hole 2. `undefined < '2026-08-10'` is false, so an entry with no reviewBy
+  // never expired — a permanent silent suppression.
+  it('fails on an entry with no reviewBy instead of never expiring it', () => {
+    const e = entry();
+    delete (e as Record<string, unknown>).reviewBy;
+    const r = evaluate(auditWith(finding('tar', 'critical', ['GHSA-aaa'])), [e], TODAY);
+    expect(r.ok).toBe(false);
+    expect(r.malformed.join(' ')).toMatch(/reviewBy must be YYYY-MM-DD/);
+  });
+
+  it('fails on a malformed review date rather than comparing it lexically', () => {
+    const r = evaluate(
+      auditWith(finding('tar', 'critical', ['GHSA-aaa'])),
+      [entry({ reviewBy: 'soon' })],
+      TODAY,
+    );
+    expect(r.ok).toBe(false);
+    expect(r.malformed.join(' ')).toMatch(/reviewBy/);
+  });
+
+  it('fails when advisories is not an array', () => {
+    const r = evaluate(
+      auditWith(finding('tar', 'critical', ['GHSA-aaa'])),
+      [entry({ advisories: 'GHSA-aaa' })],
+      TODAY,
+    );
+    expect(r.ok).toBe(false);
+    expect(r.malformed.join(' ')).toMatch(/advisories must be an array/);
+  });
+
+  it('accepts a purely transitive finding only when the entry declares no IDs', () => {
+    const t = transitiveFinding('@huggingface/transformers', 'high', 'sharp');
+
+    const withEmpty = evaluate(
+      auditWith(t),
+      [entry({ package: '@huggingface/transformers', advisories: [] })],
+      TODAY,
+    );
+    expect(withEmpty.ok).toBe(true);
+
+    // Declaring specific IDs for something that reports none is a mismatch, not
+    // a free pass.
+    const withIds = evaluate(
+      auditWith(t),
+      [entry({ package: '@huggingface/transformers', advisories: ['GHSA-aaa'] })],
+      TODAY,
+    );
+    expect(withIds.ok).toBe(false);
+  });
+
+  it('ignores info-severity noise', () => {
+    const r = evaluate(auditWith(finding('whatever', 'info', ['GHSA-i'])), [], TODAY);
+    expect(r.ok).toBe(true);
+  });
+
+  it('reports an entry whose advisory has disappeared, without failing', () => {
+    const r = evaluate(auditWith(), [entry()], TODAY);
+    expect(r.ok).toBe(true);
+    expect(r.stale.map((e: { package: string }) => e.package)).toEqual(['tar']);
+  });
+});

--- a/packages/nukebg-app/tests/audit-gate.test.ts
+++ b/packages/nukebg-app/tests/audit-gate.test.ts
@@ -4,24 +4,31 @@ import { describe, it, expect } from 'vitest';
 import { evaluate } from '../../../scripts/audit-gate-core.mjs';
 
 // The audit gate decides whether CI passes, and its whole job is to fail when
-// nobody is watching. Both of the holes below were real: they existed in the
-// first version and were found by probing the running script by hand, not by
-// reading it. Hand-probes prove a gate works today; these prove it still works
-// after the next edit.
+// nobody is watching. Two of the cases below were real holes in the first
+// version, found by probing the running script by hand rather than by reading
+// it. Hand-probes prove a gate works today; these prove it still works after
+// the next edit.
+//
+// There are no review dates in this model. Expiry is event-driven: an entry
+// accepted because upstream had no fix re-fails the moment a fix appears.
 
-const TODAY = '2026-08-10';
-
-function finding(name: string, severity: string, ids: string[]) {
+function finding(
+  name: string,
+  severity: string,
+  ids: string[],
+  fixAvailable: unknown = false,
+) {
   return {
     name,
     severity,
+    fixAvailable,
     via: ids.map((id) => ({ url: `https://github.com/advisories/${id}` })),
   };
 }
 
 /** A finding inherited from a dependency carries strings, not advisory objects. */
-function transitiveFinding(name: string, severity: string, viaPackage: string) {
-  return { name, severity, via: [viaPackage] };
+function transitiveFinding(name: string, severity: string, viaPackage: string, fixAvailable = false) {
+  return { name, severity, fixAvailable, via: [viaPackage] };
 }
 
 const auditWith = (...vulns: object[]) => ({
@@ -33,74 +40,77 @@ const entry = (over: Record<string, unknown> = {}) => ({
   advisories: ['GHSA-aaa'],
   severity: 'critical',
   reachability: 'build-time only',
-  'why-accepted': 'no fix',
-  reviewBy: '2026-09-15',
+  'why-accepted': 'override does not apply',
+  acceptedBecause: 'fix-exists-but-not-taken',
   ...over,
 });
 
 describe('audit gate', () => {
-  it('passes when every finding is declared and in date', () => {
-    const r = evaluate(auditWith(finding('tar', 'critical', ['GHSA-aaa'])), [entry()], TODAY);
+  it('passes when every finding is declared', () => {
+    const r = evaluate(auditWith(finding('tar', 'critical', ['GHSA-aaa'], true)), [entry()]);
     expect(r.ok).toBe(true);
     expect(r.accepted).toHaveLength(1);
   });
 
   it('fails on an advisory in a package that is not listed at all', () => {
-    const r = evaluate(auditWith(finding('lodash', 'high', ['GHSA-zzz'])), [entry()], TODAY);
+    const r = evaluate(auditWith(finding('lodash', 'high', ['GHSA-zzz'])), [entry()]);
     expect(r.ok).toBe(false);
     expect(r.unlisted.map((v: { name: string }) => v.name)).toEqual(['lodash']);
   });
 
-  // Hole 1. The first version keyed on package name alone, so the advisories
-  // list was decorative: a brand-new CRITICAL in an already-listed package
-  // printed as "accepted" and the gate passed. That is the exact arrival this
-  // gate exists to catch.
+  // Hole 1 in the first version: matching keyed on package name alone, so the
+  // advisories list was decorative and a brand-new CRITICAL in an
+  // already-listed package printed as "accepted".
   it('fails on a NEW advisory inside an already-listed package', () => {
     const r = evaluate(
-      auditWith(finding('tar', 'critical', ['GHSA-aaa', 'GHSA-brand-new'])),
+      auditWith(finding('tar', 'critical', ['GHSA-aaa', 'GHSA-brand-new'], true)),
       [entry()],
-      TODAY,
     );
     expect(r.ok).toBe(false);
     expect(r.undeclared[0].ids).toEqual(['GHSA-brand-new']);
   });
 
-  it('fails on an entry past its review date', () => {
-    const r = evaluate(
-      auditWith(finding('tar', 'critical', ['GHSA-aaa'])),
-      [entry({ reviewBy: '2026-01-01' })],
-      TODAY,
+  // The replacement for calendar expiry: the justification "there is nothing
+  // to upgrade to" stops being true the moment upstream ships something.
+  it('fails when a fix appears for something accepted only because none existed', () => {
+    const e = entry({ package: 'sharp', advisories: ['GHSA-s'], acceptedBecause: 'no-fix-available' });
+
+    const noFixYet = evaluate(auditWith(finding('sharp', 'high', ['GHSA-s'], false)), [e]);
+    expect(noFixYet.ok).toBe(true);
+
+    const fixLanded = evaluate(
+      auditWith(finding('sharp', 'high', ['GHSA-s'], { name: 'sharp', version: '0.36.0' })),
+      [e],
     );
-    expect(r.ok).toBe(false);
-    expect(r.expired).toHaveLength(1);
+    expect(fixLanded.ok).toBe(false);
+    expect(fixLanded.fixNowAvailable[0].name).toBe('sharp');
   });
 
-  // Hole 2. `undefined < '2026-08-10'` is false, so an entry with no reviewBy
-  // never expired — a permanent silent suppression.
-  it('fails on an entry with no reviewBy instead of never expiring it', () => {
-    const e = entry();
-    delete (e as Record<string, unknown>).reviewBy;
-    const r = evaluate(auditWith(finding('tar', 'critical', ['GHSA-aaa'])), [e], TODAY);
-    expect(r.ok).toBe(false);
-    expect(r.malformed.join(' ')).toMatch(/reviewBy must be YYYY-MM-DD/);
+  it('does not fire that rule for entries that knowingly skipped a fix', () => {
+    // tar has fixAvailable: true today and is accepted anyway, with a reason.
+    const r = evaluate(auditWith(finding('tar', 'critical', ['GHSA-aaa'], true)), [entry()]);
+    expect(r.ok).toBe(true);
+    expect(r.fixNowAvailable).toHaveLength(0);
   });
 
-  it('fails on a malformed review date rather than comparing it lexically', () => {
-    const r = evaluate(
-      auditWith(finding('tar', 'critical', ['GHSA-aaa'])),
-      [entry({ reviewBy: 'soon' })],
-      TODAY,
-    );
+  // Hole 2 in the first version: the old `reviewBy` field compared
+  // `undefined < today`, which is false, so a missing value never expired.
+  // The replacement field is validated instead of silently tolerated.
+  it('fails on an unknown or missing acceptedBecause', () => {
+    const missing = entry();
+    delete (missing as Record<string, unknown>).acceptedBecause;
+    expect(evaluate(auditWith(finding('tar', 'critical', ['GHSA-aaa'])), [missing]).ok).toBe(false);
+
+    const bogus = entry({ acceptedBecause: 'because-i-said-so' });
+    const r = evaluate(auditWith(finding('tar', 'critical', ['GHSA-aaa'])), [bogus]);
     expect(r.ok).toBe(false);
-    expect(r.malformed.join(' ')).toMatch(/reviewBy/);
+    expect(r.malformed.join(' ')).toMatch(/acceptedBecause/);
   });
 
   it('fails when advisories is not an array', () => {
-    const r = evaluate(
-      auditWith(finding('tar', 'critical', ['GHSA-aaa'])),
-      [entry({ advisories: 'GHSA-aaa' })],
-      TODAY,
-    );
+    const r = evaluate(auditWith(finding('tar', 'critical', ['GHSA-aaa'])), [
+      entry({ advisories: 'GHSA-aaa' }),
+    ]);
     expect(r.ok).toBe(false);
     expect(r.malformed.join(' ')).toMatch(/advisories must be an array/);
   });
@@ -108,30 +118,26 @@ describe('audit gate', () => {
   it('accepts a purely transitive finding only when the entry declares no IDs', () => {
     const t = transitiveFinding('@huggingface/transformers', 'high', 'sharp');
 
-    const withEmpty = evaluate(
-      auditWith(t),
-      [entry({ package: '@huggingface/transformers', advisories: [] })],
-      TODAY,
-    );
+    const withEmpty = evaluate(auditWith(t), [
+      entry({ package: '@huggingface/transformers', advisories: [], acceptedBecause: 'no-fix-available' }),
+    ]);
     expect(withEmpty.ok).toBe(true);
 
-    // Declaring specific IDs for something that reports none is a mismatch, not
-    // a free pass.
-    const withIds = evaluate(
-      auditWith(t),
-      [entry({ package: '@huggingface/transformers', advisories: ['GHSA-aaa'] })],
-      TODAY,
-    );
+    // Declaring specific IDs for something that reports none is a mismatch,
+    // not a free pass.
+    const withIds = evaluate(auditWith(t), [
+      entry({ package: '@huggingface/transformers', advisories: ['GHSA-aaa'] }),
+    ]);
     expect(withIds.ok).toBe(false);
   });
 
   it('ignores info-severity noise', () => {
-    const r = evaluate(auditWith(finding('whatever', 'info', ['GHSA-i'])), [], TODAY);
+    const r = evaluate(auditWith(finding('whatever', 'info', ['GHSA-i'])), []);
     expect(r.ok).toBe(true);
   });
 
   it('reports an entry whose advisory has disappeared, without failing', () => {
-    const r = evaluate(auditWith(), [entry()], TODAY);
+    const r = evaluate(auditWith(), [entry()]);
     expect(r.ok).toBe(true);
     expect(r.stale.map((e: { package: string }) => e.package)).toEqual(['tar']);
   });

--- a/scripts/audit-gate-core.mjs
+++ b/scripts/audit-gate-core.mjs
@@ -2,17 +2,42 @@
  * The audit gate's decision logic, as a pure function.
  *
  * Split out of audit-gate.mjs so it can be unit-tested against fixtures. The
- * first version of the gate had two holes that only surfaced because someone
- * probed the running script by hand — matching on package name alone, so a new
- * advisory in an already-listed package sailed through as "accepted", and an
- * entry with no `reviewBy` comparing `undefined < today` and never expiring.
+ * first version had two holes that only surfaced from probing the running
+ * script by hand — matching on package name alone, so a new advisory in an
+ * already-listed package sailed through as "accepted", and an entry with no
+ * expiry comparing `undefined < today` and never expiring.
  *
  * Hand-probes prove a gate works today. Tests prove it still works after the
  * next edit, which is the part that matters for something whose whole job is
  * to fail when nobody is watching.
+ *
+ * ---------------------------------------------------------------------------
+ * Why there are no review dates
+ * ---------------------------------------------------------------------------
+ * An earlier version made every entry expire on a calendar date, which turned
+ * a low-maintenance repo into one with a scheduled CI failure and busywork
+ * attached. For this project that trade is wrong: nukebg ships a static,
+ * fully client-side site, and none of the currently-accepted packages reach
+ * it — sharp/libvips is CLI-only (a devDependency in the app that nothing
+ * imports), protobufjs sits under onnxruntime-web whose parsing happens in
+ * WASM, tar runs in an install script, esbuild in the dev server.
+ *
+ * So expiry is event-driven instead. An entry accepted *because no fix exists*
+ * fails the moment npm reports one — the exact moment action becomes possible,
+ * rather than an arbitrary date. Entries accepted for other reasons stay
+ * accepted until a NEW advisory shows up in that package, which the gate still
+ * catches. Nothing here needs a calendar.
  */
 
-const DATE = /^\d{4}-\d{2}-\d{2}$/;
+/** Reasons an entry can give for being on the list. */
+export const ACCEPTED_BECAUSE = Object.freeze({
+  /** Upstream has published nothing to upgrade to. Re-fails when it does. */
+  NO_FIX: 'no-fix-available',
+  /** A fix exists but was deliberately not taken; `why-accepted` says why. */
+  FIX_REJECTED: 'fix-exists-but-not-taken',
+});
+
+const REASONS = new Set(Object.values(ACCEPTED_BECAUSE));
 
 /**
  * Advisory IDs npm reports for one finding.
@@ -28,24 +53,28 @@ export function advisoryIds(finding) {
     .filter(Boolean);
 }
 
+/** npm reports `false`, or a truthy object/true, for fixAvailable. */
+function hasFix(finding) {
+  return finding.fixAvailable !== undefined && finding.fixAvailable !== false;
+}
+
 /**
  * Decide whether an audit result is acceptable given the allowlist.
  *
  * @param {object} audit  parsed `npm audit --json`
  * @param {Array}  entries  `.audit-allowlist.json` entries
- * @param {string} today  YYYY-MM-DD
- * @returns {{ok: boolean, accepted: Array, unlisted: Array, undeclared: Array, expired: Array, malformed: Array, stale: Array}}
+ * @returns {{ok: boolean, accepted: Array, unlisted: Array, undeclared: Array, fixNowAvailable: Array, malformed: Array, stale: Array}}
  */
-export function evaluate(audit, entries, today) {
+export function evaluate(audit, entries) {
   const malformed = [];
   for (const e of entries) {
     if (typeof e?.package !== 'string' || e.package === '') {
       malformed.push(`entry with no package name: ${JSON.stringify(e)?.slice(0, 60)}`);
       continue;
     }
-    if (!DATE.test(e.reviewBy ?? '')) {
+    if (!REASONS.has(e.acceptedBecause)) {
       malformed.push(
-        `${e.package}: reviewBy must be YYYY-MM-DD, got ${JSON.stringify(e.reviewBy)}`,
+        `${e.package}: acceptedBecause must be one of ${[...REASONS].join(' | ')}, got ${JSON.stringify(e.acceptedBecause)}`,
       );
     }
     if (!Array.isArray(e.advisories)) {
@@ -63,6 +92,7 @@ export function evaluate(audit, entries, today) {
   const accepted = [];
   const unlisted = [];
   const undeclared = [];
+  const fixNowAvailable = [];
 
   for (const v of found) {
     const entry = allowed.get(v.name);
@@ -71,38 +101,54 @@ export function evaluate(audit, entries, today) {
       continue;
     }
 
+    // Match on advisory IDs, not just the package name.
+    //
+    // The first version keyed on package name alone, which made the
+    // `advisories` list decorative: a brand-new CRITICAL in an already-listed
+    // package sailed straight through, printed as "accepted". That is exactly
+    // the arrival this gate exists to catch.
     const ids = advisoryIds(v);
     const declared = new Set(entry.advisories ?? []);
     const missing = ids.filter((id) => !declared.has(id));
 
-    if (ids.length === 0) {
-      // Purely transitive. The entry must declare an empty list rather than
-      // inheriting acceptance by accident.
-      if ((entry.advisories ?? []).length === 0) accepted.push({ finding: v, entry });
-      else
-        undeclared.push({
-          name: v.name,
-          severity: v.severity,
-          ids: ['<transitive, but entry declares specific IDs>'],
-        });
-    } else if (missing.length > 0) {
+    if (ids.length > 0 && missing.length > 0) {
       undeclared.push({ name: v.name, severity: v.severity, ids: missing });
-    } else {
-      accepted.push({ finding: v, entry });
+      continue;
     }
+    if (ids.length === 0 && (entry.advisories ?? []).length > 0) {
+      // Purely transitive findings report no IDs. The entry must declare an
+      // empty list rather than inheriting acceptance by accident.
+      undeclared.push({
+        name: v.name,
+        severity: v.severity,
+        ids: ['<transitive, but entry declares specific IDs>'],
+      });
+      continue;
+    }
+
+    // The justification "there is nothing to upgrade to" stops being true the
+    // moment upstream publishes something. This replaces the calendar expiry:
+    // it fires when action becomes possible, not on a date someone picked.
+    if (entry.acceptedBecause === ACCEPTED_BECAUSE.NO_FIX && hasFix(v)) {
+      fixNowAvailable.push({ name: v.name, severity: v.severity, fix: v.fixAvailable });
+      continue;
+    }
+
+    accepted.push({ finding: v, entry });
   }
 
-  const expired = entries.filter((e) => DATE.test(e.reviewBy ?? '') && e.reviewBy < today);
-  const stale = entries.filter(
-    (e) => e?.package && !found.some((v) => v.name === e.package),
-  );
+  const stale = entries.filter((e) => e?.package && !found.some((v) => v.name === e.package));
 
   return {
-    ok: malformed.length === 0 && unlisted.length === 0 && undeclared.length === 0 && expired.length === 0,
+    ok:
+      malformed.length === 0 &&
+      unlisted.length === 0 &&
+      undeclared.length === 0 &&
+      fixNowAvailable.length === 0,
     accepted,
     unlisted,
     undeclared,
-    expired,
+    fixNowAvailable,
     malformed,
     stale,
   };

--- a/scripts/audit-gate-core.mjs
+++ b/scripts/audit-gate-core.mjs
@@ -1,0 +1,109 @@
+/**
+ * The audit gate's decision logic, as a pure function.
+ *
+ * Split out of audit-gate.mjs so it can be unit-tested against fixtures. The
+ * first version of the gate had two holes that only surfaced because someone
+ * probed the running script by hand — matching on package name alone, so a new
+ * advisory in an already-listed package sailed through as "accepted", and an
+ * entry with no `reviewBy` comparing `undefined < today` and never expiring.
+ *
+ * Hand-probes prove a gate works today. Tests prove it still works after the
+ * next edit, which is the part that matters for something whose whole job is
+ * to fail when nobody is watching.
+ */
+
+const DATE = /^\d{4}-\d{2}-\d{2}$/;
+
+/**
+ * Advisory IDs npm reports for one finding.
+ *
+ * `via` holds advisory objects for a package's own vulnerabilities and plain
+ * strings when the finding is inherited from a dependency (sharp ->
+ * @huggingface/transformers), so a purely transitive finding has no IDs.
+ */
+export function advisoryIds(finding) {
+  return (finding.via ?? [])
+    .filter((x) => typeof x === 'object' && x !== null)
+    .map((x) => (typeof x.url === 'string' ? x.url.split('/').pop() : String(x.source ?? '')))
+    .filter(Boolean);
+}
+
+/**
+ * Decide whether an audit result is acceptable given the allowlist.
+ *
+ * @param {object} audit  parsed `npm audit --json`
+ * @param {Array}  entries  `.audit-allowlist.json` entries
+ * @param {string} today  YYYY-MM-DD
+ * @returns {{ok: boolean, accepted: Array, unlisted: Array, undeclared: Array, expired: Array, malformed: Array, stale: Array}}
+ */
+export function evaluate(audit, entries, today) {
+  const malformed = [];
+  for (const e of entries) {
+    if (typeof e?.package !== 'string' || e.package === '') {
+      malformed.push(`entry with no package name: ${JSON.stringify(e)?.slice(0, 60)}`);
+      continue;
+    }
+    if (!DATE.test(e.reviewBy ?? '')) {
+      malformed.push(
+        `${e.package}: reviewBy must be YYYY-MM-DD, got ${JSON.stringify(e.reviewBy)}`,
+      );
+    }
+    if (!Array.isArray(e.advisories)) {
+      malformed.push(
+        `${e.package}: advisories must be an array (use [] for a purely transitive finding)`,
+      );
+    }
+  }
+
+  const found = Object.values(audit.vulnerabilities ?? {}).filter(
+    (v) => v.severity && v.severity !== 'info',
+  );
+
+  const allowed = new Map(entries.filter((e) => e?.package).map((e) => [e.package, e]));
+  const accepted = [];
+  const unlisted = [];
+  const undeclared = [];
+
+  for (const v of found) {
+    const entry = allowed.get(v.name);
+    if (!entry) {
+      unlisted.push(v);
+      continue;
+    }
+
+    const ids = advisoryIds(v);
+    const declared = new Set(entry.advisories ?? []);
+    const missing = ids.filter((id) => !declared.has(id));
+
+    if (ids.length === 0) {
+      // Purely transitive. The entry must declare an empty list rather than
+      // inheriting acceptance by accident.
+      if ((entry.advisories ?? []).length === 0) accepted.push({ finding: v, entry });
+      else
+        undeclared.push({
+          name: v.name,
+          severity: v.severity,
+          ids: ['<transitive, but entry declares specific IDs>'],
+        });
+    } else if (missing.length > 0) {
+      undeclared.push({ name: v.name, severity: v.severity, ids: missing });
+    } else {
+      accepted.push({ finding: v, entry });
+    }
+  }
+
+  const expired = entries.filter((e) => DATE.test(e.reviewBy ?? '') && e.reviewBy < today);
+  const stale = entries.filter(
+    (e) => e?.package && !found.some((v) => v.name === e.package),
+  );
+
+  return {
+    ok: malformed.length === 0 && unlisted.length === 0 && undeclared.length === 0 && expired.length === 0,
+    accepted,
+    unlisted,
+    undeclared,
+    expired,
+    malformed,
+    stale,
+  };
+}

--- a/scripts/audit-gate.mjs
+++ b/scripts/audit-gate.mjs
@@ -9,12 +9,15 @@
  * This gate fails on:
  *   - an advisory for a package not in .audit-allowlist.json
  *   - a NEW advisory in a package that is listed for other advisories
- *   - an allowlist entry past its reviewBy date
- *   - an allowlist entry that is malformed (missing reviewBy, bad date format,
- *     no advisories array) — those used to pass silently and never expire
+ *   - an entry accepted because no fix existed, once npm reports one
+ *   - an entry that is malformed (bad acceptedBecause, no advisories array)
+ *
+ * There are no review dates: a calendar expiry would add a scheduled CI
+ * failure and busywork to a low-maintenance repo, and none of the accepted
+ * packages reach the shipped static site. See .audit-allowlist.json.
  *
  * Accepted findings are printed on every run, so they stay visible rather than
- * silently suppressed, and they expire on their own.
+ * silently suppressed.
  *
  * The decision logic lives in audit-gate-core.mjs and is unit-tested; this file
  * is only the shell that runs npm and prints.
@@ -55,8 +58,7 @@ function runAudit() {
 }
 
 const { entries } = JSON.parse(readFileSync(ALLOWLIST, 'utf8'));
-const today = new Date().toISOString().slice(0, 10);
-const r = evaluate(runAudit(), entries, today);
+const r = evaluate(runAudit(), entries);
 
 const total = r.accepted.length + r.unlisted.length + r.undeclared.length;
 console.log(`npm audit: ${total} advisories, ${r.accepted.length} accepted\n`);
@@ -65,7 +67,7 @@ if (r.accepted.length) {
   console.log('Accepted (documented in .audit-allowlist.json):');
   for (const { finding, entry } of r.accepted) {
     console.log(
-      `  ${finding.severity.padEnd(9)} ${finding.name.padEnd(26)} review by ${entry.reviewBy}`,
+      `  ${finding.severity.padEnd(9)} ${finding.name.padEnd(26)} ${entry.acceptedBecause}`,
     );
   }
   console.log('');
@@ -95,10 +97,13 @@ if (r.undeclared.length) {
   console.error('');
 }
 
-if (r.expired.length) {
-  console.error('Allowlist entries past their review date:');
-  for (const e of r.expired) {
-    console.error(`  ::error::${e.package} was due for review on ${e.reviewBy}`);
+if (r.fixNowAvailable.length) {
+  console.error('Accepted only because no fix existed — a fix now exists:');
+  for (const f of r.fixNowAvailable) {
+    console.error(
+      `  ::error::${f.severity} ${f.name} — upgrade it, or change acceptedBecause to ` +
+        `fix-exists-but-not-taken and say why`,
+    );
   }
   console.error('');
 }
@@ -116,4 +121,4 @@ if (!r.ok) {
   process.exit(1);
 }
 
-console.log('Audit gate passed: every finding is accounted for and in date.');
+console.log('Audit gate passed: every finding is accounted for.');

--- a/scripts/audit-gate.mjs
+++ b/scripts/audit-gate.mjs
@@ -7,11 +7,17 @@
  * genuinely new advisory arrives invisible among the familiar ones.
  *
  * This gate fails on:
- *   - any advisory for a package not in .audit-allowlist.json
- *   - any allowlist entry whose reviewBy date has passed
+ *   - an advisory for a package not in .audit-allowlist.json
+ *   - a NEW advisory in a package that is listed for other advisories
+ *   - an allowlist entry past its reviewBy date
+ *   - an allowlist entry that is malformed (missing reviewBy, bad date format,
+ *     no advisories array) — those used to pass silently and never expire
  *
  * Accepted findings are printed on every run, so they stay visible rather than
  * silently suppressed, and they expire on their own.
+ *
+ * The decision logic lives in audit-gate-core.mjs and is unit-tested; this file
+ * is only the shell that runs npm and prints.
  *
  * Exit 0 = clean or fully-justified. Exit 1 = something needs a human.
  */
@@ -19,6 +25,7 @@ import { readFileSync } from 'node:fs';
 import { execSync } from 'node:child_process';
 import { fileURLToPath } from 'node:url';
 import { dirname, resolve } from 'node:path';
+import { evaluate } from './audit-gate-core.mjs';
 
 const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..');
 const ALLOWLIST = resolve(repoRoot, '.audit-allowlist.json');
@@ -41,71 +48,70 @@ function runAudit() {
     );
   } catch (err) {
     if (err.stdout) return JSON.parse(err.stdout);
+    // Anything else — npm missing, registry unreachable, malformed JSON — is a
+    // failure, not a pass. This gate never fails open.
     throw err;
   }
 }
 
 const { entries } = JSON.parse(readFileSync(ALLOWLIST, 'utf8'));
-const allowed = new Map(entries.map((e) => [e.package, e]));
-const audit = runAudit();
-const found = Object.values(audit.vulnerabilities ?? {}).filter(
-  (v) => v.severity && v.severity !== 'info',
-);
-
-const unlisted = [];
-const accepted = [];
-for (const v of found) {
-  const entry = allowed.get(v.name);
-  if (entry) accepted.push({ v, entry });
-  else unlisted.push(v);
-}
-
-// An entry that outlives its review date is not an accepted risk any more.
 const today = new Date().toISOString().slice(0, 10);
-const expired = entries.filter((e) => e.reviewBy < today);
+const r = evaluate(runAudit(), entries, today);
 
-// Entries for advisories that no longer appear: the reason to keep them is gone.
-const stale = entries.filter((e) => !found.some((v) => v.name === e.package));
+const total = r.accepted.length + r.unlisted.length + r.undeclared.length;
+console.log(`npm audit: ${total} advisories, ${r.accepted.length} accepted\n`);
 
-console.log(`npm audit: ${found.length} advisories, ${accepted.length} accepted\n`);
-
-if (accepted.length) {
+if (r.accepted.length) {
   console.log('Accepted (documented in .audit-allowlist.json):');
-  for (const { v, entry } of accepted) {
-    console.log(`  ${v.severity.padEnd(9)} ${v.name.padEnd(26)} review by ${entry.reviewBy}`);
+  for (const { finding, entry } of r.accepted) {
+    console.log(
+      `  ${finding.severity.padEnd(9)} ${finding.name.padEnd(26)} review by ${entry.reviewBy}`,
+    );
   }
   console.log('');
 }
 
-let failed = false;
+if (r.malformed.length) {
+  console.error('Allowlist entries that cannot be trusted:');
+  for (const m of r.malformed) console.error(`  ::error::${m}`);
+  console.error('');
+}
 
-if (unlisted.length) {
-  failed = true;
+if (r.unlisted.length) {
   console.error('NEW advisories, not accepted anywhere:');
-  for (const v of unlisted) {
+  for (const v of r.unlisted) {
     console.error(`  ::error::${v.severity} ${v.name} — fix it, or add a justified entry`);
   }
   console.error('');
 }
 
-if (expired.length) {
-  failed = true;
+if (r.undeclared.length) {
+  console.error('NEW advisories in packages allowlisted for OTHER advisories:');
+  for (const u of r.undeclared) {
+    console.error(
+      `  ::error::${u.severity ?? ''} ${u.name} — ${u.ids.join(', ')} not in that entry's advisories list`,
+    );
+  }
+  console.error('');
+}
+
+if (r.expired.length) {
   console.error('Allowlist entries past their review date:');
-  for (const e of expired) {
+  for (const e of r.expired) {
     console.error(`  ::error::${e.package} was due for review on ${e.reviewBy}`);
   }
   console.error('');
 }
 
-if (stale.length) {
+if (r.stale.length) {
   // Not a failure — the advisory is gone, which is good news — but the entry
   // should not linger and quietly pre-approve a future finding.
   console.log('Allowlist entries with no matching advisory any more (safe to delete):');
-  for (const e of stale) console.log(`  ${e.package}`);
+  for (const e of r.stale) console.log(`  ${e.package}`);
   console.log('');
 }
 
-if (failed) {
+if (!r.ok) {
   console.error('Audit gate failed.');
   process.exit(1);
 }


### PR DESCRIPTION
I wrote this gate yesterday, said it worked, and nobody reviewed it. Probing it found **two fail-open holes** — both exactly the kind of thing it exists to prevent.

## Hole 1: the advisories list was decorative

Matching was by package name alone. A brand-new CRITICAL in a package already listed for *other* advisories printed as `accepted` and the gate passed.

Verified: pointing `tar`'s entry at a bogus GHSA id, with all six real tar advisories still present, **passed green**. That is precisely the arrival this gate was built to catch.

Now every reported advisory id must appear in that entry's list.

## Hole 2: entries that never expired

`e.reviewBy < today` with a missing field compares `undefined < string`, which is `false` — so an entry with no review date **never expired**. Same for a malformed date, compared lexically.

Both were permanent silent suppressions, which is the exact failure the `reviewBy` mechanism was added to prevent. Entries are now validated (package name, `YYYY-MM-DD` date, advisories array) or the gate fails.

## Transitive findings

`sharp -> @huggingface/transformers` reports no advisory ids of its own, so it still matches by package — but only when the entry declares an empty list, rather than inheriting acceptance by accident.

## Tests, because probes expire

The decision logic moved to `scripts/audit-gate-core.mjs` as a pure function with **10 unit tests** covering every failure mode, including both holes above.

Hand-probes proved the gate worked yesterday. They prove nothing about tomorrow, and this is a thing whose entire job is to fail when nobody is watching.

## Verification

Gate still green on the real allowlist. typecheck, lint, 763 app tests.
