### PR TITLE
chore(deps): stop dependabot re-proposing onnxruntime-node, automate the pin

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,6 +20,15 @@ updates:
           - "patch"
           - "minor"
     ignore:
+      # onnxruntime-node ships a native library whose soname is shared
+      # with the copy @huggingface/transformers pins exactly. Any bump
+      # away from that pin installs two copies which collide at load
+      # time and the CLI stops working entirely. Happened twice: Aug 9
+      # and again via #339, which reached main. The version is not ours
+      # to choose — it follows transformers. See #360 and the guard in
+      # packages/nukebg-cli/tests/onnxruntime-single-runtime.test.ts.
+      # Run `npm run sync:onnx-pin` when transformers moves.
+      - dependency-name: "onnxruntime-node"
       # ONNX Runtime is pinned to a specific dev build on purpose
       # (RMBG-1.4 WASM compatibility). Migrate manually, not via Dependabot.
       - dependency-name: "onnxruntime-web"

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "test:e2e:iphone": "npm run test:e2e:iphone -w nukebg-app",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
+    "sync:onnx-pin": "node scripts/sync-onnx-pin.mjs",
     "format": "npm run format -w nukebg-app",
     "format:check": "npm run format:check -w nukebg-app"
   },

--- a/packages/nukebg-cli/tests/onnxruntime-single-runtime.test.ts
+++ b/packages/nukebg-cli/tests/onnxruntime-single-runtime.test.ts
@@ -36,6 +36,8 @@ describe('onnxruntime-node resolves to a single copy', () => {
 
   it('the lockfile contains exactly one onnxruntime-node resolution', () => {
     const described = copies.map(([path, e]) => `${e.version} @ ${path}`);
+    // Two copies means the specs drifted apart; the sibling assertion
+    // below names which. Both are repaired by `npm run sync:onnx-pin`.
     expect(copies.length, `found:\n  ${described.join('\n  ')}`).toBe(1);
   });
 
@@ -59,7 +61,8 @@ describe('onnxruntime-node resolves to a single copy', () => {
     expect(direct).toMatch(/^\d+\.\d+\.\d+$/);
     expect(
       direct,
-      `nukebg-cli pins ${direct}, @huggingface/transformers pins ${transformersPin}`,
+      `nukebg-cli pins ${direct}, @huggingface/transformers pins ${transformersPin}.\n` +
+        `Fix with: npm run sync:onnx-pin && npm install`,
     ).toBe(transformersPin);
   });
 });

--- a/scripts/sync-onnx-pin.mjs
+++ b/scripts/sync-onnx-pin.mjs
@@ -1,0 +1,82 @@
+#!/usr/bin/env node
+/**
+ * Keep nukebg-cli's onnxruntime-node pin equal to whatever
+ * @huggingface/transformers pins.
+ *
+ * The two depend on the same native library and share its soname. If the
+ * specs disagree npm installs both copies, they collide at load time, and
+ * the CLI stops working:
+ *
+ *   libonnxruntime.so.1: version `VERS_1.21.0' not found
+ *
+ * That has happened twice — Aug 9 2026, and again via #339, which reached
+ * main and sat there for a week. onnxruntime-node is now ignored in
+ * dependabot.yml, so the only thing that legitimately moves this pin is
+ * transformers itself. When it moves, run this.
+ *
+ *   node scripts/sync-onnx-pin.mjs           write the pin
+ *   node scripts/sync-onnx-pin.mjs --check   report drift, exit 1
+ *
+ * The invariant is also asserted by
+ * packages/nukebg-cli/tests/onnxruntime-single-runtime.test.ts, which is
+ * what fails in CI. This script is the fix for that failure.
+ */
+import { readFileSync, writeFileSync } from 'node:fs';
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const root = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const CLI_PKG = resolve(root, 'packages/nukebg-cli/package.json');
+const TRANSFORMERS_PKG = resolve(root, 'node_modules/@huggingface/transformers/package.json');
+
+const check = process.argv.includes('--check');
+
+/** Read a package.json, failing with a useful message rather than a stack. */
+function read(path, what) {
+  try {
+    return JSON.parse(readFileSync(path, 'utf8'));
+  } catch {
+    console.error(`Could not read ${what} at ${path}`);
+    if (path === TRANSFORMERS_PKG) console.error('Run `npm install` first.');
+    process.exit(1);
+  }
+}
+
+const transformers = read(TRANSFORMERS_PKG, '@huggingface/transformers');
+const wanted = transformers.dependencies?.['onnxruntime-node'];
+
+if (!wanted) {
+  console.error('@huggingface/transformers no longer depends on onnxruntime-node.');
+  console.error('The constraint this script exists for may be gone — see #360.');
+  process.exit(1);
+}
+
+if (!/^\d+\.\d+\.\d+$/.test(wanted)) {
+  // A range upstream would mean npm could satisfy it with something newer
+  // than the copy actually installed, which reopens the split.
+  console.error(`transformers pins a range (${wanted}), not an exact version.`);
+  console.error('Resolve by hand and update #360 — the assumption behind this script broke.');
+  process.exit(1);
+}
+
+const cli = read(CLI_PKG, 'nukebg-cli');
+const current = cli.dependencies?.['onnxruntime-node'];
+
+if (current === wanted) {
+  console.log(`onnxruntime-node pin is already ${wanted}.`);
+  process.exit(0);
+}
+
+if (check) {
+  console.error(
+    `onnxruntime-node pin drift: nukebg-cli has ${current}, transformers pins ${wanted}.`,
+  );
+  console.error('Run `npm run sync:onnx-pin` and commit the result, including the lockfile.');
+  process.exit(1);
+}
+
+cli.dependencies['onnxruntime-node'] = wanted;
+// Preserve the file's trailing newline; npm writes package.json that way.
+writeFileSync(CLI_PKG, `${JSON.stringify(cli, null, 2)}\n`);
+console.log(`onnxruntime-node pin ${current} -> ${wanted}`);
+console.log('Now run `npm install` and commit package-lock.json alongside this change.');


