### PR TITLE
release: block a silent publish of the nested sharp gap (#404)

### DIFF
--- a/packages/nukebg-cli/package.json
+++ b/packages/nukebg-cli/package.json
@@ -25,7 +25,8 @@
   "scripts": {
     "build": "tsup",
     "test": "vitest run --passWithNoTests",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "prepublishOnly": "node ../../scripts/check-publish-deps.mjs"
   },
   "dependencies": {
     "@huggingface/transformers": "^3.8.1",

--- a/packages/nukebg-cli/tests/publish-deps-guard.test.ts
+++ b/packages/nukebg-cli/tests/publish-deps-guard.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+// @ts-expect-error — plain .mjs script, no types, deliberately dependency-free
+import { satisfies, findConflicts } from '../../../scripts/check-publish-deps.mjs';
+
+/**
+ * The publish guard for #404.
+ *
+ * npm applies `overrides` only from the install root, and this monorepo's root
+ * package.json is never published — so the `sharp: ^0.35.4` pin from #381
+ * fixes this tree and nothing a user installs. CI cannot see the difference,
+ * because here the override collapses the two copies into one.
+ *
+ * `scripts/check-publish-deps.mjs` runs from `prepublishOnly`, so it does not
+ * gate CI; it stops `npm publish` with an explanation instead. These tests
+ * exist because a guard that fails open is worse than none, and the semver
+ * comparison is the part that would fail open if it were wrong.
+ */
+
+const REPO = resolve(__dirname, '..', '..', '..');
+
+describe('satisfies — the caret semantics the guard rests on', () => {
+  it.each([
+    // 0.x is the case that matters here: ^0.34.1 must NOT accept 0.35.x,
+    // which is exactly why transformers and the CLI cannot share one sharp.
+    ['0.34.5', '^0.34.1', true],
+    ['0.35.4', '^0.34.1', false],
+    ['0.34.0', '^0.34.1', false],
+    // Normal caret above 0.x.
+    ['1.5.0', '^1.2.3', true],
+    ['2.0.0', '^1.2.3', false],
+    // Tilde and exact.
+    ['1.2.9', '~1.2.3', true],
+    ['1.3.0', '~1.2.3', false],
+    ['1.2.3', '1.2.3', true],
+    ['1.2.4', '1.2.3', false],
+  ])('%s vs %s -> %s', (version, range, expected) => {
+    expect(satisfies(version as string, range as string)).toBe(expected);
+  });
+
+  it.each(['>=1.0.0 <2', 'workspace:*', 'npm:other@1.0.0', 'latest'])(
+    'reports %s as unknown rather than passing it',
+    (range) => {
+      // Failing open is the one outcome this script must never have.
+      expect(satisfies('1.0.0', range)).toBe('unknown');
+    },
+  );
+});
+
+describe('findConflicts — against the real tree', () => {
+  it('still reports the known sharp gap, so the guard is not silently satisfied', () => {
+    const conflicts = findConflicts() as Array<Record<string, string>>;
+    const sharp = conflicts.find((c) => c.nested === 'sharp');
+
+    expect(
+      sharp,
+      'no sharp conflict found — either #404 was resolved (update this test) ' +
+        'or the guard stopped detecting it (fix the guard)',
+    ).toBeDefined();
+    expect(sharp!.via).toBe('@huggingface/transformers');
+  });
+
+  it('the CLI is still publishable, which is what makes the guard load-bearing', () => {
+    // If nukebg-cli were marked private the guard would be belt-and-braces.
+    // It is not, so prepublishOnly is the only thing standing between this
+    // gap and a published package.
+    const cli = JSON.parse(readFileSync(resolve(REPO, 'packages/nukebg-cli/package.json'), 'utf8'));
+    expect(cli.private ?? false).toBe(false);
+    expect(cli.scripts.prepublishOnly).toContain('check-publish-deps');
+  });
+});

--- a/scripts/check-publish-deps.mjs
+++ b/scripts/check-publish-deps.mjs
@@ -1,0 +1,114 @@
+#!/usr/bin/env node
+/**
+ * Refuse to publish nukebg-cli while a direct dependency forces a nested copy
+ * of a package the CLI pins for security reasons (#404).
+ *
+ * npm applies `overrides` only from the install root, and this monorepo's root
+ * package.json is never published. So the `sharp: ^0.35.4` pin added in #381
+ * fixes this tree — which is all CI and the audit gate ever look at — and
+ * nothing a user installs.
+ *
+ * Concretely, today: nukebg-cli depends on sharp ^0.35.4 and on
+ * @huggingface/transformers ^3.8.1, and transformers hard-depends on
+ * sharp ^0.34.1. A range 0.35.4 cannot satisfy, so `npm i -g nukebg-cli`
+ * resolves the good copy at top level and a nested 0.34.x underneath.
+ *
+ * This script does not decide whether that is acceptable. It only makes sure
+ * the decision is taken deliberately rather than discovered by a user: it runs
+ * from `prepublishOnly`, so CI stays green and `npm publish` stops with an
+ * explanation.
+ *
+ *   node scripts/check-publish-deps.mjs
+ *
+ * Exit 0 = no direct dependency forces a conflicting nested copy.
+ * Exit 1 = one does; the message names the pair and points at #404.
+ */
+import { readFileSync } from 'node:fs';
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const read = (p) => JSON.parse(readFileSync(resolve(repoRoot, p), 'utf8'));
+
+/**
+ * Does `version` satisfy `range`?
+ *
+ * Deliberately handles only the shapes this repo uses — `^x.y.z`, `~x.y.z`,
+ * and exact — rather than pulling in a semver dependency for a script whose
+ * whole job is to be run once at publish time. Anything it does not recognise
+ * is reported as unknown rather than silently passing, because a check that
+ * fails open is the thing this file exists to prevent.
+ */
+export function satisfies(version, range) {
+  const parse = (v) => v.split('.').map(Number);
+  const [vMaj, vMin, vPat] = parse(version);
+  const m = /^([\^~]?)(\d+)\.(\d+)\.(\d+)$/.exec(range.trim());
+  if (!m) return 'unknown';
+  const [, op, maj, min, pat] = m;
+  const [rMaj, rMin, rPat] = [Number(maj), Number(min), Number(pat)];
+
+  const atLeast =
+    vMaj > rMaj ||
+    (vMaj === rMaj && (vMin > rMin || (vMin === rMin && vPat >= rPat)));
+  if (!atLeast) return false;
+
+  // 0.x is special in semver: ^0.34.1 allows 0.34.x but not 0.35.0.
+  if (op === '^') return rMaj === 0 ? vMaj === 0 && vMin === rMin : vMaj === rMaj;
+  if (op === '~') return vMaj === rMaj && vMin === rMin;
+  return vMaj === rMaj && vMin === rMin && vPat === rPat;
+}
+
+/** The version the root override pins a package to, if it pins one. */
+function overriddenTo(name) {
+  const range = (read('package.json').overrides ?? {})[name];
+  return range ? range.replace(/^[\^~]/, '') : null;
+}
+
+export function findConflicts() {
+  const cli = read('packages/nukebg-cli/package.json');
+  const direct = { ...(cli.dependencies ?? {}) };
+  const conflicts = [];
+
+  for (const depName of Object.keys(direct)) {
+    let depManifest;
+    try {
+      depManifest = read(`node_modules/${depName}/package.json`);
+    } catch {
+      continue; // not installed here; nothing to inspect
+    }
+    for (const [nested, nestedRange] of Object.entries(depManifest.dependencies ?? {})) {
+      if (!(nested in direct)) continue;
+      const pinned = overriddenTo(nested) ?? direct[nested].replace(/^[\^~]/, '');
+      const ok = satisfies(pinned, nestedRange);
+      if (ok === false || ok === 'unknown') {
+        conflicts.push({ via: depName, nested, nestedRange, pinned, verdict: ok });
+      }
+    }
+  }
+  return conflicts;
+}
+
+// Running as a script rather than imported by the tests.
+if (process.argv[1] && resolve(process.argv[1]) === resolve(fileURLToPath(import.meta.url))) {
+  const conflicts = findConflicts();
+  if (conflicts.length === 0) {
+    console.log('publish check passed: no direct dependency forces a conflicting nested copy.');
+    process.exit(0);
+  }
+  console.error('Refusing to publish nukebg-cli.\n');
+  for (const c of conflicts) {
+    console.error(
+      `  ${c.nested}: the CLI resolves ${c.pinned}, but ${c.via} requires ${c.nestedRange}` +
+        `${c.verdict === 'unknown' ? ' (range not understood by this check)' : ''}`,
+    );
+  }
+  console.error(
+    '\nnpm applies `overrides` only from the install root, and this workspace root is\n' +
+      'never published — so an installed CLI gets BOTH copies. CI cannot see this,\n' +
+      'because in this tree the override collapses them into one.\n\n' +
+      'This is not a claim that the nested copy is exploitable; see #404 for the\n' +
+      'reachability analysis. It is a claim that publishing should be a decision,\n' +
+      'not an accident. Resolve #404, then publish.',
+  );
+  process.exit(1);
+}


### PR DESCRIPTION
Ships #407. Refs #404.

### What it does

`npm publish` of `nukebg-cli` now stops with the conflict named, instead of shipping it silently:

```
Refusing to publish nukebg-cli.
  sharp: the CLI resolves 0.35.4, but @huggingface/transformers requires ^0.34.1
```

npm applies `overrides` only from the install root and this workspace root is never published, so the pin from #381 fixes CI's tree and nothing a user installs. The guard runs from `prepublishOnly`, so it does not gate CI — it gates the one moment the gap would become real.

It decides nothing. Marking the CLI private, waiting for transformers, or accepting the risk all remain open on #404.

### Why it can be trusted

The semver comparison is the whole guard, so it reports anything it does not recognise as **unknown** rather than passing. Both properties mutation-checked: making it fail open breaks four tests, and dropping the 0.x caret rule (`^0.34.1` must not accept `0.35.4`) breaks the two that matter. That rule is the entire case — if it were wrong, this would all look fine.

### And the risk is narrower than it looked

transformers reaches sharp both to decode (`image.js:183`) and to resize raw pixels (`image.js:410`). The CLI decodes with its **own** patched sharp and hands transformers pre-decoded RGBA, never calling `RawImage.read()`. So only the resize path is live — and **GHSA-rgj7-g3m4-5g8c, the advisory that started this, is libheif**, a decoder a raw-pixel resize never touches.

Not extended to the generic libvips advisory; that one still needs the CVEs read rather than the summaries. Posted on #404.

### CI

All green on #407. typecheck 0, lint 0, **1286 tests** across three workspaces.

https://claude.ai/code/session_013QHMsfPmMMTY77jRWc8Hvb