### PR TITLE
release: require status checks on main, add a daily health check

### DIFF
--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -1,13 +1,34 @@
 name: Dependabot auto-merge
 
-# Auto-merge Dependabot PRs that are patch + minor only and have CI green.
-# Closes #191. Major-version bumps still require manual review (the
-# `update-type` filter on the merge step rejects them).
+# Auto-merge Dependabot PRs that are patch + minor only. Closes #191.
+# Major-version bumps still require manual review (the `update-type` filter
+# on the merge step rejects them).
+#
+# THE "CI GREEN" PART IS NOT ENFORCED HERE. This file has no way to check it.
+# `gh pr merge --auto` defers to GitHub's native auto-merge, which waits only
+# for the checks that branch protection marks REQUIRED. Until 2026-08-20 the
+# repo had `allow_auto_merge=false` and `main` had no protection and no
+# rulesets at all, so there was nothing to wait for and `--auto` merged
+# immediately. #339 and #344 each landed on `main` with SIX failing checks
+# (Typecheck + tests, Build + test on all three OS, OSV-Scanner, npm audit).
+# #339 is the onnxruntime-node break that then sat on `main` for eleven days.
+#
+# What actually gates this now lives outside this file:
+#   - repo setting `allow_auto_merge=true`, so `--auto` genuinely queues
+#   - branch protection on `main` requiring `Lint + format` and
+#     `Typecheck + tests` (both from ci.yml, which has no `paths` filter so
+#     they report on every PR — cli.yml's `Build + test` legs are deliberately
+#     NOT required, because a paths-filtered check never reports on unrelated
+#     PRs and would block them forever)
+#
+# If those two are ever removed, this workflow silently goes back to merging
+# red. See #360 and .github/workflows/main-health.yml.
 #
 # We use `pull_request_target` so the workflow runs with the perms of the
 # *base* branch's workflow file, not the PR's. That means a malicious
 # dependency update can't escalate by editing this workflow inside the PR
-# itself — the version of this file on `dev` is what runs.
+# itself. Note the base branch is `main` (dependabot targets the default
+# branch), not `dev` as this comment previously claimed.
 
 on:
   pull_request_target:

