### PR TITLE
release: model-load race, dropzone disable, leaked listener

### DIFF
--- a/packages/nukebg-app/src/components/ar-app.ts
+++ b/packages/nukebg-app/src/components/ar-app.ts
@@ -316,17 +316,26 @@ export class ArApp extends HTMLElement {
       '#error-modal-dismiss',
     ) as HTMLButtonElement | null;
     const backdrop = this.shadowRoot!.querySelector('#error-modal-backdrop') as HTMLElement | null;
-    retryBtn?.addEventListener('click', () => this.retryFromError());
-    dismissBtn?.addEventListener('click', () => this.hideErrorModal());
-    backdrop?.addEventListener('click', () => this.hideErrorModal());
-    window.addEventListener('keydown', (e) => {
-      if (e.key !== 'Escape') return;
-      const modal = this.shadowRoot?.querySelector('#error-modal') as HTMLElement | null;
-      if (modal && !modal.hasAttribute('hidden')) {
-        e.preventDefault();
-        this.hideErrorModal();
-      }
-    });
+    retryBtn?.addEventListener('click', () => this.retryFromError(), { signal });
+    dismissBtn?.addEventListener('click', () => this.hideErrorModal(), { signal });
+    backdrop?.addEventListener('click', () => this.hideErrorModal(), { signal });
+    // `window` outlives this component, so without `{ signal }` this
+    // handler would survive disconnectedCallback() and keep a live
+    // reference to the (by then detached) shadow root — a genuine leak,
+    // unlike the three listeners above which are on elements that get
+    // garbage-collected with the shadow root anyway.
+    window.addEventListener(
+      'keydown',
+      (e) => {
+        if (e.key !== 'Escape') return;
+        const modal = this.shadowRoot?.querySelector('#error-modal') as HTMLElement | null;
+        if (modal && !modal.hasAttribute('hidden')) {
+          e.preventDefault();
+          this.hideErrorModal();
+        }
+      },
+      { signal },
+    );
 
     // PWA install button + guide — controller owns the wiring and uses
     // the same AbortSignal so cleanup is automatic on disconnect.

