### PR TITLE
release: measured device decision (#389) + integrity asymmetry filed (#409)

### DIFF
--- a/packages/nukebg-app/src/workers/ml.worker.ts
+++ b/packages/nukebg-app/src/workers/ml.worker.ts
@@ -47,11 +47,33 @@ let currentModelId: ModelId = DEFAULT_MODEL;
 let RawImageClass:
   (new (data: Uint8ClampedArray, w: number, h: number, channels: number) => unknown) | null = null;
 
-/** Detect compute device - currently forced to WASM */
-async function detectDevice(): Promise<'webgpu' | 'wasm'> {
-  // Force WASM - WebGPU in Transformers.js is unstable and causes
-  // NetworkError on some browsers when loading the WebGPU runtime.
-  // Re-enable when Transformers.js WebGPU support is stable.
+/**
+ * The execution provider RMBG runs on. WASM, and not as a placeholder.
+ *
+ * This used to be an async function returning `'webgpu' | 'wasm'` that could
+ * only ever return one of them, above a comment reading "Re-enable when
+ * Transformers.js WebGPU support is stable" — a condition with no owner and
+ * no way for anyone to notice it had been met. #389 measured it instead.
+ *
+ * Chromium 141, real GPU, transformers 3.8.1, drop-to-export median of three
+ * runs on the same fixture:
+ *
+ *   wasm     14958 ms   (warmup ~7.8 s)
+ *   webgpu   18485 ms   (warmup ~9.5 s)
+ *
+ * So two things, and the second is the one that decides it. The NetworkError
+ * the old comment described did not reproduce — that condition looks stale
+ * for this engine. But WebGPU was ~24% SLOWER end to end, consistently, with
+ * variance under 2%. The assumed win is not there.
+ *
+ * WASM therefore stays, on evidence rather than on a stale caveat. What would
+ * justify revisiting: a measurement showing WebGPU ahead on hardware that
+ * matters, or a transformers release whose notes claim a WebGPU speedup. Not
+ * "it feels like it should be faster". Firefox and Safari were not measured,
+ * and the original report said "some browsers", so re-enabling would need
+ * them too.
+ */
+function computeDevice(): 'wasm' {
   return 'wasm';
 }
 
@@ -193,7 +215,7 @@ async function loadModel(
   modelId: ModelId = DEFAULT_MODEL,
   emitReady = true,
 ): Promise<void> {
-  const device = await detectDevice();
+  const device = computeDevice();
 
   if (segmenters.has(modelId)) {
     currentModelId = modelId;

--- a/packages/nukebg-app/src/workers/ml.worker.ts
+++ b/packages/nukebg-app/src/workers/ml.worker.ts
@@ -55,18 +55,33 @@ let RawImageClass:
  * Transformers.js WebGPU support is stable" — a condition with no owner and
  * no way for anyone to notice it had been met. #389 measured it instead.
  *
- * Chromium 141, real GPU, transformers 3.8.1, drop-to-export median of three
- * runs on the same fixture:
+ * Chromium 141, real GPU, transformers 3.8.1, same fixtures, one browser
+ * session so the second image pays neither the download nor the warmup:
  *
- *   wasm     14958 ms   (warmup ~7.8 s)
- *   webgpu   18485 ms   (warmup ~9.5 s)
+ *                    first image        second image
+ *                    (download +        (inference
+ *                     warmup + infer)     only)
+ *   wasm             15391 ms           7840 ms
+ *   webgpu           17301 ms           8291 ms
  *
- * So two things, and the second is the one that decides it. The NetworkError
- * the old comment described did not reproduce — that condition looks stale
- * for this engine. But WebGPU was ~24% SLOWER end to end, consistently, with
- * variance under 2%. The assumed win is not there.
+ * Two findings. The NetworkError the old comment described did not
+ * reproduce, so that caveat looks stale for this engine. And WebGPU is
+ * marginally slower — about 6% on warm inference, about 12% cold, the cold
+ * gap being the larger WebGPU runtime bundle plus shader compilation.
  *
- * WASM therefore stays, on evidence rather than on a stale caveat. What would
+ * A first pass measured 24% and that number was wrong: it launched a fresh
+ * browser per run, so every run re-downloaded the model and the figure was
+ * mostly cold-start cost. Worth stating because the honest result is much
+ * duller — WebGPU is not dramatically worse, it is simply not better.
+ *
+ * Two plausible reasons it does not win here, neither confirmed. The graph
+ * does not fully fit the WebGPU provider: onnxruntime logs "Some nodes were
+ * not assigned to the preferred execution providers", and every unassigned
+ * node costs a GPU/CPU round trip. And the model is `dtype: 'q8'` — WASM has
+ * good INT8 kernels, while WebGPU backends typically widen to f32, doing more
+ * numerical work to save transfer that a model this size never needed.
+ *
+ * WASM therefore stays, on evidence rather than a stale caveat. What would
  * justify revisiting: a measurement showing WebGPU ahead on hardware that
  * matters, or a transformers release whose notes claim a WebGPU speedup. Not
  * "it feels like it should be faster". Firefox and Safari were not measured,


### PR DESCRIPTION
Ships #410 and its correction #412. Closes #389.

### `detectDevice()` decided on measurement instead of a stale caveat

It was an `async` function returning `'webgpu' | 'wasm'` that could only return one, above a comment reading *"Re-enable when Transformers.js WebGPU support is stable"* — a condition with no owner and no way to notice it had been met.

Chromium 141, real GPU, transformers 3.8.1, one browser session so the second image pays neither the download nor the warmup:

| | first image (download + warmup + inference) | second image (inference only) |
|---|---|---|
| **wasm** | 15391 ms | **7840 ms** |
| **webgpu** | 17301 ms | **8291 ms** |

The NetworkError did **not** reproduce — the pipeline completed cleanly under `device=webgpu`. WebGPU is ~6% slower warm and ~12% cold, the cold gap being the larger runtime bundle plus shader compilation.

So WASM stays, on evidence. Two plausible reasons it does not win, neither confirmed but both recorded in the code: onnxruntime reports nodes not assigned to the preferred provider (each one a GPU/CPU round trip), and the model is `q8` — WASM has good INT8 kernels while WebGPU backends typically widen to f32.

**A first pass reported 24% and that was wrong** — it launched a fresh browser per run, so every run re-downloaded the model and the figure was mostly cold-start cost. Corrected in #412 before release rather than after. The conclusion survives; the story is much duller. WebGPU is not dramatically worse here, it is simply not better.

Not a committed test: headless Chromium yields no WebGPU adapter under any software-rendering flag tried, so this needed a headed browser on a real GPU. The numbers live in the comment where the next reader will find them.

### Also filed this round

**#409** — the three models are not verified to the same standard. LaMa and SAM hash the downloaded bytes and refuse to create a session on mismatch ("fail closed", in LaMa's own words). RMBG's check has four silent returns and runs against the Cache API after transformers has already built the pipeline. The asymmetry is inverse to exposure: RMBG is the model every user downloads. Left as a decision with the trade-off written out.

### CI

Green on both #410 and #412. typecheck 0, lint 0, **1286 tests** across three workspaces.

https://claude.ai/code/session_013QHMsfPmMMTY77jRWc8Hvb