### PR TITLE
test(e2e): prove an editor stroke reaches the exported image

### DIFF
--- a/packages/nukebg-app/e2e/editor-stroke.spec.ts
+++ b/packages/nukebg-app/e2e/editor-stroke.spec.ts
@@ -1,0 +1,179 @@
+import { test, expect, type Page } from '@playwright/test';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+/**
+ * An eraser stroke in the advanced editor reaches the exported image (#387).
+ *
+ * The unit suite in tests/components/ar-editor-advanced-drawing.test.ts pins
+ * the ordered sequence of canvas operations a stroke produces. That is enough
+ * to refactor the painting safely — it caught seven mutations and held through
+ * the extraction in #395 — but it cannot prove those calls paint anything. The
+ * canvas is fully mocked there: `getContext` returns a recording stub and
+ * `getImageData` returns `new ImageData(1, 1)`. Every assertion in that file
+ * would pass against a canvas that renders nothing at all.
+ *
+ * WHAT THIS ASSERTS, AND WHY NOT THE OBVIOUS THING
+ *
+ * The obvious test is: sample the editor canvas, drag, sample again, expect a
+ * difference. That was the first version of this file, and it passed with the
+ * painting entirely disabled.
+ *
+ * `redrawDisplay()` also paints the cursor preview — the dashed brush outline
+ * tracking the pointer — onto the same canvas. So moving the mouse changes
+ * those pixels whether or not the stroke painted anything. The test measured
+ * "did the canvas change" when the question was "did the user's edit change".
+ * Only mutation-testing it revealed that: it looked correct and would have
+ * cost 20 seconds of CI per run to assert nothing.
+ *
+ * So this measures the artefact instead: erase across the subject, commit, and
+ * check the exported PNG has meaningfully less subject left in it. That covers
+ * the whole chain — stroke, working canvas, commit, re-export — has no cursor
+ * preview anywhere in it, and needs no screenshot baseline. See
+ * refresh-visual-baselines.yml for why those are worth avoiding: per-platform,
+ * Linux-only regeneration, and silently stale when nobody refreshes them.
+ *
+ * The second version compared a hash of the exported bytes, and was also
+ * vacuous: the first export comes from the pipeline and the second from the
+ * editor's commit, so the encoded bytes differ even with nothing edited. Three
+ * versions of this file, two of them asserting nothing, and the only thing
+ * that told them apart was disabling the painting and re-running.
+ */
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const FIXTURE = resolve(__dirname, '../tests/fixtures/fiat-clean.png');
+
+/**
+ * Decode the PNG the download button points at, and count how much subject
+ * survives in it.
+ *
+ * Opaque-pixel count rather than a hash of the bytes: the first export comes
+ * from the pipeline and the second from the editor's commit, so the encoded
+ * bytes differ even when nothing was edited. Measured, with the painting
+ * disabled: 147932 bytes before, 146828 after — a byte comparison "passes"
+ * on that alone. The pixel count does not move (54165 -> 54546, +0.7%).
+ */
+async function exportedSubject(page: Page): Promise<{ w: number; h: number; opaque: number }> {
+  return page.evaluate(async () => {
+    const dl = document.querySelector('ar-app')!.shadowRoot!.querySelector('ar-download')!;
+    const a = dl.shadowRoot!.querySelector('#dl-png') as HTMLAnchorElement;
+    const bitmap = await createImageBitmap(await (await fetch(a.href)).blob());
+    const off = new OffscreenCanvas(bitmap.width, bitmap.height);
+    const ctx = off.getContext('2d')!;
+    ctx.drawImage(bitmap, 0, 0);
+    const { data } = ctx.getImageData(0, 0, bitmap.width, bitmap.height);
+    let opaque = 0;
+    for (let i = 3; i < data.length; i += 4) if (data[i] > 200) opaque++;
+    return { w: bitmap.width, h: bitmap.height, opaque };
+  });
+}
+
+/** Resolves once the download button exposes a blob URL — "pipeline done". */
+async function waitForExport(page: Page, timeout: number): Promise<void> {
+  await page.waitForFunction(
+    () => {
+      const dl = document.querySelector('ar-app')?.shadowRoot?.querySelector('ar-download');
+      const a = dl?.shadowRoot?.querySelector('#dl-png') as HTMLAnchorElement | null;
+      return !!a?.href?.startsWith('blob:');
+    },
+    { timeout },
+  );
+}
+
+test.describe('advanced editor — strokes reach the exported image (#387)', () => {
+  test.skip(
+    ({ browserName }) => browserName !== 'chromium',
+    'Needs a full pipeline run first; same Chromium-only constraint as pipeline.spec.ts',
+  );
+
+  test('erasing part of the subject changes the PNG the user downloads', async ({ page }) => {
+    // Cold model download dominates: same budget as the pipeline spec.
+    test.setTimeout(240_000);
+
+    const errors: string[] = [];
+    page.on('pageerror', (err) => errors.push(err.message));
+
+    await page.goto('/');
+    await page.waitForLoadState('networkidle');
+    await page.locator('ar-dropzone').locator('input[type="file"]').setInputFiles(FIXTURE);
+    await waitForExport(page, 200_000);
+
+    const before = await exportedSubject(page);
+
+    await page.locator('ar-app').locator('#advanced-cta').click();
+    const canvas = page.locator('ar-editor-advanced').locator('canvas');
+    await expect(canvas).toBeVisible();
+
+    // page.mouse works in viewport coordinates and does NOT scroll, unlike
+    // locator.click(). The editor sits well below the fold — its canvas was at
+    // y=765 in a 720-tall viewport on the first run of this test, so the drag
+    // dispatched into empty space and failed against the app rather than
+    // against a bug.
+    await canvas.scrollIntoViewIfNeeded();
+    const box = await canvas.boundingBox();
+    expect(box, 'editor canvas has no layout box').not.toBeNull();
+    const { x, y, width, height } = box!;
+    const viewport = page.viewportSize()!;
+    expect(y + height, 'canvas is below the fold; page.mouse would miss it').toBeLessThanOrEqual(
+      viewport.height,
+    );
+
+    // Erasing transparent background is a no-op, so the stroke has to cross
+    // the subject. Find it rather than assume where it is: scan for the widest
+    // opaque run and drag along that row.
+    const subject = await canvas.evaluate((el: HTMLCanvasElement) => {
+      const { data } = el.getContext('2d')!.getImageData(0, 0, el.width, el.height);
+      let best = { row: 0, from: 0, to: 0 };
+      for (let row = 0; row < el.height; row += 4) {
+        let from = -1;
+        for (let col = 0; col <= el.width; col++) {
+          const opaque = col < el.width && data[(row * el.width + col) * 4 + 3] > 200;
+          if (opaque && from === -1) from = col;
+          if (!opaque && from !== -1) {
+            if (col - from > best.to - best.from) best = { row, from, to: col };
+            from = -1;
+          }
+        }
+      }
+      return { ...best, w: el.width, h: el.height };
+    });
+    expect(
+      subject.to - subject.from,
+      'no opaque run found — the fixture produced an empty cutout',
+    ).toBeGreaterThan(40);
+
+    // Canvas coordinates back to viewport coordinates.
+    const span = subject.to - subject.from;
+    const toClientX = (col: number) => x + (col / subject.w) * width;
+    const clientY = y + (subject.row / subject.h) * height;
+
+    await page.mouse.move(toClientX(subject.from + span * 0.2), clientY);
+    await page.mouse.down();
+    await page.mouse.move(toClientX(subject.from + span * 0.8), clientY, { steps: 12 });
+    await page.mouse.up();
+
+    // Commit, then wait for the app to re-export.
+    await page.locator('ar-editor-advanced').locator('#done').click();
+    await waitForExport(page, 60_000);
+
+    const after = await expect
+      .poll(() => exportedSubject(page).then((s) => s.opaque), {
+        timeout: 30_000,
+        message: 'the exported PNG still has all its subject — the erase never reached it',
+      })
+      .toBeLessThan(before.opaque * 0.95)
+      .then(() => exportedSubject(page));
+
+    // Same canvas, so the counts are comparable rather than a crop artefact.
+    expect({ w: after.w, h: after.h }).toEqual({ w: before.w, h: before.h });
+
+    // The 0.95 is not arbitrary. Measured on this fixture: a working erase
+    // takes 54165 opaque pixels to 41861 (-22.7%); with the painting disabled
+    // the same run lands on 54546 (+0.7%), because committing round-trips the
+    // image through refine and nudges a few edge pixels either way. Anything
+    // between those two separates them; 5% sits well clear of the noise
+    // without pinning the test to one fixture's exact geometry.
+
+    expect(errors, 'page errors during the edit').toEqual([]);
+  });
+});

