### PR TITLE
style(editor): drop the ten stray border-radius values from the advanced editor

### DIFF
--- a/packages/nukebg-app/src/components/ar-editor-advanced.ts
+++ b/packages/nukebg-app/src/components/ar-editor-advanced.ts
@@ -316,7 +316,7 @@ export class ArEditorAdvanced extends HTMLElement {
           margin-top: 12px;
           padding: 12px;
           border: 1px dashed var(--color-accent-primary, #00ff41);
-          border-radius: 4px;
+          border-radius: 0;
           background: rgba(var(--color-accent-rgb, 0, 255, 65), 0.04);
           font-family: 'JetBrains Mono', monospace;
           font-size: 12px;
@@ -346,7 +346,7 @@ export class ArEditorAdvanced extends HTMLElement {
           background: transparent;
           color: var(--color-accent-primary, #00ff41);
           border: 1px solid var(--color-accent-primary, #00ff41);
-          border-radius: 2px;
+          border-radius: 0;
           padding: 4px 10px;
           cursor: pointer;
           letter-spacing: 0.05em;
@@ -370,7 +370,7 @@ export class ArEditorAdvanced extends HTMLElement {
           background: transparent;
           color: var(--color-accent-primary, #00ff41);
           border: 1px solid var(--color-accent-primary, #00ff41);
-          border-radius: 50%;
+          border-radius: 0;
           width: 22px;
           height: 22px;
           padding: 0;
@@ -387,7 +387,7 @@ export class ArEditorAdvanced extends HTMLElement {
           margin-bottom: 8px;
           padding: 10px 12px;
           border: 1px solid rgba(var(--color-accent-rgb, 0, 255, 65), 0.35);
-          border-radius: 3px;
+          border-radius: 0;
           background: rgba(var(--color-accent-rgb, 0, 255, 65), 0.03);
           display: grid;
           grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
@@ -432,7 +432,7 @@ export class ArEditorAdvanced extends HTMLElement {
           padding: 1px 5px;
           border: 1px solid rgba(var(--color-accent-rgb, 0, 255, 65), 0.45);
           border-bottom-width: 2px;
-          border-radius: 3px;
+          border-radius: 0;
           background: rgba(0, 0, 0, 0.35);
           color: var(--color-text-secondary, #00dd44);
           font-family: inherit;
@@ -467,7 +467,7 @@ export class ArEditorAdvanced extends HTMLElement {
           margin-bottom: 8px;
           padding: 6px 8px;
           border: 1px solid rgba(var(--color-accent-rgb, 0, 255, 65), 0.25);
-          border-radius: 3px;
+          border-radius: 0;
         }
         .toolbar-row {
           display: flex;
@@ -490,7 +490,7 @@ export class ArEditorAdvanced extends HTMLElement {
         .tool-group {
           display: inline-flex;
           border: 1px solid var(--color-accent-primary, #00ff41);
-          border-radius: 2px;
+          border-radius: 0;
           overflow: hidden;
         }
         .tool-btn {
@@ -530,7 +530,7 @@ export class ArEditorAdvanced extends HTMLElement {
           background: transparent;
           color: var(--color-accent-primary, #00ff41);
           border: 1px solid var(--color-accent-primary, #00ff41);
-          border-radius: 2px;
+          border-radius: 0;
           padding: 4px 10px;
           cursor: pointer;
           letter-spacing: 0.05em;
@@ -658,7 +658,7 @@ export class ArEditorAdvanced extends HTMLElement {
         .zoom-group {
           display: inline-flex;
           border: 1px solid var(--color-accent-primary, #00ff41);
-          border-radius: 2px;
+          border-radius: 0;
           overflow: hidden;
           margin-left: auto;
         }
@@ -716,7 +716,7 @@ export class ArEditorAdvanced extends HTMLElement {
           background: var(--color-bg-elevated, #111111);
           color: var(--color-accent-primary, #00ff41);
           border: 1px solid var(--color-accent-primary, #00ff41);
-          border-radius: 2px;
+          border-radius: 0;
           padding: 5px 12px;
           cursor: pointer;
         }


### PR DESCRIPTION
Child #2 of the chain in #347. Refs #346.

## Chain context

```
dev
 └── feat/editor-convergence          (tracker, #347)
      └── fix/editor-theme-tokens     #1 (#348)
           └── chore/editor-radius    ← 📍 this PR
                └── refactor/editor-shell   next
```

**Starts:** on top of #348. **Ends:** no non-zero `border-radius` anywhere in `ar-editor-advanced.ts`.
**Depends on:** #348 — review that first; this diff is only readable once #348 has landed on the tracker.
**Out of scope:** layout, markup, the shell convergence itself.

## Summary

`main.css` defines every `--radius-*` token as `0px` — square is the terminal look, on purpose. The advanced editor grew ten declarations that ignore it. This sets all ten to `0`.

| Where | Was |
|---|---|
| `:host` | `4px` |
| `.help-panel`, `.toolbar`, `.help-section kbd` | `3px` |
| `.restore-btn`, `.tool-group`, `.action-btn`, `.zoom-group`, `button.action` | `2px` |
| `.help-btn` | `50%` |

Set to `0` rather than deleted, matching the explicit `border-radius: 0` that the rest of this file (`.bg-btn`, the mobile `.toolbar`) and its sibling components already write. Same line count, so the diff is a clean value change.

## Three non-zero radii elsewhere are deliberate and stay

Worth stating, because a blanket "no border-radius" lint rule would be wrong here:

| Location | Why it stays |
|---|---|
| `ar-batch-item.ts:158` | Rotating spinner ring — `50%` is geometrically required |
| `ar-editor.ts:553` | `.touch-indicator.circle` mirrors the round brush shape, paired with `.touch-indicator.square` |
| `main.css:790` | `kbd` keycap, living in the design system's own file — an exception by decision, not component drift |

No guard test added on purpose. Unlike the undefined tokens in #348, which were invisible, a stray rounded corner in a square design is visible the moment you look at it. An allowlist-driven test for three legitimate exceptions would cost more upkeep than it saves.

## Changes

| File | Change |
|------|--------|
| `src/components/ar-editor-advanced.ts` | 10 `border-radius` values → `0` |

## Test plan

- [x] `npm test` — 1232 passing, unchanged from #348 (no test asserted on radius).
- [x] `npm run typecheck` clean.
- [x] `npm run lint` clean.
- [x] `npx prettier --check --end-of-line auto` on the changed file — clean.
- [ ] Eyeball on the Cloudflare preview: the `?` help toggle is now a 22 px square instead of a circle. That is the intended change.

## Review notes

The only visually noticeable one is `.help-btn`, which stops being a circle. It moves into the sidebar entirely in slice #4, so this is a short-lived state — but leaving it round for two slices would have left the one obviously non-square control in the editor as the exception that invites the next one.
