### PR TITLE
refactor(editor): extract stroke painting out of the advanced editor

### DIFF
--- a/packages/nukebg-app/src/components/ar-editor-advanced.ts
+++ b/packages/nukebg-app/src/components/ar-editor-advanced.ts
@@ -39,6 +39,7 @@ import { t } from '../i18n';
 import { type Point } from './lasso-simplify';
 import { LassoModel } from '../lib/lasso-model';
 import { HistoryManager } from '../lib/history-manager';
+import { paintStrokeSegment } from '../lib/stroke-painter';
 import { emit } from '../lib/event-bus';
 import { renderArEditorAdvancedTemplate } from './ar-editor-advanced.template';
 import { DEFAULT_BRUSH, MIN_BRUSH, MAX_BRUSH } from './ar-editor-advanced.constants';
@@ -773,77 +774,21 @@ export class ArEditorAdvanced extends HTMLElement {
     return this.lasso.hitAnchor(ix, iy, this.anchorRadius() + 4);
   }
 
+  /**
+   * Paint one segment of the current stroke onto the working canvas.
+   *
+   * Thin adapter over `paintStrokeSegment` since #255. The drawing itself
+   * moved to src/lib/stroke-painter.ts; what stayed here is reading the five
+   * pieces of editor state it depends on and handing them over explicitly.
+   */
   private applyStrokeSegment(fromX: number, fromY: number, toX: number, toY: number): void {
     if (!this.working) return;
-    const wctx = this.working.getContext('2d')!;
-    const r = this.brushRadius;
-
-    const square = this.brushShape === 'square';
-
-    if (this.tool === 'eraser') {
-      wctx.save();
-      wctx.globalCompositeOperation = 'destination-out';
-      if (square) {
-        // A stroked line is only `2r` wide perpendicular to motion, so on
-        // a diagonal drag it erases a narrower band than the square
-        // cursor promises. Stamping axis-aligned squares along the
-        // segment gives the true swept footprint, and covers the
-        // single-click case for free. Same stepping the brush uses.
-        this.stampAlong(fromX, fromY, toX, toY, r, (cx, cy) =>
-          wctx.fillRect(cx - r, cy - r, r * 2, r * 2),
-        );
-      } else {
-        wctx.lineCap = 'round';
-        wctx.lineJoin = 'round';
-        wctx.lineWidth = r * 2;
-        wctx.beginPath();
-        wctx.moveTo(fromX, fromY);
-        wctx.lineTo(toX, toY);
-        wctx.stroke();
-      }
-      wctx.restore();
-      return;
-    }
-
-    if (this.tool !== 'brush' || !this.originalBacking) return;
-    const backing = this.originalBacking;
-    this.stampAlong(fromX, fromY, toX, toY, r, (cx, cy) => {
-      wctx.save();
-      wctx.beginPath();
-      if (square) {
-        wctx.rect(cx - r, cy - r, r * 2, r * 2);
-      } else {
-        wctx.arc(cx, cy, r, 0, Math.PI * 2);
-      }
-      wctx.clip();
-      wctx.drawImage(backing, 0, 0);
-      wctx.restore();
+    paintStrokeSegment(this.working.getContext('2d')!, fromX, fromY, toX, toY, {
+      tool: this.tool,
+      shape: this.brushShape,
+      radius: this.brushRadius,
+      backing: this.originalBacking,
     });
-  }
-
-  /**
-   * Walk a segment in steps small enough that consecutive stamps overlap,
-   * calling `stamp` at each centre. Shared by the brush and the square
-   * eraser so both trace the same path density; a single click yields one
-   * stamp rather than nothing.
-   */
-  private stampAlong(
-    fromX: number,
-    fromY: number,
-    toX: number,
-    toY: number,
-    r: number,
-    stamp: (cx: number, cy: number) => void,
-  ): void {
-    const dx = toX - fromX;
-    const dy = toY - fromY;
-    const dist = Math.hypot(dx, dy);
-    const step = Math.max(1, r * 0.4);
-    const steps = Math.max(1, Math.ceil(dist / step));
-    for (let i = 0; i <= steps; i++) {
-      const tfrac = i / steps;
-      stamp(fromX + dx * tfrac, fromY + dy * tfrac);
-    }
   }
 
   private applyTransform(): void {

--- a/packages/nukebg-app/src/lib/stroke-painter.ts
+++ b/packages/nukebg-app/src/lib/stroke-painter.ts
@@ -1,0 +1,129 @@
+/**
+ * Canvas painting for the advanced editor's brush and eraser.
+ *
+ * Extracted from `ar-editor-advanced.ts` in #255. The component read five
+ * pieces of its own state inside `applyStrokeSegment` — tool, shape, radius,
+ * working canvas, original backing — and the extraction turns those implicit
+ * reads into an explicit signature. That is the point of the move, more than
+ * the line count: what a stroke depends on is now readable without tracing
+ * `this` through a 1700-line component.
+ *
+ * NOT to be confused with `brush-stroke.ts` in this same directory, despite
+ * the names. That one is a value type that walks an ImageData buffer with
+ * nested pixel loops, extracted from the since-deleted `ar-editor.ts`; it has
+ * no callers and is proposed for deletion in #392. This one issues canvas 2D
+ * operations. Same idea, different mechanism, no shared code.
+ *
+ * The drawing behaviour here is pinned by
+ * `tests/components/ar-editor-advanced-drawing.test.ts` (#387), which records
+ * the ordered sequence of context calls a stroke produces. Those tests were
+ * written against the pre-extraction component and must keep passing
+ * unedited — if a change here needs one of them rewritten, that is a
+ * behaviour change wearing a refactor's clothes.
+ */
+
+/** Tools that paint. The editor's `lasso` reaches none of this. */
+export type PaintTool = 'brush' | 'eraser';
+
+export type StrokeShape = 'circle' | 'square';
+
+export interface StrokeOptions {
+  /** Anything other than 'brush' or 'eraser' paints nothing. */
+  tool: PaintTool | string;
+  shape: StrokeShape;
+  /** Radius in image pixels. The caller is responsible for clamping it. */
+  radius: number;
+  /**
+   * Source the brush repaints from — the pre-edit image. Null means the brush
+   * has nothing to restore and does nothing; the eraser never reads it.
+   */
+  backing: CanvasImageSource | null;
+}
+
+/**
+ * Walk a segment in steps small enough that consecutive stamps overlap,
+ * calling `stamp` at each centre. Shared by the brush and the square eraser
+ * so both trace the same path density; a single click yields one stamp
+ * rather than nothing.
+ *
+ * Note the stamp *positions* are `from + delta * (i / steps)`, so the step
+ * size decides how many stamps there are, not how far apart they land. That
+ * distinction matters when testing this: a change to the 0.4 factor is
+ * invisible at radii where `max(1, …)` floors it, and at distances where
+ * both factors round to the same `steps`. See the note in the drawing tests.
+ */
+export function stampAlong(
+  fromX: number,
+  fromY: number,
+  toX: number,
+  toY: number,
+  r: number,
+  stamp: (cx: number, cy: number) => void,
+): void {
+  const dx = toX - fromX;
+  const dy = toY - fromY;
+  const dist = Math.hypot(dx, dy);
+  const step = Math.max(1, r * 0.4);
+  const steps = Math.max(1, Math.ceil(dist / step));
+  for (let i = 0; i <= steps; i++) {
+    const tfrac = i / steps;
+    stamp(fromX + dx * tfrac, fromY + dy * tfrac);
+  }
+}
+
+/**
+ * Paint one segment of a stroke onto `ctx`.
+ *
+ * The eraser punches alpha out with `destination-out`; the brush clips to the
+ * stamp footprint and repaints from `backing`, which is what makes it an undo
+ * of the erase rather than a paint in some colour.
+ */
+export function paintStrokeSegment(
+  ctx: CanvasRenderingContext2D,
+  fromX: number,
+  fromY: number,
+  toX: number,
+  toY: number,
+  opts: StrokeOptions,
+): void {
+  const r = opts.radius;
+  const square = opts.shape === 'square';
+
+  if (opts.tool === 'eraser') {
+    ctx.save();
+    ctx.globalCompositeOperation = 'destination-out';
+    if (square) {
+      // A stroked line is only `2r` wide perpendicular to motion, so on
+      // a diagonal drag it erases a narrower band than the square
+      // cursor promises. Stamping axis-aligned squares along the
+      // segment gives the true swept footprint, and covers the
+      // single-click case for free. Same stepping the brush uses.
+      stampAlong(fromX, fromY, toX, toY, r, (cx, cy) => ctx.fillRect(cx - r, cy - r, r * 2, r * 2));
+    } else {
+      ctx.lineCap = 'round';
+      ctx.lineJoin = 'round';
+      ctx.lineWidth = r * 2;
+      ctx.beginPath();
+      ctx.moveTo(fromX, fromY);
+      ctx.lineTo(toX, toY);
+      ctx.stroke();
+    }
+    ctx.restore();
+    return;
+  }
+
+  if (opts.tool !== 'brush' || !opts.backing) return;
+  const backing = opts.backing;
+  stampAlong(fromX, fromY, toX, toY, r, (cx, cy) => {
+    ctx.save();
+    ctx.beginPath();
+    if (square) {
+      ctx.rect(cx - r, cy - r, r * 2, r * 2);
+    } else {
+      ctx.arc(cx, cy, r, 0, Math.PI * 2);
+    }
+    ctx.clip();
+    ctx.drawImage(backing, 0, 0);
+    ctx.restore();
+  });
+}

--- a/packages/nukebg-app/tests/components/ar-advanced-toolbar.test.ts
+++ b/packages/nukebg-app/tests/components/ar-advanced-toolbar.test.ts
@@ -211,31 +211,32 @@ describe('ar-editor-advanced — lasso actions are ranked (#346)', () => {
  * shape, which is the part that would make the port cosmetic if it broke.
  */
 describe('ar-editor-advanced — brush shape reaches the pixels (#346)', () => {
-  it('the stroke routine branches on shape for both eraser and brush', () => {
-    const fn = ED.match(/private applyStrokeSegment\([\s\S]*?\r?\n {2}\}/);
-    expect(fn).not.toBeNull();
-    const body = fn![0];
-    expect(body).toMatch(/const square = this\.brushShape === 'square';/);
-    // Square eraser stamps along the segment rather than stroking a
-    // line: a stroke is only 2r wide perpendicular to motion, so a
-    // diagonal drag would erase a narrower band than the cursor shows.
-    // Stamping also covers the single-click case, which butt caps did not.
-    expect(body).toMatch(/this\.stampAlong\(fromX, fromY, toX, toY, r,/);
-    expect(body).toMatch(/fillRect\(cx - r, cy - r, r \* 2, r \* 2\)/);
-    // Round eraser keeps the cheaper stroked path.
-    expect(body).toMatch(/lineCap = 'round'/);
-    // Brush: clip to a rect instead of an arc.
-    expect(body).toMatch(/wctx\.rect\(cx - r, cy - r, r \* 2, r \* 2\)/);
-    expect(body).toMatch(/wctx\.arc\(cx, cy, r, 0, Math\.PI \* 2\)/);
-  });
-
-  it('brush and square eraser share one stepping routine', () => {
-    // Both must trace the same path density, and a single click has to
-    // produce one stamp rather than nothing.
-    expect(ED).toMatch(/private stampAlong\(/);
-    const fn = ED.match(/private stampAlong\([\s\S]*?\r?\n {2}\}/);
-    expect(fn![0]).toMatch(/const steps = Math\.max\(1, Math\.ceil\(dist \/ step\)\)/);
-  });
+  /*
+   * Two tests lived here asserting the stroke internals by regex — that
+   * `applyStrokeSegment` read `this.brushShape`, that `private stampAlong(`
+   * existed, that the bodies contained particular fillRect/arc/rect calls.
+   *
+   * They were removed when the painting moved to src/lib/stroke-painter.ts
+   * in #255, because every behaviour they were reaching for is now asserted
+   * directly in ar-editor-advanced-drawing.test.ts (#387), against the
+   * recorded sequence of canvas operations rather than the source text:
+   *
+   *   fillRect(cx-r, cy-r, 2r, 2r)  -> exact trace `fillRect(0,0,4,4)`
+   *   lineCap = 'round'             -> exact trace with `lineCap=round`
+   *   wctx.rect(cx-r, ...)          -> exact trace `rect(0,0,4,4)`
+   *   wctx.arc(cx, cy, r, 0, 2pi)   -> exact trace `arc(2,2,2,0,6.283...)`
+   *   steps = max(1, ceil(d/step))  -> three spacing tests, one of which
+   *                                    pins the 0.4 factor specifically
+   *
+   * What did not survive the move is the structural half — the name
+   * `stampAlong`, the `this.` receiver, the `private` keyword — and that is
+   * the half a refactor is allowed to change. Deleting rather than
+   * rewriting them is the call #135's triage prescribed: migrate an
+   * affected source-pattern test as part of the refactor that affects it.
+   *
+   * The two tests below still read the source, because what they assert
+   * (cursor preview, disabled-state toggling) has no behavioural reach yet.
+   */
 
   it('the on-canvas cursor shows the shape it will paint with', () => {
     expect(ED).toMatch(/if \(this\.brushShape === 'square'\) \{[\s\S]*?this\.ctx\.rect\(/);


### PR DESCRIPTION
Third slice of #255, and the first to move **logic** rather than text. Does not close it.

`ar-editor-advanced.ts`: **1749 → 1694 lines**. `applyStrokeSegment` and `stampAlong` move to `src/lib/stroke-painter.ts`.

### The line count is not the point

55 lines is a rounding error on a 1700-line component. What the move actually buys:

```diff
-private applyStrokeSegment(fromX, fromY, toX, toY): void {
-  const wctx = this.working.getContext('2d')!;
-  const r = this.brushRadius;
-  const square = this.brushShape === 'square';
-  if (this.tool === 'eraser') { … }
-  if (this.tool !== 'brush' || !this.originalBacking) return;
+export function paintStrokeSegment(ctx, fromX, fromY, toX, toY, opts: {
+  tool; shape; radius; backing;
+}): void
```

Five implicit `this` reads become an explicit signature. What a stroke depends on is readable without tracing through the component, and the painting is testable without mounting one.

### The acceptance criterion was set in advance, and met

#390 landed 16 characterization tests with a stated rule: **they must pass unedited.** They do — `git diff` on that file is empty.

Stronger than that, the mutation battery from #390 was re-run against the new module, and **every failure count is identical to before the move**:

| Mutation | Before | After |
|---|---|---|
| `step = max(1, r * 0.4)` → `r * 0.5` | 1 | 1 |
| eraser `destination-out` → `source-over` | 3 | 3 |
| square stamp `2r` → `2r + 1` | 2 | 2 |
| circle eraser `lineWidth = 2r` → `r` | 2 | 2 |
| brush `arc(…, 2π)` → `arc(…, π)` | 1 | 1 |
| `i <= steps` → `i < steps` | 4 | 4 |
| brush square `rect(…)` → `arc(…)` | 1 | 1 |

Same seven caught, same counts. The net reaches through the extraction rather than merely surviving it.

Comparing the moved code directly: every drawing operation is identical and the stepping maths is byte-for-byte the same. The only textual differences are the declaration line and prettier rejoining a callback that fits on one line now it has lost two levels of indentation.

### Two source-pattern tests removed, not rewritten

`ar-advanced-toolbar.test.ts` had two tests asserting the internals by regex — that the body read `this.brushShape`, that `private stampAlong(` existed, that particular calls appeared in particular method bodies.

Every behaviour they were reaching for is now asserted more precisely by the drawing suite, against recorded canvas operations instead of source text:

| Old assertion | Now |
|---|---|
| `/fillRect\(cx - r, cy - r, r \* 2, r \* 2\)/` | exact trace `fillRect(0,0,4,4)` |
| `/lineCap = 'round'/` | exact trace containing `lineCap=round` |
| `/wctx\.rect\(cx - r, …\)/` | exact trace `rect(0,0,4,4)` |
| `/wctx\.arc\(cx, cy, r, 0, Math\.PI \* 2\)/` | exact trace `arc(2,2,2,0,6.283…)` |
| `/steps = Math\.max\(1, Math\.ceil\(dist \/ step\)\)/` | three spacing tests, one pinning the 0.4 factor |

What did not survive is the structural half — the method name, the `this.` receiver, the `private` keyword — which is precisely the half a refactor is allowed to change.

Removing rather than rewriting is the call #135's triage prescribed: *"migrating the affected test to behavioural is part of the refactor scope"*. A comment stands where they were with the mapping above, so the trail is not lost. The block's other two tests stay — they assert cursor preview and disabled-state toggling, which have no behavioural reach yet.

### One thing caught during the work, worth mentioning

My first attempt at the excision computed its end boundary by searching forward from `stampAlong` for a `});` — which that method does not contain, so it matched something much later and **deleted 699 lines instead of 72**. The component dropped to 1067 and I reverted immediately.

Nothing shipped, but it is the argument for checking the shape of a mechanical edit rather than only its result: the tests would still have had plenty to say, but a 682-line deletion is the kind of thing that is much cheaper to catch at the diff than at the test.

The second attempt bounded the block by line number and printed the seams before touching anything: 72 lines, 776–847, ending immediately before `applyTransform`.

### Naming

`stroke-painter.ts`, not `brush-stroke.ts` — `src/lib/brush-stroke.ts` already exists, is dead code from the deleted `ar-editor.ts`, and is proposed for removal in #392. Different mechanism (ImageData pixel loops vs canvas operations), no shared code. The new file's header says so explicitly while both exist.

### Verification

`typecheck` 0 · `lint` 0 · **1256 tests** across three workspaces.

### Remaining for #255

Component at 1694. History/undo-redo (~150) and canvas IO (~250) still to come, plus the rest of the tool state (`setTool`, `syncToolUI`, `syncCmdBar`) which is UI wiring and may be better left in place.

https://claude.ai/code/session_013QHMsfPmMMTY77jRWc8Hvb