--- a/.github/workflows/main-health.yml
+++ b/.github/workflows/main-health.yml
@@ -1,0 +1,154 @@
+name: Main health
+
+# #360 item 3 — main carried a broken onnxruntime-node for eleven days
+# (2026-08-10 .. 2026-08-20). Two separate faults produced that, and this
+# workflow is the answer to the second one only.
+#
+# FAULT 1, why the break got in: nothing required checks to pass. `main` had
+# no branch protection and no rulesets, and the repo had
+# `allow_auto_merge=false`, so `gh pr merge --auto` in
+# dependabot-automerge.yml had nothing to wait for and merged on the spot.
+# CI ran on those PRs and correctly went red — #339 and #344 each landed
+# with SIX failing checks. Fixed on 2026-08-20, outside this file:
+# `allow_auto_merge=true` plus branch protection on `main` requiring
+# `Lint + format` and `Typecheck + tests`.
+#
+# FAULT 2, why nobody noticed for eleven days: the `push` trigger is fine
+# (ci.yml and cli.yml both list `push: branches: [main, dev]`), but GitHub
+# does not start workflow runs for events created by the default
+# `secrets.GITHUB_TOKEN`, and that is what the auto-merge authenticates as.
+# Merges that landed on main:
+#
+#   #339 (the break)  merged_by github-actions[bot]  -> no CI run
+#   #344              merged_by github-actions[bot]  -> no CI run
+#   #363              merged_by github-actions[bot]  -> no CI run
+#   #358              merged_by yocreoquesi          -> CI ran
+#   #359              merged_by yocreoquesi          -> CI ran
+#   #362              merged_by yocreoquesi          -> CI ran
+#
+# `schedule` events are exempt from that suppression, which is why
+# security.yml's weekly cron was the ONLY workflow that ran on the broken
+# commit — and it went red, and nobody read it. A red run is not a signal.
+# THIS workflow opens an issue, so the failure reaches notifications instead
+# of dying in the Actions tab.
+#
+# Fault 1 is closed, so this is no longer the only thing standing between a
+# bad dependency and `main`. It stays because required checks only prove the
+# tree was green AT MERGE TIME. They say nothing about a tree that goes red
+# later without a commit — a newly disclosed CVE, a transformers release that
+# moves the ONNX pin, a bot merge whose push never triggered CI.
+
+on:
+  schedule:
+    # Daily 07:00 UTC. Dependabot's window is ~06:10 UTC (the merge
+    # timestamps on #339 and #344), so this lands after the day's
+    # auto-merges rather than before them.
+    - cron: '0 7 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: main-health
+  cancel-in-progress: false
+
+jobs:
+  health:
+    name: main is installable and green
+    # Linux only, deliberately. The failure this exists to catch is the
+    # `libonnxruntime.so.1: version VERS_1.21.0 not found` soname collision,
+    # a Linux-specific manifestation, and a cheap job people trust beats a
+    # full matrix that cries wolf. The cross-platform matrix still runs
+    # per-PR in cli.yml.
+    #
+    # Playwright is excluded for the same reason: its jobs stall for hours
+    # on this repo's runners, and a heartbeat that flakes is a heartbeat
+    # nobody reads.
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          ref: main
+
+      - uses: actions/setup-node@v7
+        with:
+          node-version: '22'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      # Runs before the tests so a red run names the cause in its first
+      # failing step rather than in a test assertion.
+      - name: ONNX pin matches transformers
+        run: npm run sync:onnx-pin -- --check
+
+      # Order matters and mirrors cli.yml: tsup externalises nukebg-core, so
+      # the emitted worker imports nukebg-core/dist at runtime.
+      - name: Build nukebg-core
+        run: npm run build -w nukebg-core
+
+      - name: Build nukebg-cli
+        run: npm run build -w nukebg-cli
+
+      - name: Typecheck
+        run: npm run typecheck
+
+      # Includes tests/onnxruntime-single-runtime.test.ts, the guard that
+      # caught this class of break both times it happened.
+      - name: Tests
+        run: npm test
+
+  report:
+    name: Report
+    needs: health
+    if: always()
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
+    steps:
+      # One issue, reused. A fresh issue per failing day would reproduce the
+      # alarm fatigue this is meant to cure.
+      - name: Open, update or close the tracking issue
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          RESULT: ${{ needs.health.result }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          set -euo pipefail
+
+          existing="$(gh issue list --repo "$REPO" --state open \
+            --label 'ci:main-red' --limit 1 --json number --jq '.[0].number // ""')"
+
+          if [ "$RESULT" = "success" ]; then
+            if [ -n "$existing" ]; then
+              gh issue comment "$existing" --repo "$REPO" \
+                --body "main is green again as of $RUN_URL — closing."
+              gh issue close "$existing" --repo "$REPO"
+            fi
+            exit 0
+          fi
+
+          if [ -n "$existing" ]; then
+            gh issue comment "$existing" --repo "$REPO" --body "Still red: $RUN_URL"
+            exit 0
+          fi
+
+          cat > /tmp/main-red.md <<MSG
+          The scheduled health check on \`main\` failed: $RUN_URL
+
+          This runs daily because dependabot auto-merges land on \`main\`
+          without triggering CI — see the header of
+          \`.github/workflows/main-health.yml\` and #360 for why.
+
+          Check the ONNX pin first: \`npm run sync:onnx-pin -- --check\`.
+          MSG
+
+          gh issue create --repo "$REPO" \
+            --title 'main is red — scheduled health check failed' \
+            --label 'ci:main-red' \
+            --body-file /tmp/main-red.md


### PR DESCRIPTION
Ships #364. Closes #360. Workflows only, no production code.

`main` carried a broken `onnxruntime-node` for eleven days. Two separate faults produced that, and #360 item 3 named neither of them correctly.

## Fault 1: nothing required checks to pass

CI ran on the dependabot PRs and correctly went red. They merged anyway.

```
PR #339 (the onnx break)  ->  6 failing checks, merged to main
PR #344                   ->  6 failing checks, merged to main
```

Both failed `Typecheck + tests`, `Build + test` on all three OS, `OSV-Scanner` and `npm audit`.

`main` returned `"Branch not protected"` with `rulesets: []`, and the repo had `allow_auto_merge=false`. `gh pr merge --auto` defers to GitHub's native auto-merge, which waits only for checks that branch protection marks required. None were marked, and native auto-merge was unavailable, so there was nothing to wait for.

Fixed by repo config rather than code:

| Setting | Value |
|---|---|
| `allow_auto_merge` | `true`, so `--auto` genuinely queues |
| `main` required checks | `Lint + format`, `Typecheck + tests` |
| `strict` | `false` |
| `enforce_admins` | `false` |
| required reviews | none |

Both required checks come from `ci.yml`, which has no `paths` filter, so they report on every PR. `cli.yml`'s `Build + test` legs are deliberately **not** required: `cli.yml` is paths-filtered, and a paths-filtered check never reports on an unrelated PR, leaving it stuck pending and blocking that PR forever. Playwright is excluded because those jobs stall for hours on this repo's runners.

Counterfactual checked against the real head SHA of #339: `Typecheck + tests` was `failure`. With this in place the break does not land.

## Fault 2: the damage stayed invisible

The `push` trigger was never the problem. `ci.yml` and `cli.yml` both list `push: branches: [main, dev]`. GitHub does not start workflow runs for events created by the default `secrets.GITHUB_TOKEN`, which is what the auto-merge authenticates as.

| PR | `merged_by` | CI on `main`? |
|---|---|---|
| #339, #344, #363 | `github-actions[bot]` | no |
| #358, #359, #362 | `yocreoquesi` | yes |

`schedule` events are exempt, which is why `security.yml`'s weekly cron was the only workflow that ran on the broken commit. It failed, and went unread for eleven days. A red run is not a signal.

`main-health.yml` covers this: daily 07:00 UTC (after dependabot's ~06:10 window) plus `workflow_dispatch`. It installs `main`, checks the ONNX pin, builds core and CLI, typechecks and runs the suite. Linux only, no Playwright, for the same credibility reason. The `report` job opens one reusable `ci:main-red` issue on failure, comments while it stays red, and closes it on recovery.

Fault 1 being closed does not retire it. Required checks prove the tree was green **at merge time** and say nothing about one that goes red later without a commit: a newly disclosed CVE, a transformers release that moves the ONNX pin, a bot merge whose push never fired CI.

## Also in here

Two false comments in `dependabot-automerge.yml`, corrected:

- It claimed to auto-merge PRs that "have CI green". It never checked, and #339 is what that cost.
- It claimed the `dev` copy of the file runs under `pull_request_target`. The base branch is `main`, since dependabot targets the default branch.

## Test plan

- [x] #364 merged on CLEAN, all checks green.
- [x] Branch protection read back: `contexts=["Lint + format","Typecheck + tests"] strict=false admins=false`.
- [x] Counterfactual: `Typecheck + tests` = `failure` on #339's head SHA.
- [x] YAML parses for both workflows; `report` job script passes `bash -n`.
- [x] Success path dry-run against the live repo: the `gh issue list` query resolves, step exits 0, no side effects.
- [x] `ci:main-red` label created, so `gh issue create --label` will not fail on first red.

## After merge

Fire `main-health` via `workflow_dispatch` immediately. `schedule` only ever runs the default branch's copy, so it does nothing until this lands.
