### PR TITLE
fix(editor): give MIN_ANCHORS a single owner

### DIFF
--- a/packages/nukebg-app/src/components/ar-editor-advanced.ts
+++ b/packages/nukebg-app/src/components/ar-editor-advanced.ts
@@ -51,9 +51,11 @@ const PAD_RATIO = 0.25;
 const MIN_LASSO_POINT_DIST = 2;
 // Fraction of min(w, h) used as Douglas-Peucker epsilon.
 const LASSO_EPS_RATIO = 0.006;
-// Minimum anchors we'll ever let the user delete down to — below this
-// the polygon stops being meaningful.
-const MIN_ANCHORS = 3;
+// MIN_ANCHORS is not declared here. It used to be, as a second `= 3`
+// alongside LassoModel.MIN_ANCHORS, and the two agreed only because nobody
+// had changed either — see #388. LassoModel owns the rule: it holds the
+// anchors, enforces the floor in four places, and is unit-tested. This file
+// now reads it from there.
 
 // View transform. 1 = natural fit (max-width / max-height); zoom multiplies
 // that via a CSS transform on the canvas. Keep in sync with ar-editor.ts.
@@ -1125,7 +1127,7 @@ export class ArEditorAdvanced extends HTMLElement {
     // them just adds visual noise. Match cursor-preview line width (2) for
     // stroke consistency across tools.
     const anchors = this.lasso.getAnchors();
-    if (!this.selectionMask && anchors && anchors.length >= MIN_ANCHORS) {
+    if (!this.selectionMask && anchors && anchors.length >= LassoModel.MIN_ANCHORS) {
       const pts = anchors;
       this.ctx.save();
       const accentRgb2 =
@@ -1222,7 +1224,7 @@ export class ArEditorAdvanced extends HTMLElement {
 
       if (kind === 'refine') {
         const poly = lassoAnchors ? [...lassoAnchors] : this.selectionMaskToPolygon(w, h);
-        if (!poly || poly.length < MIN_ANCHORS) throw new Error('No region for refine');
+        if (!poly || poly.length < LassoModel.MIN_ANCHORS) throw new Error('No region for refine');
         newAlpha = await this.refineWithSam(poly, prevAlpha, w, h, ac.signal);
       } else if (hasMask) {
         newAlpha = new Uint8Array(prevAlpha);
@@ -1358,7 +1360,7 @@ export class ArEditorAdvanced extends HTMLElement {
     if (this.busy) return;
     if (!this.working || !this.current) return;
     const lassoAnchors = this.lasso.getAnchors();
-    if (!lassoAnchors || lassoAnchors.length < MIN_ANCHORS) return;
+    if (!lassoAnchors || lassoAnchors.length < LassoModel.MIN_ANCHORS) return;
 
     const w = this.current.width;
     const h = this.current.height;
@@ -1541,7 +1543,7 @@ export class ArEditorAdvanced extends HTMLElement {
   private async rmbgDecodeFromLasso(): Promise<void> {
     if (!this.current || !this.original) return;
     const lassoAnchors = this.lasso.getAnchors();
-    if (!lassoAnchors || lassoAnchors.length < MIN_ANCHORS) return;
+    if (!lassoAnchors || lassoAnchors.length < LassoModel.MIN_ANCHORS) return;
 
     const w = this.current.width;
     const h = this.current.height;

--- a/packages/nukebg-app/tests/lib/lasso-model.test.ts
+++ b/packages/nukebg-app/tests/lib/lasso-model.test.ts
@@ -1,5 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import { LassoModel } from '../../src/lib/lasso-model';
+import { readFileSync, readdirSync } from 'node:fs';
+import { resolve, join, sep } from 'node:path';
 
 /**
  * Behavioural tests for the LassoModel state machine extracted from
@@ -262,5 +264,76 @@ describe('LassoModel', () => {
       loose.close();
       expect(loose.getAnchors()?.length ?? 0).toBeLessThanOrEqual(tight.getAnchors()?.length ?? 0);
     });
+  });
+});
+
+/**
+ * LassoModel owns the minimum-anchor rule (#388).
+ *
+ * `ar-editor-advanced.ts` used to declare its own `const MIN_ANCHORS = 3`
+ * beside `LassoModel.MIN_ANCHORS`, and enforce it independently in four
+ * places. They agreed only because nobody had changed either. Changing one
+ * would have left a lasso that can be simplified below the minimum on one
+ * code path and not another — subtle, and not the kind of thing review
+ * catches.
+ *
+ * LassoModel is the owner because it holds the anchors, enforces the floor
+ * in four places of its own, and is the only one of the two that is
+ * unit-tested. This guards the collapse rather than trusting it to stay.
+ */
+describe('MIN_ANCHORS has exactly one owner (#388)', () => {
+  const SRC = resolve(__dirname, '..', '..', 'src');
+
+  function tsFilesUnder(dir: string): string[] {
+    const out: string[] = [];
+    for (const entry of readdirSync(dir, { withFileTypes: true })) {
+      const full = join(dir, entry.name);
+      if (entry.isDirectory()) out.push(...tsFilesUnder(full));
+      else if (entry.name.endsWith('.ts')) out.push(full);
+    }
+    return out;
+  }
+
+  const sources = tsFilesUnder(SRC).map((f) => ({
+    name: f
+      .slice(SRC.length + 1)
+      .split(sep)
+      .join('/'),
+    text: readFileSync(f, 'utf8'),
+  }));
+
+  it('finds a source tree at all', () => {
+    expect(sources.length).toBeGreaterThan(30);
+  });
+
+  it('only lasso-model.ts declares it', () => {
+    const declarers = sources
+      .filter((f) => /(const|readonly|let|var)\s+MIN_ANCHORS\s*=/.test(f.text))
+      .map((f) => f.name);
+    expect(declarers, 'read LassoModel.MIN_ANCHORS instead of declaring another').toEqual([
+      'lib/lasso-model.ts',
+    ]);
+  });
+
+  it('is the value the rest of the app compares against, not a literal', () => {
+    // Not a tautology: this fails if someone inlines the 3 back into an
+    // anchor comparison, which is the other way the rule drifts.
+    expect(LassoModel.MIN_ANCHORS).toBe(3);
+
+    // Scoped to the lasso's own vocabulary on purpose. `roi-process.ts`
+    // rejects `polygon.length < 3` and looks like a fourth copy, but it is
+    // a different rule that happens to share the number: three points is
+    // the geometric precondition for rasterising a polygon at all, not the
+    // editor's policy for a usable lasso. If MIN_ANCHORS were ever raised
+    // to four, roi-process should still accept three.
+    const inlined = sources
+      .filter((f) => f.name !== 'lib/lasso-model.ts')
+      // No leading \b: the component's local is `lassoAnchors`, and a
+      // word boundary there would have missed it. Confirmed by mutation —
+      // the first version of this regex let `lassoAnchors.length < 3`
+      // straight through.
+      .filter((f) => /anchors[^\r\n]*\.length\s*[<>]=?\s*3\b/i.test(f.text))
+      .map((f) => f.name);
+    expect(inlined, 'compare against LassoModel.MIN_ANCHORS, not a literal 3').toEqual([]);
   });
 });


### PR DESCRIPTION
Closes #388.

`ar-editor-advanced.ts` declared its own `const MIN_ANCHORS = 3` beside `LassoModel.MIN_ANCHORS`, and enforced the floor independently in four places. They agreed only because nobody had changed either. Changing one would have left a lasso that can be simplified below the minimum on one code path and not another — subtle, and not something review catches.

`LassoModel` owns it: it holds the anchors, enforces the floor in four places of its own, and is the only one of the two that is unit-tested.

### The interesting part is what the guard nearly got wrong

Two tests now pin this: that only `lasso-model.ts` declares the constant, and that nothing compares anchors against a bare `3`.

The second one flagged `roi-process.ts` on its first run:

```ts
if (polygon.length < 3) {
  throw new Error('ROI polygon must have at least 3 points');
}
```

That looks like a fourth copy. **It isn't.** Three points is the geometric precondition for rasterising a polygon at all, not the editor's policy for a usable lasso. If `MIN_ANCHORS` were ever raised to four, `roi-process` should still accept three. Same number, different rule — so the test is scoped to the lasso's own vocabulary and the comment explains the exclusion rather than leaving the next person to rediscover it.

Collapsing that one would have been the easy mistake: it looks like exactly the duplication this issue is about.

### And the guard itself needed a second pass

Both were mutation-checked. Reintroducing the duplicate declaration failed immediately:

```
× only lasso-model.ts declares it
  expected [ …(2) ] to deeply equal [ 'lib/lasso-model.ts' ]
```

Inlining the literal **did not**:

```
lassoAnchors.length < LassoModel.MIN_ANCHORS  →  lassoAnchors.length < 3
  Tests  26 passed          ← should have failed
```

The regex opened with `\banchors\b`, and the component's local is `lassoAnchors` — no word boundary before `anchors`. Dropping the leading boundary catches both, verified:

```
× is the value the rest of the app compares against, not a literal
```

That is the third time today a guard has looked right and caught nothing until something was broken on purpose to check it. Worth stating plainly: **writing the assertion is not the work; proving it fires is.**

### Verification

`typecheck` 0 · `lint` 0 · **1266 tests** across three workspaces.

https://claude.ai/code/session_013QHMsfPmMMTY77jRWc8Hvb