### PR TITLE
fix(editor): make the advanced editor follow the theme, and guard the gap that hid it

### DIFF
--- a/packages/nukebg-app/src/components/ar-editor-advanced.ts
+++ b/packages/nukebg-app/src/components/ar-editor-advanced.ts
@@ -320,7 +320,7 @@ export class ArEditorAdvanced extends HTMLElement {
           background: rgba(var(--color-accent-rgb, 0, 255, 65), 0.04);
           font-family: 'JetBrains Mono', monospace;
           font-size: 12px;
-          color: var(--color-text, #ddd);
+          color: var(--color-text-secondary, #00dd44);
         }
         :host([active]) { display: block; }
         @media (pointer: coarse) {
@@ -418,7 +418,7 @@ export class ArEditorAdvanced extends HTMLElement {
         }
         .help-section dt {
           font-size: 11px;
-          color: var(--color-text, #ddd);
+          color: var(--color-text-secondary, #00dd44);
           white-space: nowrap;
         }
         .help-section dd {
@@ -434,7 +434,7 @@ export class ArEditorAdvanced extends HTMLElement {
           border-bottom-width: 2px;
           border-radius: 3px;
           background: rgba(0, 0, 0, 0.35);
-          color: var(--color-text, #ddd);
+          color: var(--color-text-secondary, #00dd44);
           font-family: inherit;
           font-size: 10px;
           line-height: 1;
@@ -540,15 +540,15 @@ export class ArEditorAdvanced extends HTMLElement {
         .action-btn:hover:not(:disabled) { background: var(--color-accent-primary, #00ff41); color: #000; }
         .action-btn:disabled { opacity: 0.4; cursor: not-allowed; }
         .action-btn.danger {
-          color: #ff6d6d;
-          border-color: #ff6d6d;
+          color: var(--color-error, #ff3131);
+          border-color: var(--color-error, #ff3131);
         }
-        .action-btn.danger:hover:not(:disabled) { background: #ff6d6d; color: #000; }
+        .action-btn.danger:hover:not(:disabled) { background: var(--color-error, #ff3131); color: #000; }
         .action-btn.confirm {
-          color: #7bd37b;
-          border-color: #7bd37b;
+          color: var(--color-accent-primary, #00ff41);
+          border-color: var(--color-accent-primary, #00ff41);
         }
-        .action-btn.confirm:hover:not(:disabled) { background: #7bd37b; color: #000; }
+        .action-btn.confirm:hover:not(:disabled) { background: var(--color-accent-primary, #00ff41); color: #000; }
         .preview-diff {
           font-family: 'JetBrains Mono', monospace;
           font-size: 11px;
@@ -583,7 +583,7 @@ export class ArEditorAdvanced extends HTMLElement {
         .size-row .size-val {
           font-variant-numeric: tabular-nums;
           font-size: 11px;
-          color: var(--color-text, #ddd);
+          color: var(--color-text-secondary, #00dd44);
           min-width: 28px;
           text-align: right;
         }
@@ -595,7 +595,7 @@ export class ArEditorAdvanced extends HTMLElement {
         }
         .bg-label {
           font-size: 11px;
-          color: var(--color-text-muted, #888);
+          color: var(--color-text-tertiary, #00b34a);
           margin-right: 2px;
         }
         .bg-btn {
@@ -680,7 +680,7 @@ export class ArEditorAdvanced extends HTMLElement {
           font-family: inherit;
           font-size: 11px;
           background: transparent;
-          color: var(--color-text, #ddd);
+          color: var(--color-text-secondary, #00dd44);
           border: none;
           padding: 4px 8px;
           min-width: 44px;
@@ -713,7 +713,7 @@ export class ArEditorAdvanced extends HTMLElement {
         button.action {
           font-family: inherit;
           font-size: 12px;
-          background: var(--color-bg, #111);
+          background: var(--color-bg-elevated, #111111);
           color: var(--color-accent-primary, #00ff41);
           border: 1px solid var(--color-accent-primary, #00ff41);
           border-radius: 2px;
@@ -722,7 +722,7 @@ export class ArEditorAdvanced extends HTMLElement {
         }
         button.action:hover:not(:disabled) { background: var(--color-accent-primary, #00ff41); color: #000; }
         button.action:disabled { opacity: 0.4; cursor: not-allowed; }
-        button.action.secondary { color: var(--color-text-secondary, #999); border-color: var(--color-border, #444); }
+        button.action.secondary { color: var(--color-text-secondary, #999); border-color: var(--color-surface-border, #1a3a1a); }
 
         /* #35 — honor prefers-reduced-motion on any JS/CSS anim that
            ar-editor-advanced owns. Keeps hint-pulse from firing for

--- a/packages/nukebg-app/tests/css-token-integrity.test.ts
+++ b/packages/nukebg-app/tests/css-token-integrity.test.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync, readdirSync } from 'node:fs';
+import { resolve, join } from 'node:path';
+
+/**
+ * CSS token integrity.
+ *
+ * color-consistency.test.ts audits the *value* side of theming: it forbids a
+ * raw `#00ff41` from bypassing the variable system. It never audits the *name*
+ * side, so `var(--color-text, #ddd)` sails through — the fallback is stripped
+ * before the check, and `--color-text` is not defined anywhere.
+ *
+ * That gap shipped four undefined tokens into ar-editor-advanced.ts, which
+ * therefore rendered grey fallbacks and ignored all six themes from
+ * `:root[data-theme=...]`. Undefined custom properties are valid CSS, so
+ * neither the compiler nor ESLint can catch this — only a test can.
+ *
+ * Rule: every `var(--color-*)` a component references must be defined in
+ * main.css, or declared locally in that component's own CSS.
+ */
+
+const root = resolve(__dirname, '..');
+
+/** Mirrors color-consistency.test.ts: a *.styles.ts module IS the stylesheet. */
+function extractCssBlocks(source: string, name: string): string[] {
+  if (/\.styles\.ts$/.test(name)) return [source];
+
+  const blocks: string[] = [];
+  const regex = /<style>([\s\S]*?)<\/style>/g;
+  let match;
+  while ((match = regex.exec(source)) !== null) {
+    blocks.push(match[1]);
+  }
+  return blocks;
+}
+
+function readComponentFiles(dir: string): { name: string; content: string }[] {
+  const absDir = resolve(root, dir);
+  return readdirSync(absDir)
+    .filter((f) => f.endsWith('.ts'))
+    .map((f) => ({ name: join(dir, f), content: readFileSync(resolve(absDir, f), 'utf8') }));
+}
+
+/** Collect every `--name` declared as a custom property in a CSS source. */
+function declaredProps(css: string): Set<string> {
+  const names = new Set<string>();
+  const regex = /(--[\w-]+)\s*:/g;
+  let match;
+  while ((match = regex.exec(css)) !== null) names.add(match[1]);
+  return names;
+}
+
+/** Collect every `--color-*` name read through var(). */
+function usedColorVars(css: string): string[] {
+  const names: string[] = [];
+  const regex = /var\(\s*(--color-[\w-]+)/g;
+  let match;
+  while ((match = regex.exec(css)) !== null) names.push(match[1]);
+  return names;
+}
+
+const mainCss = readFileSync(resolve(root, 'src/styles/main.css'), 'utf8');
+const globalProps = declaredProps(mainCss);
+
+describe('css token integrity — every var(--color-*) resolves to a real definition', () => {
+  it('main.css actually defines the core palette (guards the guard)', () => {
+    // If this fails the parser is broken, not the components.
+    expect(globalProps.has('--color-accent-primary')).toBe(true);
+    expect(globalProps.has('--color-text-tertiary')).toBe(true);
+    expect(globalProps.has('--color-surface-border')).toBe(true);
+  });
+
+  const components = readComponentFiles('src/components');
+
+  for (const { name, content } of components) {
+    const cssBlocks = extractCssBlocks(content, name);
+    if (cssBlocks.length === 0) continue;
+
+    it(`${name} references no undefined --color-* token`, () => {
+      const undefinedTokens = new Set<string>();
+
+      for (const css of cssBlocks) {
+        const localProps = declaredProps(css);
+        for (const used of usedColorVars(css)) {
+          if (!globalProps.has(used) && !localProps.has(used)) undefinedTokens.add(used);
+        }
+      }
+
+      expect(
+        [...undefinedTokens],
+        `${name} reads CSS variables that are never defined, so they silently fall back to their ` +
+          `literal fallback and stop following the theme:\n  ${[...undefinedTokens].join('\n  ')}`,
+      ).toEqual([]);
+    });
+  }
+});


### PR DESCRIPTION
Child #1 of the chain in #347. Refs #346.

## Chain context

```
dev
 └── feat/editor-convergence          (tracker, #347)
      └── fix/editor-theme-tokens     ← 📍 this PR
           └── chore/editor-radius    next
```

**Starts:** clean `dev` (096cb62). **Ends:** every `var(--color-*)` in every component resolves, and the advanced editor follows all six themes.
**Depends on:** nothing. **Out of scope:** layout, markup, the shell convergence itself.

## Summary

- Adds a guard that fails when a component reads a CSS variable that is defined nowhere.
- Maps the four undefined tokens in `ar-editor-advanced.ts` onto real palette tokens.
- Routes the two off-palette action colours through `--color-error` / `--color-accent-primary`.

## The bug

`color-consistency.test.ts` audits the **value** side of theming — it forbids a raw `#00ff41` from bypassing the variable system. It never audits the **name** side, and it strips `var()` fallbacks before checking. So this passed review and CI:

```css
color: var(--color-text, #ddd);
```

`--color-text` is defined nowhere in the codebase. Neither are `--color-bg`, `--color-border` or `--color-text-muted`. Undefined custom properties are valid CSS, so nothing — not `tsc`, not ESLint — could catch it.

Consequence: the advanced editor rendered `#ddd` / `#111` / `#444` / `#888` greys and was the only surface in the app that ignored the six `:root[data-theme]` palettes. Switch to amber or cyan today and the editor stays grey.

## Changes

| File | Change |
|------|--------|
| `tests/css-token-integrity.test.ts` | **New.** Cross-checks every `var(--color-*)` a component reads against the definitions in `main.css`, allowing locally declared props. Includes a guards-the-guard assertion so a broken parser fails loudly instead of passing vacuously. |
| `src/components/ar-editor-advanced.ts` | 14 token references remapped (see table below). |

```
--color-text        -> --color-text-secondary    (5 uses)
--color-text-muted  -> --color-text-tertiary
--color-bg          -> --color-bg-elevated       (identical #111, no visual change)
--color-border      -> --color-surface-border
#ff6d6d             -> var(--color-error, #ff3131)          .action-btn.danger
#7bd37b             -> var(--color-accent-primary, #00ff41) .action-btn.confirm
```

## Test plan

- [x] New guard fails on `dev` naming exactly the four tokens, and only in `ar-editor-advanced.ts` — the other 13 components with CSS blocks are already clean.
- [x] `npm test` — 1232 passing (app 784, cli 96, core 352). App count rose 770 → 784 from the new file.
- [x] `npm run typecheck` clean.
- [x] `npm run lint` clean.
- [x] `npx prettier --check --end-of-line auto` on both changed files — clean. (Repo-wide `format:check` reports ~134 untouched files on a Windows checkout: `core.autocrlf=true` versus `endOfLine: "lf"` with no `text=auto` rule in `.gitattributes`. CI runs on ubuntu with LF, so it is a local artifact only — worth a follow-up `.gitattributes` fix, not part of this PR.)

## Review notes

The visual result is intentionally *not* identical to `dev`: the greys become theme greens, and the danger/confirm buttons pick up the palette. That is the fix, not a side effect. `--color-bg -> --color-bg-elevated` is the one genuinely no-op swap — both are `#111`.
