### PR TITLE
fix(security): verify the RMBG weights on both download paths, not one

### DIFF
--- a/packages/nukebg-app/src/lib/verify-rmbg-integrity.ts
+++ b/packages/nukebg-app/src/lib/verify-rmbg-integrity.ts
@@ -1,0 +1,66 @@
+import { RMBG_PARAMS } from 'nukebg-core';
+
+/**
+ * Supply-chain integrity check for the RMBG-1.4 weights.
+ *
+ * Lifted out of `ml.worker.ts` in #397 so both download paths can use it.
+ * It had lived inside the worker, which meant the worker verified its
+ * download and `refine/loaders/rmbg14.ts` — reached from the advanced
+ * editor's Reprocess / Crop / Refine buttons — verified nothing, while the
+ * surrounding code read as though the model was checked everywhere. Nothing
+ * here was ever worker-specific: `caches` and `crypto.subtle` exist on the
+ * main thread too, so the split was accidental rather than designed.
+ *
+ * Call it AFTER `transformers.pipeline()` resolves — by then the quantized
+ * ONNX lives in the standard browser Cache API (`transformers-cache`) — and
+ * BEFORE exposing the pipeline to inference. On mismatch it evicts the
+ * cache entry and throws, so the caller must not retain the pipeline it
+ * just built; the next load then re-fetches from upstream.
+ *
+ * Verification is best-effort and never blocks a working install: it skips
+ * silently when the Cache API is unavailable (http context, cross-origin
+ * restrictions) or when the blob is not in the cache. That is deliberate —
+ * a browser that cannot expose the cache is not evidence of tampering — but
+ * it does mean a passing call is not proof the bytes were checked. Only a
+ * throw is proof they were checked and failed.
+ */
+export async function verifyRmbgIntegrity(modelId: string): Promise<void> {
+  if (modelId !== 'briaai/RMBG-1.4') return;
+  if (typeof caches === 'undefined') return;
+
+  let cache: Cache;
+  try {
+    cache = await caches.open(RMBG_PARAMS.CACHE_NAME);
+  } catch {
+    return;
+  }
+
+  const resp = await cache.match(RMBG_PARAMS.MODEL_URL);
+  if (!resp) {
+    console.warn(
+      '[NukeBG ML] Model blob not found in transformers cache — integrity check skipped.',
+    );
+    return;
+  }
+
+  const buf = await resp.arrayBuffer();
+  if (buf.byteLength !== RMBG_PARAMS.EXPECTED_SIZE) {
+    await cache.delete(RMBG_PARAMS.MODEL_URL);
+    throw new Error(
+      `RMBG-1.4 model size mismatch: got ${buf.byteLength} bytes, expected ` +
+        `${RMBG_PARAMS.EXPECTED_SIZE}. Cache evicted; reload to re-fetch.`,
+    );
+  }
+
+  const digestBuf = await crypto.subtle.digest('SHA-256', buf);
+  const digestHex = Array.from(new Uint8Array(digestBuf))
+    .map((b) => b.toString(16).padStart(2, '0'))
+    .join('');
+  if (digestHex !== RMBG_PARAMS.EXPECTED_SHA256) {
+    await cache.delete(RMBG_PARAMS.MODEL_URL);
+    throw new Error(
+      `RMBG-1.4 hash mismatch: got ${digestHex}, expected ${RMBG_PARAMS.EXPECTED_SHA256}. ` +
+        `Cache evicted; reload to re-fetch.`,
+    );
+  }
+}

