### PR TITLE
fix(ci): fetch tags in the main health check

### DIFF
--- a/.github/workflows/main-health.yml
+++ b/.github/workflows/main-health.yml
@@ -71,6 +71,11 @@ jobs:
       - uses: actions/checkout@v7
         with:
           ref: main
+          # changelog-integrity.test.ts asserts every dated section has a
+          # tag. The default shallow clone fetches none, so it would fail
+          # for want of data rather than for a real defect.
+          fetch-depth: 0
+          fetch-tags: true
 
       - uses: actions/setup-node@v7
         with:


### PR DESCRIPTION
## Why

#422 reported `main` as red. It was not: the code on `main` (42bf90b) is fine. The changelog integrity guard from #420 reads `git tag`, and while `ci.yml` got `fetch-depth: 0` + `fetch-tags: true`, `main-health.yml` still did a shallow clone with no tags. The guard's first assertion said so: `no git tags visible`.

## Change

Same two checkout options in `main-health.yml`, with the same comment as `ci.yml`.

`cli.yml` also runs tests on checkout, but only `nukebg-cli`'s, so it does not hit this guard.

## Verification

Dispatched `main-health.yml` from this branch (it still checks out `main`): run 34726623773, success.

Closes #422

https://claude.ai/code/session_01EPo1yZNhmsqgfMMzb8BcfQ