### PR TITLE
build(cli): raise the nukebg-cli Node floor to 22.12 and take commander 15

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,23 @@ Unreleased entries accumulate on the `dev` branch. When we cut a release we copy
 
 ### Changed
 
+- **`nukebg-cli` now requires Node.js 22.12 or newer** (was 20). Raised to
+  take `commander` 15, which is ESM-only and declares
+  `engines.node >= 22.12.0`. Node 20 reached end of life in April 2026, and
+  neither `nukebg-cli` nor `nukebg-core` has been published to npm yet, so
+  this breaks no installed consumer — before first publish is the cheapest
+  moment to move a floor. `tsup` `target` moved to `node22` in step.
+  The floor for the repo root, `nukebg-app` and `nukebg-core` stays at
+  `>=20.0.0`: the CLI is the only package that needs 22, and forcing
+  browser-app contributors up for a dependency they never load was the
+  original reason the floor sat at 20.
+- **`commander` 12.1.0 to 15.0.0.** The one user-visible change arrives with
+  13: excess command-arguments now error instead of being ignored, so
+  `nukebg a.png b.png` is rejected rather than silently dropping the second
+  path. The rest are inert here — the short flags are all single-character,
+  `storeOptionsAsProperties` is unused, and `--no-watermark` / `--no-auto-crop`
+  are lone negatives, so 15's change to implicit negation defaults does not
+  apply.
 - **Classifier collapsed from 4 to 3 content types.** Removed `ILLUSTRATION`
   from `ImageContentType`. Audit confirmed the label had zero behavioural
   impact: `finalize-result.ts` treated it identically to `PHOTO` and no

--- a/openspec/changes/extract-core-cli/specs/distribution.md
+++ b/openspec/changes/extract-core-cli/specs/distribution.md
@@ -69,7 +69,7 @@ The root `package.json` MUST declare `"workspaces": ["packages/*"]`. Each packag
 - `"bin": { "nukebg": "./dist/cli.js" }`.
 - `"dependencies"` includes `nukebg-core` (workspace reference), `onnxruntime-node`, `@huggingface/transformers`, `sharp`, `commander`, and `env-paths`.
 - MUST NOT depend on `onnxruntime-web`.
