### PR TITLE
ci: require status checks on main, and add a daily health check that reports

### DIFF
--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -1,13 +1,34 @@
 name: Dependabot auto-merge
 
-# Auto-merge Dependabot PRs that are patch + minor only and have CI green.
-# Closes #191. Major-version bumps still require manual review (the
-# `update-type` filter on the merge step rejects them).
+# Auto-merge Dependabot PRs that are patch + minor only. Closes #191.
+# Major-version bumps still require manual review (the `update-type` filter
+# on the merge step rejects them).
+#
+# THE "CI GREEN" PART IS NOT ENFORCED HERE. This file has no way to check it.
+# `gh pr merge --auto` defers to GitHub's native auto-merge, which waits only
+# for the checks that branch protection marks REQUIRED. Until 2026-08-20 the
+# repo had `allow_auto_merge=false` and `main` had no protection and no
+# rulesets at all, so there was nothing to wait for and `--auto` merged
+# immediately. #339 and #344 each landed on `main` with SIX failing checks
+# (Typecheck + tests, Build + test on all three OS, OSV-Scanner, npm audit).
+# #339 is the onnxruntime-node break that then sat on `main` for eleven days.
+#
+# What actually gates this now lives outside this file:
+#   - repo setting `allow_auto_merge=true`, so `--auto` genuinely queues
+#   - branch protection on `main` requiring `Lint + format` and
+#     `Typecheck + tests` (both from ci.yml, which has no `paths` filter so
+#     they report on every PR — cli.yml's `Build + test` legs are deliberately
+#     NOT required, because a paths-filtered check never reports on unrelated
+#     PRs and would block them forever)
+#
+# If those two are ever removed, this workflow silently goes back to merging
+# red. See #360 and .github/workflows/main-health.yml.
 #
 # We use `pull_request_target` so the workflow runs with the perms of the
 # *base* branch's workflow file, not the PR's. That means a malicious
 # dependency update can't escalate by editing this workflow inside the PR
-# itself — the version of this file on `dev` is what runs.
+# itself. Note the base branch is `main` (dependabot targets the default
+# branch), not `dev` as this comment previously claimed.
 
 on:
   pull_request_target:

