### PR TITLE
style(ui): rank the status blocks and demote "process another"

### DIFF
--- a/packages/nukebg-app/src/components/ar-app.styles.ts
+++ b/packages/nukebg-app/src/components/ar-app.styles.ts
@@ -377,9 +377,25 @@ export const AR_APP_STYLES: string = `
         /* Honesty + Ko-fi pitch under the status line. Same monospace
            voice, same tertiary tone as the limitations summary so they
            don't fight the dropzone for attention. */
-        .hero-disclaimer,
+        /* #354 — these two used to share one rule with the status line
+           and the limitations body: four separate messages at 12px
+           tertiary, indistinguishable at a glance.
+           The ramp is by role, not by decoration. The disclaimer is the
+           only actionable one — it tells you what to do when a result is
+           wrong — so it reads as body. The Ko-fi pitch is the least
+           urgent, stays at tertiary, and gains space so it registers as a
+           different kind of message rather than a fourth line of the
+           same paragraph. Both use existing tokens; no contrast is
+           lowered, and the disclaimer's goes up. */
+        .hero-disclaimer {
+          margin: 10px 0 0;
+          font-family: 'JetBrains Mono', monospace;
+          font-size: 12px;
+          line-height: 1.55;
+          color: var(--color-text-secondary, #00dd44);
+        }
         .hero-support {
-          margin: 6px 0 0;
+          margin: 14px 0 0;
           font-family: 'JetBrains Mono', monospace;
           font-size: 12px;
           line-height: 1.55;

--- a/packages/nukebg-app/src/components/ar-download.ts
+++ b/packages/nukebg-app/src/components/ar-download.ts
@@ -180,11 +180,17 @@ export class ArDownload extends HTMLElement {
           gap: 8px;
           align-items: center;
         }
+        /* #354 — "process another" carried the same 1px surface-border as
+           the WebP CTA, so an escape hatch read as a peer of a download.
+           It keeps its 44px touch target and its accent colour, but drops
+           the box: borderless, it stops competing with the two things
+           that actually produce a file. #72's bordered CTAs are
+           untouched. */
         .btn-secondary {
           background: transparent;
-          color: var(--color-accent-primary, #00ff41);
-          border: 1px solid var(--color-surface-border, #1a3a1a);
-          padding: 10px 20px;
+          color: var(--color-text-secondary, #00dd44);
+          border: 1px solid transparent;
+          padding: 10px 12px;
           border-radius: 0;
           font-family: 'JetBrains Mono', monospace;
           font-weight: 500;
@@ -192,11 +198,14 @@ export class ArDownload extends HTMLElement {
           text-transform: uppercase;
           letter-spacing: 0.05em;
           cursor: pointer;
-          transition: background 0.3s ease, box-shadow 0.3s ease;
+          transition: color 0.2s ease;
         }
-        .btn-secondary:hover {
-          background: var(--color-accent-muted, rgba(0, 255, 65, 0.05));
-          box-shadow: 0 0 8px var(--color-accent-glow, rgba(0, 255, 65, 0.15));
+        .btn-secondary:hover,
+        .btn-secondary:focus-visible {
+          color: var(--color-accent-primary, #00ff41);
+          text-decoration: underline;
+          text-underline-offset: 3px;
+          outline: none;
         }
         .btn-copy {
           background: transparent;

--- a/packages/nukebg-app/tests/components/ar-landing-redesign.test.ts
+++ b/packages/nukebg-app/tests/components/ar-landing-redesign.test.ts
@@ -123,3 +123,53 @@ describe('Landing redesign — i18n invariants', () => {
     });
   }
 });
+
+/**
+ * #354 — the four blocks under the dropzone must not collapse back into
+ * one undifferentiated grey-green paragraph.
+ *
+ * #69 consolidated the [STATUS] line itself but left the copy around it
+ * at the same 12px tertiary as the status line, the Ko-fi pitch and the
+ * limitations body. This pins the ramp by role, not by decoration.
+ */
+describe('landing status area — ranked, not flat (#354)', () => {
+  /** Pull a single CSS rule body out of the concatenated app source. */
+  function rule(selector: string): string {
+    const at = APP.indexOf(`${selector} {`);
+    expect(at, `rule not found: ${selector}`).toBeGreaterThan(-1);
+    const end = APP.indexOf('}', at);
+    return APP.slice(at, end);
+  }
+
+  it('the disclaimer reads as body — it is the one that tells you what to do', () => {
+    expect(rule('.hero-disclaimer')).toMatch(/color: var\(--color-text-secondary/);
+  });
+
+  it('the Ko-fi pitch stays quiet and keeps its own spacing', () => {
+    const support = rule('.hero-support');
+    expect(support).toMatch(/color: var\(--color-text-tertiary/);
+    // Separated from the disclaimer so it reads as a different message
+    // rather than a fourth line of the same paragraph.
+    expect(support).toMatch(/margin: 14px 0 0/);
+  });
+
+  it('the two carry different colours — that is the whole point', () => {
+    // The regression this guards is re-merging them into one rule, or
+    // otherwise letting all four blocks land on the same token again.
+    // Asserting the colours DIFFER survives any refactor of how the
+    // rules are written.
+    const disclaimer = rule('.hero-disclaimer');
+    const support = rule('.hero-support');
+    const colourOf = (css: string) => css.match(/--color-text-[a-z]+/)?.[0];
+    expect(colourOf(disclaimer)).toBeDefined();
+    expect(colourOf(support)).toBeDefined();
+    expect(colourOf(disclaimer)).not.toBe(colourOf(support));
+  });
+
+  it('contrast is never lowered — tertiary keeps its WCAG-bumped value', () => {
+    // main.css raised tertiary to #00b34a deliberately for AA/AAA. The
+    // ramp must move text UP the scale, never dim it further.
+    expect(rule('.hero-support')).not.toContain('opacity');
+    expect(rule('.hero-disclaimer')).not.toContain('opacity');
+  });
+});


### PR DESCRIPTION
Closes #354 (pending baseline refresh — see below). 84 insertions, 9 deletions.

## The defect

Four separate messages under the dropzone rendered identically:

| | | |
|---|---|---|
| `.status-line` | `12px` | `--color-text-tertiary` |
| `.hero-disclaimer` | `12px` | `--color-text-tertiary` |
| `.hero-support` | `12px` | `--color-text-tertiary` |
| `.status-limits-body` | `12px` | `--color-text-tertiary` |

Machine state, an honesty note, a funding pitch and a limitations disclosure, with nothing telling the eye which is which.

#69 consolidated the status **line**. It never touched the copy around it, so this survived that pass rather than coming from it.

## The ramp is by role, not decoration

- **Disclaimer → `--color-text-secondary`.** It is the only actionable one: it tells you what to do when a result comes out wrong.
- **Ko-fi pitch → stays tertiary**, gains `margin-top` so it registers as a different kind of message rather than a fourth line of the same paragraph.

Contrast only moves **up**. `main.css` raised tertiary to `#00b34a` deliberately for WCAG (there is a comment about the old `#008830` failing AA); nothing here dims below that, and a test asserts neither block gains an `opacity`.

## Result view

`process another` carried the same `1px solid --color-surface-border` as the WebP CTA — an escape hatch dressed as a download. It keeps its accent colour and its 44px touch target, and loses the box.

## What this deliberately does NOT do

An earlier draft of this work would have reversed three settled decisions silently. Recording them:

| | Stands |
|---|---|
| **#72** | The download CTAs stay **bordered** with their `rgba(0,255,65,0.05)` tint. A solid-filled primary was drafted and dropped — this system is 1px borders and no fills, so a green fill would be the least terminal-looking element on the page. #72 was right. |
| **#69** | The status line stays consolidated. Only its typography moves. |
| **#80** | The compressed type scale stands; the ramp uses it rather than reopening it. |

No copy changes, no new content, no i18n. A `[01] drop → [02] nuke → [03] download` strip was drafted for the dropzone's empty centre and left out — invention, not a fix.

## Test plan

- [x] `npm test` — 1222 passing (app 774, +4 guards).
- [x] `npm run typecheck`, `lint`, `build` clean.
- [x] `prettier --check --end-of-line auto` on all three files.
- [ ] **Landing baselines need regenerating.** This changes above-the-fold pixels, so `visual-landing` will fail until the three `-linux.png` files are refreshed. #355 adds the job that does it; dispatch it against this branch, then commit the artifact here.

## Review notes

The guard tests pin the ramp by asserting the two colours **differ**, rather than pinning literal token names — so a future retune of the scale does not fight the test, but re-flattening them does.