--- a/packages/nukebg-app/src/refine/loaders/rmbg14.ts
+++ b/packages/nukebg-app/src/refine/loaders/rmbg14.ts
@@ -1,16 +1,34 @@
 /**
- * RMBG-1.4 loader for the lab — Transformers.js on the main thread.
+ * RMBG-1.4 loader on the main thread — Transformers.js.
  *
  * Mirrors the config used by src/workers/ml.worker.ts (INT8 quant, pinned
- * revision SHA) so lab measurements track the real production baseline.
- * Kept as a separate main-thread instance rather than plumbing into the
- * worker so the lab can be invoked with simple sync calls from the
- * compare viewer / bbox-refine. Extra ~45MB in memory is acceptable for
- * staging-only exploration.
+ * revision SHA) and, since #397, its integrity check too.
+ *
+ * This began as a lab-only loader, and its header said so long after it had
+ * stopped being true. It is reached from three shipped buttons in the
+ * advanced editor — Reprocess, Crop and Refine, all via
+ * `ArEditorAdvanced.getLoader()` — so it downloads ~45MB of model weights
+ * for real users, and used to do it without verifying a byte while the
+ * worker beside it verified everything.
+ *
+ * The second in-memory copy of the model was accepted on the grounds that
+ * this was "staging-only exploration". That reason has expired with the
+ * header; whether the editor should route through the worker instead is a
+ * separate question from verification, tracked on #397.
  */
 
+import { RMBG_PARAMS } from 'nukebg-core';
+import { verifyRmbgIntegrity } from '../../lib/verify-rmbg-integrity';
+
 const MODEL_ID = 'briaai/RMBG-1.4';
-const MODEL_REVISION = '2ceba5a5efaec153162aedea169f76caf9b46cf8';
+/**
+ * Imported rather than restated. It used to be a literal copy of
+ * RMBG_PARAMS.REVISION with nothing asserting the two stayed equal — and
+ * they must, because the audited EXPECTED_SHA256 belongs to exactly one
+ * revision. If they had drifted, this path would have downloaded weights
+ * the integrity check could only reject.
+ */
+const MODEL_REVISION = RMBG_PARAMS.REVISION;
 
 export interface SegmentInput {
   /** Packed RGBA pixels at arbitrary resolution. */
@@ -79,6 +97,12 @@ export function createRmbg14Loader(): Rmbg14Loader {
       dtype: 'q8',
       revision: MODEL_REVISION,
     });
+    // Same order the worker uses: verify once the weights are in the Cache
+    // API, before the pipeline is exposed. On failure the entry is evicted
+    // and this throws, and `segPipeline` stays null so the next call
+    // re-fetches rather than reusing an unverified pipeline.
+    await verifyRmbgIntegrity(MODEL_ID);
+
     segPipeline = pipe as unknown as SegPipeline;
     return segPipeline;
   }

--- a/packages/nukebg-app/src/workers/ml.worker.ts
+++ b/packages/nukebg-app/src/workers/ml.worker.ts
@@ -12,6 +12,7 @@ import type {
 } from '../types/worker-messages';
 import { refineMask, RMBG_PARAMS } from 'nukebg-core';
 import { AsyncCallDedupe } from '../lib/async-call-dedupe';
+import { verifyRmbgIntegrity } from '../lib/verify-rmbg-integrity';
 
 const DEFAULT_MODEL: ModelId = 'briaai/RMBG-1.4';
 
@@ -22,59 +23,6 @@ const DEFAULT_MODEL: ModelId = 'briaai/RMBG-1.4';
 const MODEL_REVISIONS: Record<ModelId, string> = {
   'briaai/RMBG-1.4': RMBG_PARAMS.REVISION,
 };