--- a/packages/nukebg-app/src/components/ar-editor-advanced.ts
+++ b/packages/nukebg-app/src/components/ar-editor-advanced.ts
@@ -51,9 +51,11 @@ const PAD_RATIO = 0.25;
 const MIN_LASSO_POINT_DIST = 2;
 // Fraction of min(w, h) used as Douglas-Peucker epsilon.
 const LASSO_EPS_RATIO = 0.006;
-// Minimum anchors we'll ever let the user delete down to — below this
-// the polygon stops being meaningful.
-const MIN_ANCHORS = 3;
+// MIN_ANCHORS is not declared here. It used to be, as a second `= 3`
+// alongside LassoModel.MIN_ANCHORS, and the two agreed only because nobody
+// had changed either — see #388. LassoModel owns the rule: it holds the
+// anchors, enforces the floor in four places, and is unit-tested. This file
+// now reads it from there.
 
 // View transform. 1 = natural fit (max-width / max-height); zoom multiplies
 // that via a CSS transform on the canvas. Keep in sync with ar-editor.ts.
@@ -1125,7 +1127,7 @@ export class ArEditorAdvanced extends HTMLElement {
     // them just adds visual noise. Match cursor-preview line width (2) for
     // stroke consistency across tools.
     const anchors = this.lasso.getAnchors();
-    if (!this.selectionMask && anchors && anchors.length >= MIN_ANCHORS) {
+    if (!this.selectionMask && anchors && anchors.length >= LassoModel.MIN_ANCHORS) {
       const pts = anchors;
       this.ctx.save();
       const accentRgb2 =
@@ -1222,7 +1224,7 @@ export class ArEditorAdvanced extends HTMLElement {
 
       if (kind === 'refine') {
         const poly = lassoAnchors ? [...lassoAnchors] : this.selectionMaskToPolygon(w, h);
-        if (!poly || poly.length < MIN_ANCHORS) throw new Error('No region for refine');
+        if (!poly || poly.length < LassoModel.MIN_ANCHORS) throw new Error('No region for refine');
         newAlpha = await this.refineWithSam(poly, prevAlpha, w, h, ac.signal);
       } else if (hasMask) {
         newAlpha = new Uint8Array(prevAlpha);
@@ -1358,7 +1360,7 @@ export class ArEditorAdvanced extends HTMLElement {
     if (this.busy) return;
     if (!this.working || !this.current) return;
     const lassoAnchors = this.lasso.getAnchors();
-    if (!lassoAnchors || lassoAnchors.length < MIN_ANCHORS) return;
+    if (!lassoAnchors || lassoAnchors.length < LassoModel.MIN_ANCHORS) return;
 
     const w = this.current.width;
     const h = this.current.height;
@@ -1541,7 +1543,7 @@ export class ArEditorAdvanced extends HTMLElement {
   private async rmbgDecodeFromLasso(): Promise<void> {
     if (!this.current || !this.original) return;
     const lassoAnchors = this.lasso.getAnchors();
-    if (!lassoAnchors || lassoAnchors.length < MIN_ANCHORS) return;
+    if (!lassoAnchors || lassoAnchors.length < LassoModel.MIN_ANCHORS) return;
 
     const w = this.current.width;
     const h = this.current.height;

--- a/packages/nukebg-app/tests/lib/lasso-model.test.ts
+++ b/packages/nukebg-app/tests/lib/lasso-model.test.ts
@@ -1,5 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import { LassoModel } from '../../src/lib/lasso-model';
+import { readFileSync, readdirSync } from 'node:fs';
+import { resolve, join, sep } from 'node:path';
 
 /**
  * Behavioural tests for the LassoModel state machine extracted from
@@ -262,5 +264,76 @@ describe('LassoModel', () => {
       loose.close();
       expect(loose.getAnchors()?.length ?? 0).toBeLessThanOrEqual(tight.getAnchors()?.length ?? 0);
     });
+  });
+});
+
+/**
+ * LassoModel owns the minimum-anchor rule (#388).
+ *
+ * `ar-editor-advanced.ts` used to declare its own `const MIN_ANCHORS = 3`
+ * beside `LassoModel.MIN_ANCHORS`, and enforce it independently in four
+ * places. They agreed only because nobody had changed either. Changing one
+ * would have left a lasso that can be simplified below the minimum on one
+ * code path and not another — subtle, and not the kind of thing review
+ * catches.
+ *
+ * LassoModel is the owner because it holds the anchors, enforces the floor
+ * in four places of its own, and is the only one of the two that is
+ * unit-tested. This guards the collapse rather than trusting it to stay.
+ */
+describe('MIN_ANCHORS has exactly one owner (#388)', () => {
+  const SRC = resolve(__dirname, '..', '..', 'src');
+
+  function tsFilesUnder(dir: string): string[] {
+    const out: string[] = [];
+    for (const entry of readdirSync(dir, { withFileTypes: true })) {
+      const full = join(dir, entry.name);
+      if (entry.isDirectory()) out.push(...tsFilesUnder(full));
+      else if (entry.name.endsWith('.ts')) out.push(full);
+    }
+    return out;
+  }
+
+  const sources = tsFilesUnder(SRC).map((f) => ({
+    name: f
+      .slice(SRC.length + 1)
+      .split(sep)
+      .join('/'),
+    text: readFileSync(f, 'utf8'),
+  }));
+
+  it('finds a source tree at all', () => {
+    expect(sources.length).toBeGreaterThan(30);
+  });
+
+  it('only lasso-model.ts declares it', () => {
+    const declarers = sources
+      .filter((f) => /(const|readonly|let|var)\s+MIN_ANCHORS\s*=/.test(f.text))
+      .map((f) => f.name);
+    expect(declarers, 'read LassoModel.MIN_ANCHORS instead of declaring another').toEqual([
+      'lib/lasso-model.ts',
+    ]);
+  });
+
+  it('is the value the rest of the app compares against, not a literal', () => {
+    // Not a tautology: this fails if someone inlines the 3 back into an
+    // anchor comparison, which is the other way the rule drifts.
+    expect(LassoModel.MIN_ANCHORS).toBe(3);
+
+    // Scoped to the lasso's own vocabulary on purpose. `roi-process.ts`
+    // rejects `polygon.length < 3` and looks like a fourth copy, but it is
+    // a different rule that happens to share the number: three points is
+    // the geometric precondition for rasterising a polygon at all, not the
+    // editor's policy for a usable lasso. If MIN_ANCHORS were ever raised
+    // to four, roi-process should still accept three.
+    const inlined = sources
+      .filter((f) => f.name !== 'lib/lasso-model.ts')
+      // No leading \b: the component's local is `lassoAnchors`, and a
+      // word boundary there would have missed it. Confirmed by mutation —
+      // the first version of this regex let `lassoAnchors.length < 3`
+      // straight through.
+      .filter((f) => /anchors[^\r\n]*\.length\s*[<>]=?\s*3\b/i.test(f.text))
+      .map((f) => f.name);
+    expect(inlined, 'compare against LassoModel.MIN_ANCHORS, not a literal 3').toEqual([]);
   });
 });


### PR DESCRIPTION
Closes #387.

The unit suite from #390 pins the ordered sequence of canvas operations a stroke produces. Enough to refactor the painting safely — seven mutations caught, held through the extraction in #395 — but **it cannot prove those calls paint anything**. The canvas is fully mocked there: `getContext` returns a recording stub and `getImageData` returns `new ImageData(1, 1)`. Every assertion in that file would pass against a canvas that renders nothing at all.

This closes the gap in a real browser: erase across the subject, commit, and check the exported PNG has meaningfully less subject left in it. Whole chain in one assertion — stroke, working canvas, commit, re-export — and no screenshot baseline (`refresh-visual-baselines.yml` documents why those are worth avoiding: per-platform, Linux-only regeneration, silently stale when nobody refreshes them).

### It took three versions, and two of them asserted nothing

That is the part worth reading, because both looked correct.

**v1 — compare the editor canvas before and after the drag.** Passed with the painting entirely disabled. `redrawDisplay()` also paints the cursor preview onto that same canvas, so moving the mouse changes pixels whether or not the stroke painted. It measured *"did the canvas change"* when the question was *"did the user's edit change"*.

**v2 — compare a hash of the exported bytes.** Also passed with the painting disabled. The first export comes from the pipeline and the second from the editor's commit, so the encoded bytes differ even with nothing edited — 147932 → 146828 on this fixture.

**v3 — count opaque pixels in the export.** The numbers are in the file rather than left as a magic constant:

| | opaque pixels |
|---|---|
| pipeline export | 54165 |
| after erase, painting working | 41861 — **−22.7%** |
| after erase, painting disabled | 54546 — **+0.7%** |

Threshold at 5%: well clear of the commit round-trip's noise, without pinning the test to one fixture's exact geometry.

Only disabling the painting and re-running told the three apart. **Two of them would have shipped looking like coverage and costing 20s of CI to assert nothing.**

### Two things the test had to handle

**`page.mouse` works in viewport coordinates and does not scroll**, unlike `locator.click()`. The editor canvas sat at `y=765` in a 720-tall viewport, so the first drag dispatched into empty space and failed against the app rather than against a bug. It now scrolls into view and asserts it worked.

**Erasing transparent background is a no-op**, so the stroke has to cross the subject. Rather than assume where that is, the test scans for the widest opaque run and drags along it — which also means it survives a change of fixture or model.

### Cost

Chromium only, same constraint as `pipeline.spec.ts`. Adds ~22s to the existing e2e job, which already pays the model-download cost.

### Verification

`typecheck` 0 · `lint` 0 · **1267 tests** across three workspaces, plus the new e2e verified locally in both directions.

https://claude.ai/code/session_013QHMsfPmMMTY77jRWc8Hvb