### PR TITLE
chore(deps): bump commander from 12.1.0 to 14.0.3, not 15

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2606,12 +2606,12 @@
       }
     },
     "node_modules/commander": {
-      "version": "12.1.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-12.1.0.tgz",
-      "integrity": "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==",
+      "version": "14.0.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.3.tgz",
+      "integrity": "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==",
       "license": "MIT",
       "engines": {
-        "node": ">=18"
+        "node": ">=20"
       }
     },
     "node_modules/confbox": {
@@ -6228,7 +6228,7 @@
       "license": "GPL-3.0-only",
       "dependencies": {
         "@huggingface/transformers": "^3.8.1",
-        "commander": "^12.1.0",
+        "commander": "^14.0.3",
         "env-paths": "^4.0.0",
         "nukebg-core": "0.1.0",
         "onnxruntime-node": "1.21.0",

--- a/packages/nukebg-cli/package.json
+++ b/packages/nukebg-cli/package.json
@@ -29,7 +29,7 @@
   },
   "dependencies": {
     "@huggingface/transformers": "^3.8.1",
-    "commander": "^12.1.0",
+    "commander": "^14.0.3",
     "env-paths": "^4.0.0",
     "nukebg-core": "0.1.0",
     "onnxruntime-node": "1.21.0",


### PR DESCRIPTION
Supersedes #340, which proposed 15.0.0.

## Why not 15

The API breaking changes across 13, 14 and 15 are all inert here, and #340 went green on all three OS legs. The blocker is `engines`:

| package | `engines.node` | `type` |
|---|---|---|
| commander 12.1.0 (current) | `>=18` | commonjs |
| commander 14.0.3 (this PR) | `>=20` | commonjs |
| commander 15.0.0 (#340) | `>=22.12.0` | module |
| **`nukebg-cli`** | **`>=20.0.0`** | module |

`tsup.config.ts` also sets `target: 'node20'`.

Taking 15 would publish a CLI that declares Node 20 support while depending on a package that declares it does not support Node 20. **CI cannot catch this.** All nine workflows pin `node-version: '22'`, so the green on #340 is evidence that nobody tested the floor, not evidence that the floor holds.

14.0.3 matches the declared engines exactly, carries the same v13/v14 breaking changes, and is supported until May 2027.

## What actually changes

From v13: **excess command-arguments now error instead of being ignored.** `nukebg a.png b.png` is rejected rather than silently dropping the second path. That is the only user-visible difference, and it is a fix.

Verified inert:

| Breaking change | Why it does not bite |
|---|---|
| Throw on multiple chars after a single `-` (v13) | `-o`, `-f`, `-q`, `-v` are all single-character |
| Throw on repeat `.parse()` with `storeOptionsAsProperties` (v13) | Not used |
| Implicit negation defaults changed (v15) | `--no-watermark` and `--no-auto-crop` are lone negatives with no positive counterpart, so the v15 rule would not have applied either. The comments at `cli.ts:76-81` stay accurate |

## Changes

| File | Change |
|---|---|
| `packages/nukebg-cli/package.json` | `commander` `^12.1.0` to `^14.0.3` |
| `package-lock.json` | The commander entry only |

The lockfile diff is ten lines and touches nothing but commander. It was produced with `npm install --package-lock-only --workspace nukebg-cli`, so no OS-specific churn.

## Not in scope

Moving the CLI floor to Node 22.12 so 15 becomes available is a product decision, not a dependency one. Node 20 reached EOL in April 2026, so it is defensible, but it is a breaking change for published CLI consumers and wants its own change with an `engines` bump and `target: 'node22'`.

## Test plan

- [x] Lockfile diff reviewed line by line: only commander's `version` / `resolved` / `integrity` / `engines` and the two manifest references.
- [x] commander API surface audited. It is confined to `cli.ts` (`Command`, `Option`, `CommanderError`, `.exitOverride()`, `.configureOutput()`, `.showHelpAfterError()`, `.argument()`, `.option()`, `.addOption().choices()`, `.command()`, `.parseAsync(argv, {from:'user'})`) plus `err.exitCode` in `util/errors.ts`.
- [x] #340 proves the suite passes against 15.0.0, a strictly larger jump, on ubuntu, macos and windows.
- [ ] CI on this PR.
