### PR TITLE
release: commander 14, env-paths 4, globals 17

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2606,12 +2606,12 @@
       }
     },
     "node_modules/commander": {
-      "version": "12.1.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-12.1.0.tgz",
-      "integrity": "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==",
+      "version": "14.0.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.3.tgz",
+      "integrity": "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==",
       "license": "MIT",
       "engines": {
-        "node": ">=18"
+        "node": ">=20"
       }
     },
     "node_modules/confbox": {
@@ -6228,7 +6228,7 @@
       "license": "GPL-3.0-only",
       "dependencies": {
         "@huggingface/transformers": "^3.8.1",
-        "commander": "^12.1.0",
+        "commander": "^14.0.3",
         "env-paths": "^4.0.0",
         "nukebg-core": "0.1.0",
         "onnxruntime-node": "1.21.0",

--- a/packages/nukebg-cli/package.json
+++ b/packages/nukebg-cli/package.json
@@ -29,7 +29,7 @@
   },
   "dependencies": {
     "@huggingface/transformers": "^3.8.1",
-    "commander": "^12.1.0",
+    "commander": "^14.0.3",
     "env-paths": "^4.0.0",
     "nukebg-core": "0.1.0",
     "onnxruntime-node": "1.21.0",


### PR DESCRIPTION
Ships #367. Closes out the three dependabot PRs that had been open since 10 Aug.

`env-paths` (#342) and `globals` (#345) went to `main` directly. This carries the third.

## commander 12.1.0 to 14.0.3

Dependabot proposed 15.0.0 in #340. Closed in favour of 14.0.3, because of `engines`:

| package | `engines.node` |
|---|---|
| commander 15.0.0 | `>=22.12.0` |
| commander 14.0.3 | `>=20` |
| `nukebg-cli` | `>=20.0.0` |

`tsup.config.ts` also sets `target: 'node20'`. Taking 15 would publish a CLI declaring Node 20 support while depending on a package that declares it does not support Node 20, and no workflow could have told us: all nine pin `node-version: '22'`.

The one user-visible change, from v13: excess command-arguments now error instead of being silently ignored, so `nukebg a.png b.png` is rejected rather than dropping the second path.

The rest of the v13/v14/v15 breaking changes are inert here. Short flags are all single-character, `storeOptionsAsProperties` is unused, and `--no-watermark` / `--no-auto-crop` are lone negatives so v15's negation-default change would not have applied either.

## What the other two were checked against

Both were verified beyond their green checks, since CI cannot see either risk.

**`env-paths` 3 to 4.** The concern was the model cache directory moving and orphaning downloaded models. It does not: the path-building functions for macOS, Linux and Windows are byte-identical between the two versions. The only source change is `typeof name !== 'string'` becoming `assertSafeFilename(name)`, which adds one transitive dependency (`is-safe-filename`) and which `'nukebg'` passes. Verified at runtime too, `env-paths('nukebg', {suffix: ''}).cache` is unchanged.

**`globals` 15 to 17.** Root devDependency, consumed only by `eslint.config`. Never ships. `engines` unchanged at `>=18`.

## Follow-on

Raising the CLI floor to Node 22.12 would unlock commander 15. Node 20 reached EOL in April 2026, so it is defensible, but it is a breaking change for published CLI consumers and wants its own change with an `engines` bump and `target: 'node22'`. Not done here.

## Test plan

- [x] #367 merged on CLEAN: `Build + test` green on ubuntu, macos and windows against commander 14.
- [x] Lockfile diff reviewed line by line, ten lines, commander only, no OS-specific churn.
- [x] commander API surface audited across `cli.ts` and `util/errors.ts` against every 13/14/15 breaking change.
- [x] `env-paths` v3 vs v4 source diffed; path functions identical on all three platforms.
