### PR TITLE
fix(ml): correct the WebGPU measurement — 24% was cold-start, not inference

### DIFF
--- a/packages/nukebg-app/src/workers/ml.worker.ts
+++ b/packages/nukebg-app/src/workers/ml.worker.ts
@@ -55,18 +55,33 @@ let RawImageClass:
  * Transformers.js WebGPU support is stable" — a condition with no owner and
  * no way for anyone to notice it had been met. #389 measured it instead.
  *
- * Chromium 141, real GPU, transformers 3.8.1, drop-to-export median of three
- * runs on the same fixture:
+ * Chromium 141, real GPU, transformers 3.8.1, same fixtures, one browser
+ * session so the second image pays neither the download nor the warmup:
  *
- *   wasm     14958 ms   (warmup ~7.8 s)
- *   webgpu   18485 ms   (warmup ~9.5 s)
+ *                    first image        second image
+ *                    (download +        (inference
+ *                     warmup + infer)     only)
+ *   wasm             15391 ms           7840 ms
+ *   webgpu           17301 ms           8291 ms
  *
- * So two things, and the second is the one that decides it. The NetworkError
- * the old comment described did not reproduce — that condition looks stale
- * for this engine. But WebGPU was ~24% SLOWER end to end, consistently, with
- * variance under 2%. The assumed win is not there.
+ * Two findings. The NetworkError the old comment described did not
+ * reproduce, so that caveat looks stale for this engine. And WebGPU is
+ * marginally slower — about 6% on warm inference, about 12% cold, the cold
+ * gap being the larger WebGPU runtime bundle plus shader compilation.
  *
- * WASM therefore stays, on evidence rather than on a stale caveat. What would
+ * A first pass measured 24% and that number was wrong: it launched a fresh
+ * browser per run, so every run re-downloaded the model and the figure was
+ * mostly cold-start cost. Worth stating because the honest result is much
+ * duller — WebGPU is not dramatically worse, it is simply not better.
+ *
+ * Two plausible reasons it does not win here, neither confirmed. The graph
+ * does not fully fit the WebGPU provider: onnxruntime logs "Some nodes were
+ * not assigned to the preferred execution providers", and every unassigned
+ * node costs a GPU/CPU round trip. And the model is `dtype: 'q8'` — WASM has
+ * good INT8 kernels, while WebGPU backends typically widen to f32, doing more
+ * numerical work to save transfer that a model this size never needed.
+ *
+ * WASM therefore stays, on evidence rather than a stale caveat. What would
  * justify revisiting: a measurement showing WebGPU ahead on hardware that
  * matters, or a transformers release whose notes claim a WebGPU speedup. Not
  * "it feels like it should be faster". Firefox and Safari were not measured,


### PR DESCRIPTION
Refs #389. Corrects the figure committed in #410, which is still in `dev` awaiting release — so this lands before it ships.

### The number was wrong

The measurement launched a **fresh browser for every run**, so each run re-downloaded the 45MB model. `device: 'webgpu'` also pulls a larger onnxruntime runtime bundle. The 24% gap was mostly that, reported as if it were inference speed.

Re-measured in one browser session, so the second image pays neither the download nor the warmup:

| | first image (download + warmup + inference) | second image (inference only) |
|---|---|---|
| **wasm** | 15391 ms | **7840 ms** |
| **webgpu** | 17301 ms | **8291 ms** |

WebGPU is ~6% slower warm, ~12% cold — the cold gap being the bigger runtime plus shader compilation.

**The conclusion survives, the story does not.** WASM stays, but the honest result is far duller: WebGPU is not dramatically worse here, it is simply not better.

### Why it does not win, as far as I can tell

Two plausible reasons, neither confirmed, recorded because "the GPU is faster" is the intuition this contradicts and the next person deserves a starting point:

- **The graph does not fully fit the provider.** onnxruntime logs `Some nodes were not assigned to the preferred execution providers`, and every unassigned node costs a GPU→CPU→GPU round trip.
- **The model is `dtype: 'q8'`.** WASM has good INT8 kernels; WebGPU backends typically widen to f32 — more numerical work, to save a transfer a model this size never needed.

### Two of my own test bugs, both of which produced confident numbers

Worth naming, because each looked like a finding:

**Re-selecting the same file with `setInputFiles` does not fire `change`.** A run that reuses a fixture consecutively hangs waiting for an export that was never started. That is what looked like *"WebGPU wedges on the second image"* — a 14-minute timeout I nearly reported as a reason to keep WASM.

**A `cd` into the directory the shell was already in failed silently**, so an edit never applied and a run labelled "webgpu" measured wasm twice. Caught only because the warmup log prints the device and I checked it against the label.

### Verification

`typecheck` 0 · `lint` 0 · **1286 tests** across three workspaces.

https://claude.ai/code/session_013QHMsfPmMMTY77jRWc8Hvb