### PR TITLE
fix(ml): decide the execution provider on measurement, not a stale caveat

### DIFF
--- a/packages/nukebg-app/src/workers/ml.worker.ts
+++ b/packages/nukebg-app/src/workers/ml.worker.ts
@@ -47,11 +47,33 @@ let currentModelId: ModelId = DEFAULT_MODEL;
 let RawImageClass:
   (new (data: Uint8ClampedArray, w: number, h: number, channels: number) => unknown) | null = null;
 
-/** Detect compute device - currently forced to WASM */
-async function detectDevice(): Promise<'webgpu' | 'wasm'> {
-  // Force WASM - WebGPU in Transformers.js is unstable and causes
-  // NetworkError on some browsers when loading the WebGPU runtime.
-  // Re-enable when Transformers.js WebGPU support is stable.
+/**
+ * The execution provider RMBG runs on. WASM, and not as a placeholder.
+ *
+ * This used to be an async function returning `'webgpu' | 'wasm'` that could
+ * only ever return one of them, above a comment reading "Re-enable when
+ * Transformers.js WebGPU support is stable" — a condition with no owner and
+ * no way for anyone to notice it had been met. #389 measured it instead.
+ *
+ * Chromium 141, real GPU, transformers 3.8.1, drop-to-export median of three
+ * runs on the same fixture:
+ *
+ *   wasm     14958 ms   (warmup ~7.8 s)
+ *   webgpu   18485 ms   (warmup ~9.5 s)
+ *
+ * So two things, and the second is the one that decides it. The NetworkError
+ * the old comment described did not reproduce — that condition looks stale
+ * for this engine. But WebGPU was ~24% SLOWER end to end, consistently, with
+ * variance under 2%. The assumed win is not there.
+ *
+ * WASM therefore stays, on evidence rather than on a stale caveat. What would
+ * justify revisiting: a measurement showing WebGPU ahead on hardware that
+ * matters, or a transformers release whose notes claim a WebGPU speedup. Not
+ * "it feels like it should be faster". Firefox and Safari were not measured,
+ * and the original report said "some browsers", so re-enabling would need
+ * them too.
+ */
+function computeDevice(): 'wasm' {
   return 'wasm';
 }
 
@@ -193,7 +215,7 @@ async function loadModel(
   modelId: ModelId = DEFAULT_MODEL,
   emitReady = true,
 ): Promise<void> {
-  const device = await detectDevice();
+  const device = computeDevice();
 
   if (segmenters.has(modelId)) {
     currentModelId = modelId;


### PR DESCRIPTION
Closes #389.

### The question, and why it stayed open

`detectDevice()` was an `async` function returning `'webgpu' | 'wasm'` that could only ever return one of them, above:

```ts
// Force WASM - WebGPU in Transformers.js is unstable and causes
// NetworkError on some browsers when loading the WebGPU runtime.
// Re-enable when Transformers.js WebGPU support is stable.
```

A condition with no owner and no way for anyone to notice it had been met — the same shape as the stale CSP allowlist in #375 and the expired scanner waiver in #380, both of which broke production this week.

I said on the issue that settling it needed a browser test on WebGPU hardware and left it. Then I reconsidered: the failure described is a *runtime load* error, not GPU behaviour, and this machine has a GPU. So I measured it.

### The measurement

Chromium 141, real GPU, transformers 3.8.1, drop-to-export, median of three runs on the same fixture:

| | run 1 | run 2 | run 3 | median | warmup |
|---|---|---|---|---|---|
| **wasm** | 14958 | 14880 | 15165 | **14958 ms** | ~7.8 s |
| **webgpu** | 18583 | 18485 | 18351 | **18485 ms** | ~9.5 s |

**Two findings, and the second is the one that decides it.**

The NetworkError did **not** reproduce. The pipeline completed cleanly under `device=webgpu`, no page errors, only onnxruntime's usual node-assignment warnings. That caveat looks stale for this engine.

But WebGPU was **~24% slower** end to end, consistently, variance under 2%. The win everyone assumes is there is not there — including me: I had written on the issue that this was "worth doing at some point" because WASM is the slowest stage. That was an assumption, and it was wrong.

### What changes

WASM stays — now on evidence rather than on a caveat nobody could retire. The function says what it does, returns what it can (`'wasm'`), drops the pointless `async`, and carries the numbers plus what would justify revisiting: a measurement showing WebGPU ahead on hardware that matters, or a transformers release whose notes claim a speedup. Not an intuition.

Firefox and Safari were not measured, and the original report said "some browsers", so re-enabling would need them too. That is in the comment.

### Why this is not a committed test

Headless Chromium gives **no WebGPU adapter** under any software-rendering flags I tried — `--enable-unsafe-swiftshader`, `+ --enable-features=Vulkan`, `--use-angle=swiftshader` all returned `no adapter`. It needed a headed browser on a real GPU, which CI does not have. So the numbers live in the comment where the next person will read them, rather than in a test that could not run.

### Verification

`typecheck` 0 · `lint` 0 · **1286 tests** across three workspaces.

https://claude.ai/code/session_013QHMsfPmMMTY77jRWc8Hvb