### PR TITLE
docs(deps): correct why transformers v4 is blocked — the old reason misleads

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -33,10 +33,25 @@ updates:
       # (RMBG-1.4 WASM compatibility). Migrate manually, not via Dependabot.
       - dependency-name: "onnxruntime-web"
         update-types: ["version-update:semver-major", "version-update:semver-minor"]
-      # @huggingface/transformers v4 requires `model_type` in the model
-      # config; Xenova/RMBG-1.4 ships without it, so v4 fails to load
-      # the segmenter. See #27. Drop this entry once upstream config
-      # adds `model_type` or we fork the model.
+      # @huggingface/transformers v4 cannot load our segmenter. Verified
+      # against 4.2.0 on 2026-09-10 by installing it and running the app:
+      #
+      #   Unsupported model type "SegformerForSemanticSegmentation" for
+      #   task "image-segmentation". None of the candidate model classes
+      #   support this type.
+      #
+      # The earlier note here said v4 "requires `model_type` in the model
+      # config; Xenova/RMBG-1.4 ships without it". Both halves are stale:
+      # the app moved to briaai/RMBG-1.4, and that config DOES carry
+      # `model_type` — at the pinned revision and on main. So anyone who
+      # checks the documented reason finds it satisfied and concludes the
+      # block has lifted. It has not; v4 rejects the value the config has.
+      #
+      # Drop this entry when transformers v4 supports
+      # SegformerForSemanticSegmentation for image-segmentation, or when
+      # we move to a model it does support. Re-verify by installing v4 and
+      # dropping an image — the failure is immediate and unmistakable.
+      # See #27.
       - dependency-name: "@huggingface/transformers"
         update-types: ["version-update:semver-major"]
 


### PR DESCRIPTION
Refs #27. Answers "can we test with the latest transformers?" — **no**, and the documented reason for why was wrong.

### What the comment said

> `@huggingface/transformers` v4 requires `model_type` in the model config; **Xenova/RMBG-1.4** ships without it, so v4 fails to load the segmenter.

**Both halves are stale.** The app uses `briaai/RMBG-1.4`, not Xenova's — and that config *does* carry `model_type`, at the pinned revision and on `main`:

```
$ curl -sL .../briaai/RMBG-1.4/resolve/2ceba5a5.../config.json
model_type: 'SegformerForSemanticSegmentation'
```

So anyone verifying the documented blocker finds it satisfied, concludes the block has lifted, and tries the bump. That is exactly the path I was on.

### What actually happens

Installed 4.2.0 into the app workspace and ran the pipeline:

```
Unsupported model type "SegformerForSemanticSegmentation" for task
"image-segmentation". None of the candidate model classes support this type.
```

v4 does not reject the config for *lacking* `model_type` — it rejects the **value it has**. Same outcome, different cause, and only the cause tells you what would resolve it: transformers supporting that model type for this task, or moving to a model it supports.

### What changes

Comment only — the exclusion stays, because it is correct. It now carries the exact error, the date it was verified, and how to re-check: install v4 and drop an image. The failure is immediate and unmistakable.

### Worth noting

Third stale-reason case this session, after the CSP allowlist in #375 and the scanner waiver in #380. All three were accurate when written, and all three would have sent a reader to the wrong conclusion. The pattern is worth more attention than any one of them.

`dependabot.yml` parses. 1286 tests across three workspaces pass.

https://claude.ai/code/session_013QHMsfPmMMTY77jRWc8Hvb