-- `"engines": { "node": ">=20.0.0" }`.
+- `"engines": { "node": ">=22.12.0" }`.
 
 #### Scenario: Binary is executable after global install
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -2606,12 +2606,12 @@
       }
     },
     "node_modules/commander": {
-      "version": "14.0.3",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.3.tgz",
-      "integrity": "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==",
+      "version": "15.0.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-15.0.0.tgz",
+      "integrity": "sha512-z67u4ZhzCL/Tydu1lJARtEZYWbWaN7oYLHbsuzocr6y4N6WZAagG3RQ4FW61V1/0+jImpj293XfrcYnd1qxtPg==",
       "license": "MIT",
       "engines": {
-        "node": ">=20"
+        "node": ">=22.12.0"
       }
     },
     "node_modules/confbox": {
@@ -6228,7 +6228,7 @@
       "license": "GPL-3.0-only",
       "dependencies": {
         "@huggingface/transformers": "^3.8.1",
-        "commander": "^14.0.3",
+        "commander": "^15.0.0",
         "env-paths": "^4.0.0",
         "nukebg-core": "0.1.0",
         "onnxruntime-node": "1.21.0",
@@ -6241,7 +6241,7 @@
         "tsup": "^8.3.0"
       },
       "engines": {
-        "node": ">=20.0.0"
+        "node": ">=22.12.0"
       }
     },
     "packages/nukebg-cli/node_modules/@img/sharp-darwin-arm64": {

--- a/packages/nukebg-cli/README.md
+++ b/packages/nukebg-cli/README.md
@@ -23,7 +23,7 @@ image is processed. See [License gate](#license-gate) below.
 npm install -g nukebg-cli
 ```
 
-Requires Node.js 20 or newer. Installs the `nukebg` binary.
+Requires Node.js 22.12 or newer. Installs the `nukebg` binary.
 
 ## Usage
 

--- a/packages/nukebg-cli/package.json
+++ b/packages/nukebg-cli/package.json
@@ -29,7 +29,7 @@
   },
   "dependencies": {
     "@huggingface/transformers": "^3.8.1",
-    "commander": "^14.0.3",
+    "commander": "^15.0.0",
     "env-paths": "^4.0.0",
     "nukebg-core": "0.1.0",
     "onnxruntime-node": "1.21.0",
@@ -39,6 +39,6 @@
     "tsup": "^8.3.0"
   },
   "engines": {
-    "node": ">=20.0.0"
+    "node": ">=22.12.0"
   }
 }

--- a/packages/nukebg-cli/tsup.config.ts
+++ b/packages/nukebg-cli/tsup.config.ts
@@ -24,7 +24,12 @@ export default defineConfig({
   // worker-pipeline-runner.ts resolves it as a sibling of the bundle.
   entry: { cli: 'src/cli.ts', 'pipeline.worker': 'src/runners/pipeline.worker.ts' },
   format: ['esm'],
-  target: 'node20',
+  // node22, not node20: commander 15 is ESM-only and declares
+  // `engines.node >= 22.12.0`. The CLI's own floor moved to match — see
+  // package.json `engines` and REQ-DIST-3. Keep the two in step; a target
+  // below the engines floor silently down-levels for a runtime we no
+  // longer claim to support.
+  target: 'node22',
   platform: 'node',
   outDir: 'dist',
   clean: true,


### PR DESCRIPTION
Follow-up to #367, which held commander at 14.0.3 because 15 declares `engines.node >= 22.12.0` while `nukebg-cli` declared `>=20.0.0`. This moves the floor instead of the dependency.

## Why now is the cheap moment

Neither package is published:

```
npm view nukebg-cli version   ->  E404 Not Found
npm view nukebg-core version  ->  E404 Not Found
```

So this breaks no installed consumer. Raising a floor before first publish costs nothing; raising it after costs a major and a migration note. Node 20 also reached end of life in April 2026.

## Scoped to the CLI on purpose

`openspec/changes/extract-core-cli/proposal.md` records why the floor sat at 20:

> Bumping to 22 to support a CLI is a regression for browser-app contributors who don't need it.

That reasoning still holds for every package except the one that actually needs 22. So:

| package | `engines.node` | change |
|---|---|---|
| repo root | `>=20.0.0` | unchanged |
| `nukebg-app` | `>=20.0.0` | unchanged |
| `nukebg-core` | `>=20.0.0` | unchanged |
| **`nukebg-cli`** | **`>=22.12.0`** | **raised** |

Only REQ-DIST-3 moves in the spec. REQ-DIST-2, which is `nukebg-core`, is deliberately left at `>=20.0.0`.

## Changes

| File | Change |
|---|---|
| `packages/nukebg-cli/package.json` | `engines.node` to `>=22.12.0`, `commander` to `^15.0.0` |
| `packages/nukebg-cli/tsup.config.ts` | `target` to `node22`, with a comment tying it to the engines floor |
| `packages/nukebg-cli/README.md` | Install section now states Node 22.12 |
| `openspec/changes/extract-core-cli/specs/distribution.md` | REQ-DIST-3 engines invariant |
| `CHANGELOG.md` | `[Unreleased]` entry for both the floor and commander |
| `package-lock.json` | commander entry plus the workspace `engines` field |

`tsup` `target` moves in step deliberately. Leaving it at `node20` would down-level output for a runtime the manifest no longer claims to support, which is the kind of mismatch nobody notices until a user reports it.

The package version stays at `0.1.0`. It has never been published, so there is no release to supersede, and the only places `0.1.0` appears in tests are `cliVersion` fixtures passed in by hand, not assertions about the manifest.

## Behaviour change

Inherited from commander 13: **excess command-arguments now error instead of being ignored.** `nukebg a.png b.png` is rejected rather than silently dropping the second path.

The rest of the 13/14/15 breaking changes are inert here, as established in #367: short flags are all single-character so the flag-construction throw cannot fire, `storeOptionsAsProperties` is unused, and `--no-watermark` / `--no-auto-crop` are lone negatives so 15's change to implicit negation defaults does not apply.

## Test plan

- [x] Lockfile diff reviewed: commander's four fields plus the workspace `engines` value. Nothing else, no OS-specific churn. Produced with `npm install --package-lock-only --workspace nukebg-cli`.
- [x] REQ-DIST-2 confirmed untouched at `>=20.0.0`; only line 72 moved.
- [x] No test asserts `engines`, a Node floor, or the manifest version.
- [x] #340 already proved the CLI suite passes against commander 15.0.0 on ubuntu, macos and windows — at `target: 'node20'`, so `node22` is strictly less down-levelling.
- [ ] CI on this PR.

## Note on CI coverage

CI cannot verify a Node floor: all nine workflows pin `node-version: '22'`. Green here means the code works on Node 22, which is now exactly what the manifest claims — the two agree for the first time. If the floor is ever lowered again, that agreement is what breaks silently.