-
-/**
- * Supply-chain integrity check for RMBG-1.4. Runs AFTER
- * `transformers.pipeline()` resolves — by then the quantized ONNX
- * lives in the standard browser Cache API (`transformers-cache`).
- * We re-read the cached blob, SHA-256 it, and either accept it or
- * evict the entry and throw so the orchestrator surfaces an error
- * and the next reload re-fetches from upstream.
- *
- * Skips silently if the Cache API is unavailable (e.g. http context,
- * cross-origin restrictions) — verification is best-effort and never
- * blocks a working install.
- */
-async function verifyRmbgIntegrity(modelId: ModelId): Promise<void> {
-  if (modelId !== 'briaai/RMBG-1.4') return;
-  if (typeof caches === 'undefined') return;
-
-  let cache: Cache;
-  try {
-    cache = await caches.open(RMBG_PARAMS.CACHE_NAME);
-  } catch {
-    return;
-  }
-
-  const resp = await cache.match(RMBG_PARAMS.MODEL_URL);
-  if (!resp) {
-    console.warn(
-      '[NukeBG ML] Model blob not found in transformers cache — integrity check skipped.',
-    );
-    return;
-  }
-
-  const buf = await resp.arrayBuffer();
-  if (buf.byteLength !== RMBG_PARAMS.EXPECTED_SIZE) {
-    await cache.delete(RMBG_PARAMS.MODEL_URL);
-    throw new Error(
-      `RMBG-1.4 model size mismatch: got ${buf.byteLength} bytes, expected ` +
-        `${RMBG_PARAMS.EXPECTED_SIZE}. Cache evicted; reload to re-fetch.`,
-    );
-  }
-
-  const digestBuf = await crypto.subtle.digest('SHA-256', buf);
-  const digestHex = Array.from(new Uint8Array(digestBuf))
-    .map((b) => b.toString(16).padStart(2, '0'))
-    .join('');
-  if (digestHex !== RMBG_PARAMS.EXPECTED_SHA256) {
-    await cache.delete(RMBG_PARAMS.MODEL_URL);
-    throw new Error(
-      `RMBG-1.4 hash mismatch: got ${digestHex}, expected ${RMBG_PARAMS.EXPECTED_SHA256}. ` +
-        `Cache evicted; reload to re-fetch.`,
-    );
-  }
-}
 
 /** Transformers.js pipeline entry - shape is dynamic from the library */
 interface SegmenterEntry {

--- a/packages/nukebg-app/tests/lib/verify-rmbg-integrity.test.ts
+++ b/packages/nukebg-app/tests/lib/verify-rmbg-integrity.test.ts
@@ -1,0 +1,130 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { RMBG_PARAMS } from 'nukebg-core';
+import { verifyRmbgIntegrity } from '../../src/lib/verify-rmbg-integrity';
+
+/**
+ * Unit tests for the RMBG supply-chain check (#397).
+ *
+ * These are only possible because the check moved out of `ml.worker.ts`.
+ * While it lived inside the worker it could not be exercised directly, and
+ * that is not incidental to how the gap arose: a control nobody can call in
+ * isolation is a control nobody notices is missing from the other path.
+ *
+ * `crypto.subtle.digest` is stubbed rather than fed real bytes. The point is
+ * not to re-test SHA-256; it is to pin what this function does with the
+ * digest once it has one — accept, or evict and throw.
+ */
+
+const ORIGINAL_CACHES = globalThis.caches;
+
+function mockCache(entry: { byteLength: number } | null) {
+  const del = vi.fn(() => Promise.resolve(true));
+  const cache = {
+    match: vi.fn(() =>
+      Promise.resolve(
+        entry === null
+          ? undefined
+          : ({ arrayBuffer: () => Promise.resolve(entry as unknown as ArrayBuffer) } as Response),
+      ),
+    ),
+    delete: del,
+  };
+  vi.stubGlobal('caches', { open: vi.fn(() => Promise.resolve(cache as unknown as Cache)) });
+  return { cache, del };
+}
+
+/** Make `crypto.subtle.digest` yield exactly `hex`. */
+function stubDigest(hex: string) {
+  const bytes = new Uint8Array((hex.match(/../g) ?? []).map((h) => parseInt(h, 16)));
+  vi.stubGlobal('crypto', {
+    ...globalThis.crypto,
+    subtle: { digest: vi.fn(() => Promise.resolve(bytes.buffer)) },
+  });
+}
+
+describe('verifyRmbgIntegrity (#397)', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    globalThis.caches = ORIGINAL_CACHES;
+  });
+
+  describe('accepts the audited model', () => {
+    it('resolves without evicting when size and hash both match', async () => {
+      const { del } = mockCache({ byteLength: RMBG_PARAMS.EXPECTED_SIZE });
+      stubDigest(RMBG_PARAMS.EXPECTED_SHA256);
+
+      await expect(verifyRmbgIntegrity('briaai/RMBG-1.4')).resolves.toBeUndefined();
+      expect(del).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('rejects and evicts anything else', () => {
+    it('throws on a size mismatch, before hashing anything', async () => {
+      const { del } = mockCache({ byteLength: RMBG_PARAMS.EXPECTED_SIZE - 1 });
+      const digest = vi.fn();
+      vi.stubGlobal('crypto', { ...globalThis.crypto, subtle: { digest } });
+
+      await expect(verifyRmbgIntegrity('briaai/RMBG-1.4')).rejects.toThrow(/size mismatch/);
+      expect(del).toHaveBeenCalledWith(RMBG_PARAMS.MODEL_URL);
+      // Cheap check first: no point hashing 45MB that is already the wrong length.
+      expect(digest).not.toHaveBeenCalled();
+    });
+
+    it('throws on a hash mismatch even when the size is right', async () => {
+      const { del } = mockCache({ byteLength: RMBG_PARAMS.EXPECTED_SIZE });
+      stubDigest('0'.repeat(64));
+
+      await expect(verifyRmbgIntegrity('briaai/RMBG-1.4')).rejects.toThrow(/hash mismatch/);
+      expect(del).toHaveBeenCalledWith(RMBG_PARAMS.MODEL_URL);
+    });
+
+    it('names both digests in the error, so a mismatch is diagnosable', async () => {
+      mockCache({ byteLength: RMBG_PARAMS.EXPECTED_SIZE });
+      stubDigest('a'.repeat(64));
+
+      await expect(verifyRmbgIntegrity('briaai/RMBG-1.4')).rejects.toThrow(
+        new RegExp(`got ${'a'.repeat(64)}, expected ${RMBG_PARAMS.EXPECTED_SHA256}`),
+      );
+    });
+  });
+
+  describe('degrades quietly rather than blocking a working install', () => {
+    /*
+     * Each of these is a deliberate skip, and each also means a passing call
+     * is NOT proof the bytes were checked. Only a throw proves they were
+     * checked and failed. The module header says so; these pin the cases.
+     */
+
+    it('skips when the Cache API is unavailable', async () => {
+      vi.stubGlobal('caches', undefined);
+      await expect(verifyRmbgIntegrity('briaai/RMBG-1.4')).resolves.toBeUndefined();
+    });
+
+    it('skips when caches.open rejects, e.g. a cross-origin restriction', async () => {
+      vi.stubGlobal('caches', { open: vi.fn(() => Promise.reject(new Error('denied'))) });
+      await expect(verifyRmbgIntegrity('briaai/RMBG-1.4')).resolves.toBeUndefined();
+    });
+
+    it('skips, with a warning, when the blob is not cached', async () => {
+      const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      const { del } = mockCache(null);
+
+      await expect(verifyRmbgIntegrity('briaai/RMBG-1.4')).resolves.toBeUndefined();
+      expect(warn).toHaveBeenCalledWith(expect.stringMatching(/integrity check skipped/));
+      expect(del).not.toHaveBeenCalled();
+    });
+
+    it('ignores a model it has no audited hash for', async () => {
+      const opened = vi.fn();
+      vi.stubGlobal('caches', { open: opened });
+
+      await expect(verifyRmbgIntegrity('some/other-model')).resolves.toBeUndefined();
+      // Returns before touching the cache at all.
+      expect(opened).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/packages/nukebg-app/tests/pipeline/model-integrity.test.ts
+++ b/packages/nukebg-app/tests/pipeline/model-integrity.test.ts
@@ -1,4 +1,6 @@
 import { describe, it, expect } from 'vitest';
+import { readFileSync, readdirSync } from 'node:fs';
+import { resolve, join, sep } from 'node:path';
 import { LAMA_PARAMS, MOBILESAM_PARAMS, RMBG_PARAMS } from 'nukebg-core';
 
 /**
@@ -79,12 +81,18 @@ describe('model integrity constants (#132)', () => {
 });
 
 describe('SHA-256 verification primitive (web crypto)', () => {
-  // The actual verifyRmbgIntegrity / fetchModel logic lives inside web
-  // workers, where SubtleCrypto + Cache API are easily exercised end-to-end.
-  // Here we sanity-check that the same primitive both workers rely on
-  // produces stable output for a known input — guards against accidental
-  // encoding changes (e.g. switching to base64) that would silently
-  // bypass the LaMa/SAM/RMBG hash checks.
+  // Sanity-checks that the primitive the hash checks rely on produces stable
+  // output for a known input — guards against an accidental encoding change
+  // (e.g. switching to base64) that would silently bypass LaMa/SAM/RMBG.
+  //
+  // This comment used to say the verification logic "lives inside web
+  // workers, where SubtleCrypto + Cache API are easily exercised end-to-end".
+  // Neither half held: it was never exercised, and being unreachable from a
+  // test is part of how #397 happened — a control nobody can call in
+  // isolation is a control nobody notices is missing from the other path.
+  // RMBG's now lives in src/lib/verify-rmbg-integrity.ts and is tested
+  // directly in tests/lib/verify-rmbg-integrity.test.ts. LaMa and SAM still
+  // verify inline in their own workers.
   it('SHA-256 of the empty buffer is deterministic + lowercase hex', async () => {
     const empty = new Uint8Array(0);
     const digest = await crypto.subtle.digest('SHA-256', empty);
@@ -101,5 +109,68 @@ describe('SHA-256 verification primitive (web crypto)', () => {
       .map((b) => b.toString(16).padStart(2, '0'))
       .join('');
     expect(hex).toBe('2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824');
+  });
+});
+
+/**
+ * The constants above are only worth having if every download path uses
+ * them (#397).
+ *
+ * They did not. `ml.worker.ts` verified its download against
+ * RMBG_PARAMS; `refine/loaders/rmbg14.ts` — reached from the advanced
+ * editor's Reprocess / Crop / Refine buttons — downloaded the same weights,
+ * verified nothing, and restated the revision as its own literal. The
+ * constants were correct the whole time. Nothing checked they were reached.
+ *
+ * These tests are deliberately written over the source tree rather than
+ * against the two known files, so a third loader added later is covered
+ * without anyone remembering to come back here.
+ */
+
+const SRC = resolve(__dirname, '..', '..', 'src');
+
+function tsFilesUnder(dir: string): string[] {
+  const out: string[] = [];
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const full = join(dir, entry.name);
+    if (entry.isDirectory()) out.push(...tsFilesUnder(full));
+    else if (entry.name.endsWith('.ts')) out.push(full);
+  }
+  return out;
+}
+
+const SOURCES = tsFilesUnder(SRC).map((f) => ({
+  // Windows path separators, so the names below read the same on any OS.
+  name: f
+    .slice(SRC.length + 1)
+    .split(sep)
+    .join('/'),
+  text: readFileSync(f, 'utf8'),
+}));
+
+describe('every RMBG download path is verified (#397)', () => {
+  const loaders = SOURCES.filter(
+    (f) => /transformers\.pipeline\(/.test(f.text) && /image-segmentation/.test(f.text),
+  );
+
+  it('finds the loaders at all — a zero here would make the next test vacuous', () => {
+    expect(loaders.map((f) => f.name).sort()).toEqual([
+      'refine/loaders/rmbg14.ts',
+      'workers/ml.worker.ts',
+    ]);
+  });
+
+  it.each(loaders.map((f) => f.name))('%s verifies what it downloaded', (name) => {
+    const file = loaders.find((f) => f.name === name)!;
+    expect(file.text).toMatch(/verifyRmbgIntegrity\(/);
+  });
+
+  it('no source outside the constants restates the pinned revision', () => {
+    // A second copy of the revision can drift from the one the audited
+    // EXPECTED_SHA256 belongs to, and then the check can only ever reject.
+    const offenders = SOURCES.filter((f) => f.text.includes(RMBG_PARAMS.REVISION)).map(
+      (f) => f.name,
+    );
+    expect(offenders, `import RMBG_PARAMS.REVISION instead of hardcoding it`).toEqual([]);
   });
 });


### PR DESCRIPTION
Closes #397.

### The gap

The model was downloaded by two paths and checked on one.

`ml.worker.ts` verified size and SHA-256 against the audited constants, and said so:

```ts
// Supply-chain integrity check: verify the cached q8 ONNX bytes match
// the audited SHA-256 before exposing the pipeline to inference.
```

`refine/loaders/rmbg14.ts` pulled the same weights over the same route:

```
$ grep -n "SHA|sha256|digest|verify|integrity|EXPECTED" src/refine/loaders/rmbg14.ts
(no matches)
```

And that path **ships**. `ar-editor-advanced.ts` reaches it from three buttons — `#reprocess`, `#action-crop`, `#action-refine`, all via `getLoader()`. A user opening the advanced editor and pressing Refine downloaded ~45MB of weights that nothing inspected, on a path the surrounding code documented as verified.

To be precise: this is not a report that anything was tampered with. It is that a control the project deliberately built had a hole, and the reason nobody saw it was a stale header — the file still described a staging experiment that had since been wired into the shipped editor.

### The fix

Nothing about the check was worker-specific — `caches` and `crypto.subtle` exist on the main thread too. The split was accidental rather than designed, so the function moves to `src/lib/verify-rmbg-integrity.ts` **unchanged**, and both paths call it in the same order: after the pipeline resolves and the blob is in the Cache API, before the pipeline is exposed. On failure the loader leaves `segPipeline` null, so a retry re-fetches rather than reusing something unverified.

**Deliberately not done here:** routing the editor through the worker instead of keeping a second in-memory copy. That is the other half of the fork on #397, and it is a memory decision rather than a security one — once both paths verify, the hole is closed either way. Bundling it would have made a security fix carry an architecture change. Left on the issue, with the note that the duplication was accepted *because* the loader was "staging-only", so its justification expired along with the header.

### Two more things that had stopped being true

- The header called it a lab loader for **"staging-only exploration"**. It stopped being staging-only when the editor started calling it, and never caught up.
- It restated the pinned revision as its own literal instead of importing `RMBG_PARAMS.REVISION`. They agreed; nothing enforced it. Had they drifted, this path would have downloaded weights the audited `EXPECTED_SHA256` could only ever reject.

### Tests, in the order they matter

**1. The check is now unit-testable at all**, which it was not inside the worker — and that is not incidental. *A control nobody can call in isolation is a control nobody notices is missing from the other path.*

Eight cases cover accept, size mismatch (asserting it does **not** hash 45MB it already knows is the wrong length), hash mismatch, and each deliberate skip. The skips are worth pinning because they mean **a passing call is not proof the bytes were checked — only a throw is**, and the module header now says so.

**2. `model-integrity.test.ts` gains the invariant its constants never had:** that every path which loads the model actually reaches them. It scans the source tree rather than naming the two known files, so a third loader added later is covered without anyone remembering to come back here.

**3. And that no source outside the constants restates the revision.**

Both new invariants were mutation-checked by **reintroducing the original defects**:

```
remove the call from rmbg14.ts
  × refine/loaders/rmbg14.ts verifies what it downloaded

restore the hardcoded revision literal
  × no source outside the constants restates the pinned revision
    expected [ 'refine/loaders/rmbg14.ts' ] to deeply equal []
```

Both fail naming the offending file. Had these tests existed, the gap would not have reached production.

### Also

Corrects a comment in `model-integrity.test.ts` claiming the verification logic *"lives inside web workers, where SubtleCrypto + Cache API are easily exercised end-to-end"*. It was never exercised — which is the whole story in one sentence.

### Verification

`typecheck` 0 · `lint` 0 · **1268 tests** across three workspaces (820 app + 96 cli + 352 core). 1256 → 1268 is the 12 added here.

https://claude.ai/code/session_013QHMsfPmMMTY77jRWc8Hvb