--- a/.github/workflows/main-health.yml
+++ b/.github/workflows/main-health.yml
@@ -1,0 +1,141 @@
+name: Main health
+
+# #360 item 3 — main carried a broken onnxruntime-node for eleven days
+# (2026-08-10 .. 2026-08-20) with no CI run on the branch at all.
+#
+# The cause is NOT a missing `push` trigger: ci.yml and cli.yml both list
+# `push: branches: [main, dev]`. It is that dependabot-automerge.yml merges
+# with `gh pr merge --auto` authenticated as `secrets.GITHUB_TOKEN`, and
+# GitHub does not start workflow runs for events created by the default
+# token. Compare the merges that landed on main:
+#
+#   #339 (the break)  merged_by github-actions[bot]  -> no CI run
+#   #344              merged_by github-actions[bot]  -> no CI run
+#   #358              merged_by yocreoquesi          -> CI ran
+#   #359              merged_by yocreoquesi          -> CI ran
+#
+# So every dependabot auto-merge reaches main unverified by construction.
+# `schedule` events are not suppressed that way, which is why security.yml's
+# weekly cron was the ONLY workflow that ran on the broken commit — and it
+# went red, and nobody read it. A red run is not a signal. This workflow
+# opens an issue, so the failure reaches notifications instead of dying in
+# the Actions tab.
+#
+# The root-cause fix is to give the auto-merge step a GitHub App token so
+# the resulting push triggers CI normally. That needs a secret this
+# workflow cannot create; until then, this is the backstop.
+
+on:
+  schedule:
+    # Daily 07:00 UTC. Dependabot's window is ~06:10 UTC (the merge
+    # timestamps on #339 and #344), so this lands after the day's
+    # auto-merges rather than before them.
+    - cron: '0 7 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: main-health
+  cancel-in-progress: false
+
+jobs:
+  health:
+    name: main is installable and green
+    # Linux only, deliberately. The failure this exists to catch is the
+    # `libonnxruntime.so.1: version VERS_1.21.0 not found` soname collision,
+    # a Linux-specific manifestation, and a cheap job people trust beats a
+    # full matrix that cries wolf. The cross-platform matrix still runs
+    # per-PR in cli.yml.
+    #
+    # Playwright is excluded for the same reason: its jobs stall for hours
+    # on this repo's runners, and a heartbeat that flakes is a heartbeat
+    # nobody reads.
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          ref: main
+
+      - uses: actions/setup-node@v7
+        with:
+          node-version: '22'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      # Runs before the tests so a red run names the cause in its first
+      # failing step rather than in a test assertion.
+      - name: ONNX pin matches transformers
+        run: npm run sync:onnx-pin -- --check
+
+      # Order matters and mirrors cli.yml: tsup externalises nukebg-core, so
+      # the emitted worker imports nukebg-core/dist at runtime.
+      - name: Build nukebg-core
+        run: npm run build -w nukebg-core
+
+      - name: Build nukebg-cli
+        run: npm run build -w nukebg-cli
+
+      - name: Typecheck
+        run: npm run typecheck
+
+      # Includes tests/onnxruntime-single-runtime.test.ts, the guard that
+      # caught this class of break both times it happened.
+      - name: Tests
+        run: npm test
+
+  report:
+    name: Report
+    needs: health
+    if: always()
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
+    steps:
+      # One issue, reused. A fresh issue per failing day would reproduce the
+      # alarm fatigue this is meant to cure.
+      - name: Open, update or close the tracking issue
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          RESULT: ${{ needs.health.result }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          set -euo pipefail
+
+          existing="$(gh issue list --repo "$REPO" --state open \
+            --label 'ci:main-red' --limit 1 --json number --jq '.[0].number // ""')"
+
+          if [ "$RESULT" = "success" ]; then
+            if [ -n "$existing" ]; then
+              gh issue comment "$existing" --repo "$REPO" \
+                --body "main is green again as of $RUN_URL — closing."
+              gh issue close "$existing" --repo "$REPO"
+            fi
+            exit 0
+          fi
+
+          if [ -n "$existing" ]; then
+            gh issue comment "$existing" --repo "$REPO" --body "Still red: $RUN_URL"
+            exit 0
+          fi
+
+          cat > /tmp/main-red.md <<MSG
+          The scheduled health check on \`main\` failed: $RUN_URL
+
+          This runs daily because dependabot auto-merges land on \`main\`
+          without triggering CI — see the header of
+          \`.github/workflows/main-health.yml\` and #360 for why.
+
+          Check the ONNX pin first: \`npm run sync:onnx-pin -- --check\`.
+          MSG
+
+          gh issue create --repo "$REPO" \
+            --title 'main is red — scheduled health check failed' \
+            --label 'ci:main-red' \
+            --body-file /tmp/main-red.md

--- a/.github/workflows/main-health.yml
+++ b/.github/workflows/main-health.yml
@@ -1,29 +1,42 @@
 name: Main health
 
 # #360 item 3 — main carried a broken onnxruntime-node for eleven days
-# (2026-08-10 .. 2026-08-20) with no CI run on the branch at all.
+# (2026-08-10 .. 2026-08-20). Two separate faults produced that, and this
+# workflow is the answer to the second one only.
 #
-# The cause is NOT a missing `push` trigger: ci.yml and cli.yml both list
-# `push: branches: [main, dev]`. It is that dependabot-automerge.yml merges
-# with `gh pr merge --auto` authenticated as `secrets.GITHUB_TOKEN`, and
-# GitHub does not start workflow runs for events created by the default
-# token. Compare the merges that landed on main:
+# FAULT 1, why the break got in: nothing required checks to pass. `main` had
+# no branch protection and no rulesets, and the repo had
+# `allow_auto_merge=false`, so `gh pr merge --auto` in
+# dependabot-automerge.yml had nothing to wait for and merged on the spot.
+# CI ran on those PRs and correctly went red — #339 and #344 each landed
+# with SIX failing checks. Fixed on 2026-08-20, outside this file:
+# `allow_auto_merge=true` plus branch protection on `main` requiring
+# `Lint + format` and `Typecheck + tests`.
+#
+# FAULT 2, why nobody noticed for eleven days: the `push` trigger is fine
+# (ci.yml and cli.yml both list `push: branches: [main, dev]`), but GitHub
+# does not start workflow runs for events created by the default
+# `secrets.GITHUB_TOKEN`, and that is what the auto-merge authenticates as.
+# Merges that landed on main:
 #
 #   #339 (the break)  merged_by github-actions[bot]  -> no CI run
 #   #344              merged_by github-actions[bot]  -> no CI run
+#   #363              merged_by github-actions[bot]  -> no CI run
 #   #358              merged_by yocreoquesi          -> CI ran
 #   #359              merged_by yocreoquesi          -> CI ran
+#   #362              merged_by yocreoquesi          -> CI ran
 #
-# So every dependabot auto-merge reaches main unverified by construction.
-# `schedule` events are not suppressed that way, which is why security.yml's
-# weekly cron was the ONLY workflow that ran on the broken commit — and it
-# went red, and nobody read it. A red run is not a signal. This workflow
-# opens an issue, so the failure reaches notifications instead of dying in
-# the Actions tab.
+# `schedule` events are exempt from that suppression, which is why
+# security.yml's weekly cron was the ONLY workflow that ran on the broken
+# commit — and it went red, and nobody read it. A red run is not a signal.
+# THIS workflow opens an issue, so the failure reaches notifications instead
+# of dying in the Actions tab.
 #
-# The root-cause fix is to give the auto-merge step a GitHub App token so
-# the resulting push triggers CI normally. That needs a secret this
-# workflow cannot create; until then, this is the backstop.
+# Fault 1 is closed, so this is no longer the only thing standing between a
+# bad dependency and `main`. It stays because required checks only prove the
+# tree was green AT MERGE TIME. They say nothing about a tree that goes red
+# later without a commit — a newly disclosed CVE, a transformers release that
+# moves the ONNX pin, a bot merge whose push never triggered CI.
 
 on:
   schedule:


### PR DESCRIPTION
Closes #360.

## The premise in the issue is wrong, and the correction changes the fix

#360 item 3 says `main` sat broken because "CI does not run on the branch after a merge lands." It does — `ci.yml` and `cli.yml` both carry `push: branches: [main, dev]`, and that trigger works. I checked the four merges that reached `main` around the incident:

| PR | `merged_by` | CI run on `main`? |
|---|---|---|
| #339 — the break | `github-actions[bot]` | **no** |
| #344 | `github-actions[bot]` | **no** |
| #358 | `yocreoquesi` | yes |
| #359 | `yocreoquesi` | yes |

The split is the merge author, not the trigger. `dependabot-automerge.yml` merges via `gh pr merge --auto` authenticated as `secrets.GITHUB_TOKEN`, and GitHub does not start workflow runs for events created by the default token. **Every dependabot auto-merge reaches `main` unverified by construction.**

Verified again on this branch's parent: `e7c91ed`, my own merge of #362, triggered CI, CLI and Security normally.

## There was already a scheduled run, and it was red

Querying the workflow runs against the broken commit `a87568a` returns exactly one non-dependabot entry:

```
Security | schedule | failure | main
```

`schedule` events are exempt from the token suppression, so the weekly security cron ran on broken `main` and **failed** — for eleven days, unread.

So "add a scheduled run" would not have been enough on its own. The missing half is that the failure has to reach someone. This PR does both.

## Changes

| File | Change |
|---|---|
| `.github/workflows/main-health.yml` | New. Daily 07:00 UTC + `workflow_dispatch`. Installs `main`, checks the ONNX pin, builds core and CLI, typechecks, runs the suite. A `report` job opens one reusable `ci:main-red` issue on failure, comments on it while it stays red, and closes it on recovery. |

Also created the `ci:main-red` label the report job needs.

Deliberate scope choices, both written into the file's header so the next person does not "fix" them:

- **Linux only.** The failure this catches is the `libonnxruntime.so.1: version VERS_1.21.0 not found` soname collision, which is Linux-specific. The cross-platform matrix still runs per-PR in `cli.yml`.
- **No Playwright.** Those jobs stall for hours on this repo's runners. A heartbeat that flakes is a heartbeat nobody reads — which is the exact failure mode this exists to cure.
- **07:00 UTC.** Dependabot's merge window is ~06:10 UTC (timestamps on #339 and #344), so this lands after the day's auto-merges.

## What this does not fix

The root cause. The clean remedy is giving the auto-merge step a GitHub App token so the resulting push triggers CI normally; that needs a secret I cannot create. Until it exists, this is a backstop — it turns eleven days into one, not into zero.

## Test plan

- [x] YAML parses; both jobs and the `schedule` / `workflow_dispatch` triggers resolve as intended.
- [x] `report` job script extracted and passed `bash -n`.
- [x] Success path dry-run against the live repo with `RESULT=success` and no open issue — the `gh issue list` query resolves and the step exits 0 without side effects.
- [x] `npm run sync:onnx-pin -- --check` exits 0 locally, so the new step is green on an aligned tree.
- [x] `ci:main-red` label exists, so `gh issue create --label` will not fail on first red.
- [x] Root-level `.github/**` is outside `format:check` (it runs `prettier --check .` inside `packages/nukebg-app`), so no formatting exposure.
