### PR TITLE
release: automate the onnxruntime-node pin, stop dependabot re-proposing it

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,6 +20,15 @@ updates:
           - "patch"
           - "minor"
     ignore:
+      # onnxruntime-node ships a native library whose soname is shared
+      # with the copy @huggingface/transformers pins exactly. Any bump
+      # away from that pin installs two copies which collide at load
+      # time and the CLI stops working entirely. Happened twice: Aug 9
+      # and again via #339, which reached main. The version is not ours
+      # to choose — it follows transformers. See #360 and the guard in
+      # packages/nukebg-cli/tests/onnxruntime-single-runtime.test.ts.
+      # Run `npm run sync:onnx-pin` when transformers moves.
+      - dependency-name: "onnxruntime-node"
       # ONNX Runtime is pinned to a specific dev build on purpose
       # (RMBG-1.4 WASM compatibility). Migrate manually, not via Dependabot.
       - dependency-name: "onnxruntime-web"

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "test:e2e:iphone": "npm run test:e2e:iphone -w nukebg-app",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
+    "sync:onnx-pin": "node scripts/sync-onnx-pin.mjs",
     "format": "npm run format -w nukebg-app",
     "format:check": "npm run format:check -w nukebg-app"
   },

--- a/packages/nukebg-cli/tests/onnxruntime-single-runtime.test.ts
+++ b/packages/nukebg-cli/tests/onnxruntime-single-runtime.test.ts
@@ -36,6 +36,8 @@ describe('onnxruntime-node resolves to a single copy', () => {
 
   it('the lockfile contains exactly one onnxruntime-node resolution', () => {
     const described = copies.map(([path, e]) => `${e.version} @ ${path}`);
+    // Two copies means the specs drifted apart; the sibling assertion
+    // below names which. Both are repaired by `npm run sync:onnx-pin`.
     expect(copies.length, `found:\n  ${described.join('\n  ')}`).toBe(1);
   });
 
@@ -59,7 +61,8 @@ describe('onnxruntime-node resolves to a single copy', () => {
     expect(direct).toMatch(/^\d+\.\d+\.\d+$/);
     expect(
       direct,
-      `nukebg-cli pins ${direct}, @huggingface/transformers pins ${transformersPin}`,
+      `nukebg-cli pins ${direct}, @huggingface/transformers pins ${transformersPin}.\n` +
+        `Fix with: npm run sync:onnx-pin && npm install`,
     ).toBe(transformersPin);
   });
 });

--- a/scripts/sync-onnx-pin.mjs
+++ b/scripts/sync-onnx-pin.mjs
@@ -1,0 +1,82 @@
+#!/usr/bin/env node
+/**
+ * Keep nukebg-cli's onnxruntime-node pin equal to whatever
+ * @huggingface/transformers pins.
+ *
+ * The two depend on the same native library and share its soname. If the
+ * specs disagree npm installs both copies, they collide at load time, and
+ * the CLI stops working:
+ *
+ *   libonnxruntime.so.1: version `VERS_1.21.0' not found
+ *
+ * That has happened twice — Aug 9 2026, and again via #339, which reached
+ * main and sat there for a week. onnxruntime-node is now ignored in
+ * dependabot.yml, so the only thing that legitimately moves this pin is
+ * transformers itself. When it moves, run this.
+ *
+ *   node scripts/sync-onnx-pin.mjs           write the pin
+ *   node scripts/sync-onnx-pin.mjs --check   report drift, exit 1
+ *
+ * The invariant is also asserted by
+ * packages/nukebg-cli/tests/onnxruntime-single-runtime.test.ts, which is
+ * what fails in CI. This script is the fix for that failure.
+ */
+import { readFileSync, writeFileSync } from 'node:fs';
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const root = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const CLI_PKG = resolve(root, 'packages/nukebg-cli/package.json');
+const TRANSFORMERS_PKG = resolve(root, 'node_modules/@huggingface/transformers/package.json');
+
+const check = process.argv.includes('--check');
+
+/** Read a package.json, failing with a useful message rather than a stack. */
+function read(path, what) {
+  try {
+    return JSON.parse(readFileSync(path, 'utf8'));
+  } catch {
+    console.error(`Could not read ${what} at ${path}`);
+    if (path === TRANSFORMERS_PKG) console.error('Run `npm install` first.');
+    process.exit(1);
+  }
+}
+
+const transformers = read(TRANSFORMERS_PKG, '@huggingface/transformers');
+const wanted = transformers.dependencies?.['onnxruntime-node'];
+
+if (!wanted) {
+  console.error('@huggingface/transformers no longer depends on onnxruntime-node.');
+  console.error('The constraint this script exists for may be gone — see #360.');
+  process.exit(1);
+}
+
+if (!/^\d+\.\d+\.\d+$/.test(wanted)) {
+  // A range upstream would mean npm could satisfy it with something newer
+  // than the copy actually installed, which reopens the split.
+  console.error(`transformers pins a range (${wanted}), not an exact version.`);
+  console.error('Resolve by hand and update #360 — the assumption behind this script broke.');
+  process.exit(1);
+}
+
+const cli = read(CLI_PKG, 'nukebg-cli');
+const current = cli.dependencies?.['onnxruntime-node'];
+
+if (current === wanted) {
+  console.log(`onnxruntime-node pin is already ${wanted}.`);
+  process.exit(0);
+}
+
+if (check) {
+  console.error(
+    `onnxruntime-node pin drift: nukebg-cli has ${current}, transformers pins ${wanted}.`,
+  );
+  console.error('Run `npm run sync:onnx-pin` and commit the result, including the lockfile.');
+  process.exit(1);
+}
+
+cli.dependencies['onnxruntime-node'] = wanted;
+// Preserve the file's trailing newline; npm writes package.json that way.
+writeFileSync(CLI_PKG, `${JSON.stringify(cli, null, 2)}\n`);
+console.log(`onnxruntime-node pin ${current} -> ${wanted}`);
+console.log('Now run `npm install` and commit package-lock.json alongside this change.');


### PR DESCRIPTION
Ships #361. Single commit, no production code touched.

`onnxruntime-node`'s version is not ours to choose — it shares the native soname `libonnxruntime.so.1` with the copy `@huggingface/transformers` pins exactly, and any disagreement installs two copies that collide at load time. It broke `main` twice: 9 Aug 2026, and again via #339, which sat broken on the branch for a week until #359 reverted it.

This does not make the bump work. It makes the constraint cheap to live with:

| | |
|---|---|
| `.github/dependabot.yml` | Ignores `onnxruntime-node`, matching the existing entries for `onnxruntime-web` and `@huggingface/transformers`. |
| `scripts/sync-onnx-pin.mjs` | Derives the pin from transformers rather than remembering it. `--check` reports drift and exits 1. |
| `tests/onnxruntime-single-runtime.test.ts` | The failure message now names the command that fixes it. |

The script exits 1 rather than guessing if transformers drops the dependency or moves to a range.

## Still open on #360

- Dropping the direct dependency. `nukebg-cli` imports `onnxruntime-node` in one file, `src/runners/onnx-node-lama.ts`, using two symbols: `ort.InferenceSession` and `ort.Tensor`.
- No signal when `main` breaks — CI does not run on the branch after a merge lands.

## Test plan

- [x] 14/14 checks green on #361 across ubuntu, macos and windows.
- [x] `node scripts/sync-onnx-pin.mjs --check` exits 0 when aligned, 1 on simulated drift.
- [x] `npm test` — 1210 passing.
