### PR TITLE
fix(ci): fetch tags in the main health check

### DIFF
--- a/.github/workflows/main-health.yml
+++ b/.github/workflows/main-health.yml
@@ -71,6 +71,11 @@ jobs:
       - uses: actions/checkout@v7
         with:
           ref: main
+          # changelog-integrity.test.ts asserts every dated section has a
+          # tag. The default shallow clone fetches none, so it would fail
+          # for want of data rather than for a real defect.
+          fetch-depth: 0
+          fetch-tags: true
 
       - uses: actions/setup-node@v7
         with:


### PR DESCRIPTION
Brings #423 to `main`.

The scheduled health check runs the workflow file from `main`, so until this lands the next cron fails again on an empty `git tag` and reopens a `ci:main-red` issue like #422. `main`'s code itself is fine: dispatching the fixed workflow against `main` passed (run 34726623773).

https://claude.ai/code/session_01EPo1yZNhmsqgfMMzb8BcfQ