--- a/packages/nukebg-app/src/components/ar-dropzone.ts
+++ b/packages/nukebg-app/src/components/ar-dropzone.ts
@@ -7,6 +7,23 @@ export class ArDropzone extends HTMLElement {
   private fileInput!: HTMLInputElement;
   private dropArea!: HTMLDivElement;
   private abortController: AbortController | null = null;
+  /**
+   * Single source of truth for the enabled/disabled state (bug fix: the
+   * old `setEnabled()` only toggled a CSS class, whose only real effect is
+   * `pointer-events: none` — that blocks mouse clicks but does nothing for
+   * keyboard activation, so Enter/Space still reached fileInput.click()).
+   *
+   * Gates the paths that OPEN the file picker (click, keydown) and
+   * `paste`. It deliberately does NOT gate `change` or `drop`: once the
+   * user has committed a file, discarding it silently is worse than
+   * starting slightly early, and the in-flight load dedupe in ml.worker
+   * makes starting early safe.
+   */
+  private enabled = true;
+  /** Original tabindex value, restored by setEnabled(true) after the
+   *  disabled state forces tabindex="-1" to keep the drop area out of
+   *  the tab order while it can't do anything. */
+  private originalTabIndex = '0';
 
   constructor() {
     super();
@@ -297,6 +314,9 @@ export class ArDropzone extends HTMLElement {
 
     this.dropArea = this.shadowRoot!.querySelector('.dropzone')!;
     this.fileInput = this.shadowRoot!.querySelector('input[type="file"]')!;
+    // Capture the markup's real default tabindex so setEnabled(true) can
+    // restore it exactly, instead of hardcoding "0".
+    this.originalTabIndex = this.dropArea.getAttribute('tabindex') ?? '0';
   }
 
   private updateTexts(): void {
@@ -325,18 +345,30 @@ export class ArDropzone extends HTMLElement {
     // one of the source options on mobile, so a dedicated camera CTA
     // is unnecessary (#146).
     this.dropArea.addEventListener('click', () => {
+      if (!this.enabled) return;
       this.fileInput.click();
     });
 
-    // Keyboard support
+    // Keyboard support. `pointer-events: none` (the disabled visual state)
+    // has no effect on keyboard activation, so this needs its own guard —
+    // without it, Enter/Space could still open the file picker while the
+    // dropzone was supposed to be disabled.
     this.dropArea.addEventListener('keydown', (e) => {
+      if (!this.enabled) return;
       if (e.key === 'Enter' || e.key === ' ') {
         e.preventDefault();
         this.fileInput.click();
       }
     });
 
-    // File input change
+    // File input change. Deliberately NOT gated on `enabled`: by the time
+    // this fires the user has already chosen a file, and silently
+    // discarding it is a worse failure than processing it slightly early
+    // — the picker just closes and nothing happens, with no way to tell
+    // why. Starting early is safe because loadModel() dedupes in-flight
+    // loads, so a file arriving mid-preload joins the download already
+    // running instead of starting a second one. setEnabled() gates the
+    // paths that OPEN the picker, not the file that comes back from it.
     this.fileInput.addEventListener('change', () => {
       if (this.fileInput.files && this.fileInput.files.length > 0) {
         this.handleFiles(this.fileInput.files);
@@ -351,6 +383,9 @@ export class ArDropzone extends HTMLElement {
     this.dropArea.addEventListener('dragleave', () => {
       this.dropArea.classList.remove('dragover');
     });
+    // `drop` is ungated for the same reason as `change`: the user has
+    // already committed the file by releasing it here, so refusing it
+    // would just look broken.
     this.dropArea.addEventListener('drop', (e) => {
       e.preventDefault();
       this.dropArea.classList.remove('dragover');
@@ -362,7 +397,7 @@ export class ArDropzone extends HTMLElement {
     document.addEventListener(
       'paste',
       (e: ClipboardEvent) => {
-        if (this.dropArea.classList.contains('dropzone-disabled')) return;
+        if (!this.enabled) return;
         const items = e.clipboardData?.items;
         if (!items) return;
         for (const item of items) {
@@ -382,13 +417,30 @@ export class ArDropzone extends HTMLElement {
     this.abortController = null;
   }
 
-  /** Enable or disable the dropzone (used to block interaction until model is ready) */
+  /**
+   * Enable or disable the dropzone (used to block interaction until model
+   * is ready). `this.enabled` gates the paths that OPEN the file picker
+   * (click, keydown) plus `paste`; the CSS class stays for the visual
+   * state, and `aria-disabled` + `tabindex` keep the disabled state
+   * honest to assistive tech instead of only visual/pointer-based.
+   *
+   * `change` and `drop` are intentionally NOT gated — see those handlers.
+   */
   setEnabled(enabled: boolean): void {
+    // Assign BEFORE the render guard below: the flag is the real gate for
+    // every entry point, so it must hold even if this lands before the
+    // shadow DOM exists. Returning early without it would leave a
+    // pre-render setEnabled(false) silently enabled once we render.
+    this.enabled = enabled;
     if (!this.dropArea) return;
     if (enabled) {
       this.dropArea.classList.remove('dropzone-disabled');
+      this.dropArea.setAttribute('aria-disabled', 'false');
+      this.dropArea.setAttribute('tabindex', this.originalTabIndex);
     } else {
       this.dropArea.classList.add('dropzone-disabled');
+      this.dropArea.setAttribute('aria-disabled', 'true');
+      this.dropArea.setAttribute('tabindex', '-1');
     }
   }
 

--- a/packages/nukebg-app/src/lib/async-call-dedupe.ts
+++ b/packages/nukebg-app/src/lib/async-call-dedupe.ts
@@ -1,0 +1,55 @@
+/**
+ * Deduplicate concurrent async calls that share the same key.
+ *
+ * Extracted out of `ml.worker.ts`'s `loadModel()` (in-flight load race):
+ * that function's only "already loaded" guard was `segmenters.has(modelId)`,
+ * checked BEFORE the async `transformers.pipeline()` call resolves. Two
+ * callers for the same modelId arriving close together (e.g. the explicit
+ * `preload()` fired from ar-app.ts on page load, racing the auto-load
+ * `segment()` performs when no model is loaded yet) both pass that guard
+ * and each start their own `transformers.pipeline()` call — a second
+ * ~45MB download and a second WASM session in the same worker.
+ *
+ * `AsyncCallDedupe` fixes the general shape of that problem: only the
+ * first caller for a given key actually runs `factory()`; every other
+ * caller for the same key while that call is still in flight awaits the
+ * SAME promise instead of starting a new one. The in-flight entry is
+ * removed as soon as the call settles — on both success and failure — so
+ * a failed call does not permanently cache a rejected promise and can be
+ * retried on the next call for that key.
+ *
+ * Note this only dedupes the underlying work behind `factory()`. Any
+ * per-caller side effects (e.g. ml.worker.ts's caller-specific
+ * `model-progress` / `model-ready` postMessage, keyed by that caller's
+ * own request id) must still be performed by each caller individually
+ * after `run()` resolves — never bake caller identity into `factory()`.
+ */
+export class AsyncCallDedupe<T> {
+  private readonly inFlight = new Map<string, Promise<T>>();
+
+  /**
+   * Run `factory()` for `key`, unless a call for the same key is already
+   * in flight — in which case the existing promise is returned so the
+   * caller awaits the SAME underlying work instead of starting a new one.
+   */
+  run(key: string, factory: () => Promise<T>): Promise<T> {
+    const existing = this.inFlight.get(key);
+    if (existing) return existing;
+
+    const promise = factory().finally(() => {
+      // Guard against clearing a newer entry in case of exotic re-entrancy
+      // (factory() somehow re-registering the same key before settling).
+      // Normal usage never triggers this, but it keeps the map correct.
+      if (this.inFlight.get(key) === promise) {
+        this.inFlight.delete(key);
+      }
+    });
+    this.inFlight.set(key, promise);
+    return promise;
+  }
+
+  /** Number of keys currently in flight. Test-only introspection. */
+  get size(): number {
+    return this.inFlight.size;
+  }
+}

--- a/packages/nukebg-app/src/pipeline/worker-pipeline-runner.ts
+++ b/packages/nukebg-app/src/pipeline/worker-pipeline-runner.ts
@@ -191,11 +191,17 @@ export class WorkerPipelineRunner implements PipelineRunner {
    * Called from `run()` when the provided AbortSignal fires, or
    * directly by callers who want to tear down.
    *
-   * NOTE: ml worker termination drops the loaded RMBG session — the
-   * next segment call re-loads it from the Service Worker cache (fast,
-   * not a fresh network download). This is the correct trade-off: a
-   * user who aborts expects CPU to stop NOW, not finish the current
-   * 45s spatial pass.
+   * NOTE: ml worker termination drops the loaded RMBG session — the next
+   * segment call has to fully re-download and re-instantiate it, NOT a
+   * fast Service Worker cache hit. Two reasons: (1) service-worker.js's
+   * `EXCLUDED_PATTERNS` explicitly excludes `huggingface.co` / `cdn-lfs`
+   * from any Service Worker handling, so the SW never intercepts these
+   * requests at all; (2) transformers.js only writes into the Cache API
+   * (`transformers-cache`) AFTER a download completes successfully, so a
+   * worker terminated mid-download leaves nothing cached to hit. This is
+   * still the correct trade-off: a user who aborts expects CPU to stop
+   * NOW, not finish the current 45s spatial pass — the next load just
+   * costs a full re-download, same as the very first load.
    */
   abort(reason = 'aborted'): void {
     const err = new PipelineAbortError(reason);

--- a/packages/nukebg-app/src/workers/ml.worker.ts
+++ b/packages/nukebg-app/src/workers/ml.worker.ts
@@ -11,6 +11,7 @@ import type {
   WarmupDiagnostic,
 } from '../types/worker-messages';
 import { refineMask, RMBG_PARAMS } from 'nukebg-core';
+import { AsyncCallDedupe } from '../lib/async-call-dedupe';
 
 const DEFAULT_MODEL: ModelId = 'briaai/RMBG-1.4';
 
@@ -89,6 +90,11 @@ interface SegmenterEntry {
 
 /** Cache segmenters by model ID so switching is instant after first load */
 const segmenters = new Map<string, SegmenterEntry>();
+/**
+ * In-flight load dedupe, keyed by modelId. See `AsyncCallDedupe` doc and
+ * the `loadModel()` comment below for the race this closes.
+ */
+const modelLoads = new AsyncCallDedupe<void>();
 let currentModelId: ModelId = DEFAULT_MODEL;
 let RawImageClass:
   (new (data: Uint8ClampedArray, w: number, h: number, channels: number) => unknown) | null = null;
@@ -115,22 +121,28 @@ const progressCb = (id: string) => (progress: { status: string; progress?: numbe
   }
 };
 
-async function loadModel(
+/**
+ * Performs the actual model load: evicts any other cached model, downloads
+ * and instantiates the pipeline, verifies its integrity, and runs the WASM
+ * warmup pass. This is the expensive part `loadModel()` dedupes via
+ * `modelLoads` — it only ever runs ONCE per modelId at a time, so the
+ * eviction loop and the `transformers.pipeline()` download both run
+ * exactly once per actual load, never once per concurrent caller.
+ *
+ * `id` is the request id of whichever caller happened to be the one that
+ * triggered this particular load. It is used only for the progress
+ * postMessages that fire WHILE the load is in flight (5%, 10%, 96%,
+ * warmup-diagnostic) — best-effort UI feedback for that one caller. A
+ * second caller that joins an in-flight load (see `loadModel()`) simply
+ * won't see these intermediate messages, since it isn't the one this `id`
+ * belongs to. Final completion (progress 100 + model-ready) is sent by
+ * EVERY caller separately in `loadModel()`, each using its own `id`.
+ */
+async function performModelLoad(
   id: string,
-  modelId: ModelId = DEFAULT_MODEL,
-  emitReady = true,
+  modelId: ModelId,
+  device: 'webgpu' | 'wasm',
 ): Promise<void> {
-  const device = await detectDevice();
-
-  if (segmenters.has(modelId)) {
-    currentModelId = modelId;
-    if (emitReady) {
-      self.postMessage({ id, type: 'model-progress', progress: 100 });
-      self.postMessage({ id, type: 'model-ready', device });
-    }
-    return;
-  }
-
   // Free previous model to avoid OOM - WASM can't hold multiple models
   for (const [key, entry] of segmenters) {
     if (key !== modelId) {
@@ -226,6 +238,47 @@ async function loadModel(
     };
   }
   self.postMessage({ id, type: 'warmup-diagnostic', diagnostic: warmupDiagnostic });
+}
+
+async function loadModel(
+  id: string,
+  modelId: ModelId = DEFAULT_MODEL,
+  emitReady = true,
+): Promise<void> {
+  const device = await detectDevice();
+
+  if (segmenters.has(modelId)) {
+    currentModelId = modelId;
+    if (emitReady) {
+      self.postMessage({ id, type: 'model-progress', progress: 100 });
+      self.postMessage({ id, type: 'model-ready', device });
+    }
+    return;
+  }
+
+  // In-flight dedupe: loadModel() can be entered twice for the same
+  // modelId before the first call has populated `segmenters` — e.g. the
+  // explicit preload() ar-app.ts fires on page load races the auto-load
+  // segment() performs when a model isn't loaded yet (see the
+  // `_autoload_` comment there). Without this, both callers would pass
+  // the `segmenters.has()` guard above and each start an independent
+  // `transformers.pipeline()` call: a second ~45MB download and a second
+  // WASM session in the same worker.
+  //
+  // `modelLoads.run()` ensures only the initiating caller actually
+  // executes `performModelLoad()`; every other concurrent caller for the
+  // same modelId awaits that SAME promise instead of starting a new load.
+  // The entry is cleared on both success and failure, so a failed load
+  // can be retried by the next call rather than permanently caching a
+  // rejected promise.
+  //
+  // Once the (possibly shared) load settles, EVERY caller — initiator and
+  // joiners alike — still runs its own emitReady block below using ITS
+  // OWN `id`, never the initiator's. That matters because a stray
+  // model-ready with the wrong id could wrongly resolve some other
+  // pending segment() request (see the WorkerChannel routing + the
+  // `_autoload_` comment in segment() for that failure mode).
+  await modelLoads.run(modelId, () => performModelLoad(id, modelId, device));
 
   currentModelId = modelId;
 

--- a/packages/nukebg-app/tests/components/ar-dropzone.test.ts
+++ b/packages/nukebg-app/tests/components/ar-dropzone.test.ts
@@ -128,6 +128,97 @@ describe('ArDropzone component (#131)', () => {
       dropzone.setEnabled(true);
       expect(dz.classList.contains('dropzone-disabled')).toBe(false);
     });
+
+    it('sets aria-disabled and drops the drop area out of the tab order while disabled, restoring the original tabindex on re-enable', () => {
+      const dz = dropzone.shadowRoot!.querySelector('.dropzone')!;
+      const originalTabIndex = dz.getAttribute('tabindex');
+
+      dropzone.setEnabled(false);
+      expect(dz.getAttribute('aria-disabled')).toBe('true');
+      expect(dz.getAttribute('tabindex')).toBe('-1');
+
+      dropzone.setEnabled(true);
+      expect(dz.getAttribute('aria-disabled')).toBe('false');
+      expect(dz.getAttribute('tabindex')).toBe(originalTabIndex);
+    });
+
+    /**
+     * Regression test (bug: setEnabled(false) only toggled the CSS class,
+     * whose only real effect is `pointer-events: none`). That blocks mouse
+     * clicks but does nothing for keyboard activation, so Enter/Space
+     * could still open the file picker while the dropzone was meant to be
+     * disabled.
+     *
+     * The guard deliberately stops at the paths that OPEN the picker. See
+     * the two tests below for why `change` and `drop` must NOT be gated.
+     */
+    describe('blocks the paths that open the file picker while disabled', () => {
+      it('keyboard (Enter/Space) does not open the file picker while disabled, and does again once re-enabled', () => {
+        const dz = dropzone.shadowRoot!.querySelector('.dropzone') as HTMLElement;
+        const input = dropzone.shadowRoot!.querySelector('input[type="file"]') as HTMLInputElement;
+        const spy = vi.spyOn(input, 'click').mockImplementation(() => {});
+
+        dropzone.setEnabled(false);
+        dz.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }));
+        dz.dispatchEvent(new KeyboardEvent('keydown', { key: ' ', bubbles: true }));
+        expect(spy).not.toHaveBeenCalled();
+
+        dropzone.setEnabled(true);
+        dz.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }));
+        expect(spy).toHaveBeenCalledTimes(1);
+      });
+    });
+
+    /**
+     * The other half of the contract, and the more important half.
+     *
+     * Once a file has actually been chosen or dropped, it must be honoured
+     * even if the model is still preloading. Discarding it silently is a
+     * worse failure than starting slightly early: the picker just closes
+     * and nothing happens, with nothing on screen explaining why.
+     *
+     * Starting early is safe because `loadModel()` dedupes in-flight loads
+     * (see async-call-dedupe), so a file arriving mid-preload joins the
+     * download already running rather than starting a second one.
+     *
+     * This is also the contract the Playwright suites depend on:
+     * `setInputFiles()` writes straight to the input and fires `change`
+     * without ever going through `dropArea.click()`, right after
+     * `networkidle` — i.e. typically before the preload has resolved.
+     */
+    describe('honours a file the user already committed, even while disabled', () => {
+      it('the fileInput change event still dispatches ar:image-loaded while disabled', async () => {
+        const input = dropzone.shadowRoot!.querySelector('input[type="file"]') as HTMLInputElement;
+        const dispatched = vi.fn();
+        dropzone.addEventListener('ar:image-loaded', dispatched);
+
+        dropzone.setEnabled(false);
+        Object.defineProperty(input, 'files', {
+          value: makeFileList([makePngFile('while-disabled.png')]),
+          configurable: true,
+        });
+        input.dispatchEvent(new Event('change', { bubbles: true }));
+        await Promise.resolve();
+        await Promise.resolve();
+        expect(dispatched).toHaveBeenCalledTimes(1);
+      });
+
+      it('drop still dispatches ar:image-loaded while disabled', async () => {
+        const dz = dropzone.shadowRoot!.querySelector('.dropzone') as HTMLElement;
+        const dispatched = vi.fn();
+        dropzone.addEventListener('ar:image-loaded', dispatched);
+
+        dropzone.setEnabled(false);
+        const ev = new DragEvent('drop', { bubbles: true });
+        Object.defineProperty(ev, 'dataTransfer', {
+          value: { files: makeFileList([makePngFile('while-disabled.png')]) },
+        });
+        dz.dispatchEvent(ev);
+        await Promise.resolve();
+        await Promise.resolve();
+        expect(dispatched).toHaveBeenCalledTimes(1);
+      });
+    });
   });
 
   // ─── setLoadingState ──────────────────────────────────────────────────────

--- a/packages/nukebg-app/tests/lib/async-call-dedupe.test.ts
+++ b/packages/nukebg-app/tests/lib/async-call-dedupe.test.ts
@@ -1,0 +1,100 @@
+import { describe, it, expect, vi } from 'vitest';
+import { AsyncCallDedupe } from '../../src/lib/async-call-dedupe';
+
+/**
+ * Behavioural tests for `AsyncCallDedupe` (in-flight async call dedupe).
+ *
+ * This is the extracted, directly-testable core of the ml.worker.ts
+ * `loadModel()` fix: two concurrent `loadModel()` calls for the same
+ * modelId must invoke `transformers.pipeline()` exactly ONCE instead of
+ * starting two independent ~45MB downloads. `ml.worker.ts` itself can't
+ * be unit-tested here — it imports `@huggingface/transformers` dynamically
+ * and relies on worker-global `self.postMessage`/`onmessage`, which the
+ * rest of the test suite deliberately avoids driving directly (see
+ * tests/pipeline/model-integrity.test.ts's comment on the same point) —
+ * so this test exercises the dedupe mechanism in isolation instead.
+ */
+
+describe('AsyncCallDedupe', () => {
+  it('invokes factory() only once for two concurrent calls with the same key, and both callers resolve', async () => {
+    const dedupe = new AsyncCallDedupe<string>();
+    const factory = vi.fn(
+      () =>
+        new Promise<string>((resolve) => {
+          setTimeout(() => resolve('loaded'), 10);
+        }),
+    );
+
+    const callA = dedupe.run('model-x', factory);
+    const callB = dedupe.run('model-x', factory);
+
+    const [resultA, resultB] = await Promise.all([callA, callB]);
+
+    expect(factory).toHaveBeenCalledTimes(1);
+    expect(resultA).toBe('loaded');
+    expect(resultB).toBe('loaded');
+  });
+
+  it('clears the in-flight entry once the call settles, so a later call for the same key starts a fresh factory() run', async () => {
+    const dedupe = new AsyncCallDedupe<string>();
+    const factory = vi.fn(async () => 'loaded');
+
+    await dedupe.run('model-x', factory);
+    expect(dedupe.size).toBe(0);
+
+    await dedupe.run('model-x', factory);
+
+    expect(factory).toHaveBeenCalledTimes(2);
+  });
+
+  it('clears the in-flight entry on FAILURE too, so a failed call can be retried instead of permanently caching a rejection', async () => {
+    const dedupe = new AsyncCallDedupe<string>();
+    let attempt = 0;
+    const factory = vi.fn(() => {
+      attempt += 1;
+      return attempt === 1 ? Promise.reject(new Error('network error')) : Promise.resolve('loaded');
+    });
+
+    await expect(dedupe.run('model-x', factory)).rejects.toThrow('network error');
+    expect(dedupe.size).toBe(0);
+
+    await expect(dedupe.run('model-x', factory)).resolves.toBe('loaded');
+    expect(factory).toHaveBeenCalledTimes(2);
+  });
+
+  it('a joiner that arrives while a call is in flight also rejects when the initiator fails, without calling factory() itself', async () => {
+    const dedupe = new AsyncCallDedupe<string>();
+    let rejectFirst!: (err: Error) => void;
+    const factory = vi.fn(
+      () =>
+        new Promise<string>((_, reject) => {
+          rejectFirst = reject;
+        }),
+    );
+
+    const callA = dedupe.run('model-x', factory);
+    const callB = dedupe.run('model-x', factory);
+
+    rejectFirst(new Error('boom'));
+
+    await expect(callA).rejects.toThrow('boom');
+    await expect(callB).rejects.toThrow('boom');
+    expect(factory).toHaveBeenCalledTimes(1);
+  });
+
+  it('runs independent factories for different keys concurrently', async () => {
+    const dedupe = new AsyncCallDedupe<string>();
+    const factoryX = vi.fn(async () => 'x-loaded');
+    const factoryY = vi.fn(async () => 'y-loaded');
+
+    const [resultX, resultY] = await Promise.all([
+      dedupe.run('model-x', factoryX),
+      dedupe.run('model-y', factoryY),
+    ]);
+
+    expect(factoryX).toHaveBeenCalledTimes(1);
+    expect(factoryY).toHaveBeenCalledTimes(1);
+    expect(resultX).toBe('x-loaded');
+    expect(resultY).toBe('y-loaded');
+  });
+});


### PR DESCRIPTION
Ships #377. Follow-up to the #375 hotfix already released in #378.

Three defects found while tracing #375. None caused it — they sit on the same code path.

- **`loadModel()` had no in-flight dedupe.** Its only guard was `segmenters.has(modelId)`, not populated until `transformers.pipeline()` and the integrity check resolve. A caller arriving in that window started an independent load: a second ~45 MB download and a second WASM session in one worker. The window is real — the page-load `preload()` races the auto-load `segment()` performs when no model is resident.
- **`setEnabled(false)` did not disable anything.** It only added a CSS class whose sole guard is `pointer-events: none`, which stops the mouse and nothing else — Enter/Space still opened the file picker.
- **A leaked `window` listener.** The error-modal `keydown` handler was registered without the component's `AbortSignal`, so it outlived `disconnectedCallback()` holding a reference to a detached shadow root.

Also corrects the `abort()` docstring, which claimed the next segment call re-loads from the Service Worker cache. It does not: the SW excludes the HF hosts outright, and transformers.js only populates `transformers-cache` after a download completes.

### One thing worth reading before approving

The first push of #377 failed all three Playwright suites. My regression, caught by CI and fixed in the same PR — see [the write-up on #377](https://github.com/yocreoquesi/nukebg/pull/377#issuecomment-5609810134).

Short version: the dropzone guard initially gated `change` and `drop` too, which swallowed files that `setInputFiles()` delivers before the preload resolves. The e2e was right and the guard was wrong — a file the user already committed must never be silently discarded. The guard now covers only the paths that open the picker, and the dedupe above is what makes an early start safe. The regression is now pinned by unit tests that fail in 4ms rather than an 11-minute e2e run.

### CI

All green: `Typecheck + tests` (774/774 across 58 files), `Lint + format`, CodeQL, Cloudflare Pages, and all three Playwright suites back to ~3 min.

`OSV-Scanner` and `npm audit` still fail exactly as they do on `main` — no dependency files touched here. `sharp 0.34.5` / GHSA-rgj7-g3m4-5g8c (CVSS 8.9) is real and needs its own lockfile PR: the `osv-scanner.toml` exception claims 0.35.3 is the latest available, and **0.35.4 exists and fixes it**.

https://claude.ai/code/session_013QHMsfPmMMTY77jRWc8Hvb