### PR DESCRIPTION
Addresses the first two items of #360. 96 insertions, 1 deletion, no production code touched.

## The constraint, restated

`onnxruntime-node`'s version **is not ours to choose**. It shares the native soname `libonnxruntime.so.1` with the copy `@huggingface/transformers` pins exactly. Any spec that disagrees installs two copies, they collide at load time, and the CLI stops working entirely.

Twice now: Aug 9 2026, and again via #339, which **reached `main` and sat broken there for a week** (#359 has the diagnosis).

This PR does not try to make 1.27.0 work. It makes the constraint cheap to live with.

## Three changes

| | |
|---|---|
| `.github/dependabot.yml` | Ignore `onnxruntime-node` outright, matching the existing entries for `onnxruntime-web` and `@huggingface/transformers`. The comment names both incidents, the guard test and #360. |
| `scripts/sync-onnx-pin.mjs` | Derives the pin from transformers instead of remembering it. `--check` reports drift and exits 1; without it, writes the pin. |
| the guard test | Its failure message now names the command that fixes it. |

That last one is small and I think it matters: the test told me *what* was wrong and I still spent an hour working out *what to run*. It now says `npm run sync:onnx-pin && npm install`.

## The script refuses to guess

Two upstream changes would invalidate the assumption it rests on, and it exits 1 with an explanation rather than writing something plausible:

- transformers stops depending on `onnxruntime-node` — the constraint may be gone, revisit #360
- transformers pins a **range** instead of an exact version — a range reopens the split, since npm can satisfy `^x` with something newer than the copy actually installed

## What still is not solved

The deeper half of #360 — dropping the direct dependency, or an adapter — is untouched. Relevant finding for whoever takes it: `nukebg-cli` imports `onnxruntime-node` in **exactly one file**, `src/runners/onnx-node-lama.ts`, and uses **two symbols**, `ort.InferenceSession` and `ort.Tensor`. That is a small enough surface that removing the direct dependency looks viable, but it needs someone to establish whether transformers exposes an equivalent rather than assuming it does.

Also unaddressed: `main` carried a broken build for a week with no signal, because CI does not run on the branch after a merge lands there. #360 covers it.

## Test plan

- [x] `node scripts/sync-onnx-pin.mjs --check` — exit 0 when aligned.
- [x] Drift simulated by setting the CLI to 1.27.0: `--check` exits 1 and names both versions; a plain run repairs it.
- [x] `npm test` — 1210 passing, guard test green.
- [x] `npm run lint`, `npm run typecheck` exit 0; prettier clean on all four files.

## Follow-on

The three open dependabot PRs — #340, #342, #345 — **went green on their own** once #359 fixed `main`. They had been red since 10 Aug for this reason and nothing else. They are major bumps (commander 12→15, env-paths 3→4, globals 15→17), so they want a look at their breaking changes rather than a merge on green alone.